### PR TITLE
Fix typo in docstring

### DIFF
--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -7,7 +7,7 @@ import re
 def dogrula_filtre_dataframe(df_filtre: pd.DataFrame, zorunlu_kolonlar=None, logger=None) -> dict:
     """
     Filtre DataFrame'inde flag/query eksikliği veya bozukluğu kontrol eder.
-    Uygunsuz filtreleri {'filter_code': 'açıklama'} şeklinde döner.
+    Uygunsuz filtreleri {'filter_code': 'açıklama'} şeklinde döndürür.
     """
     sorunlu = {}
     zorunlu_kolonlar = zorunlu_kolonlar or ["flag", "query"]


### PR DESCRIPTION
## Summary
- update the `dogrula_filtre_dataframe` docstring to use Turkish verb "döndürür"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409c002074832581ba95c9052a9a4f