### PR TITLE
Refactor backtest call

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,18 +135,18 @@ def calistir_tum_sistemi(tarama_tarihi_str: str,
     fn_logger.info("[Adım 5/6] Basit Backtest Çalıştırma (backtest_core) Başlatılıyor...")
     # df_data_indikatorlu None veya boş olabilir, backtest_core bunu handle etmeli
     backtest_sonuclari = backtest_core.calistir_basit_backtest(
+        filtrelenmis_hisseler=filtrelenmis_hisseler_dict,  # Boş olabilir
+        df_tum_veri=df_data_indikatorlu,  # None veya boş olabilir
+        satis_tarihi_str=satis_tarihi_str,
+        tarama_tarihi_str=tarama_tarihi_str,
+        atlanmis_filtre_loglari=atlanmis_filtreler,  # Boş olabilir
+        logger_param=fn_logger,
+    )
     # Tuple dönerse unpack et
     if isinstance(backtest_sonuclari, tuple):
         backtest_sonuclari, istisnalar = backtest_sonuclari
     else:
         istisnalar = []
-    filtrelenmis_hisseler=filtrelenmis_hisseler_dict, # Boş olabilir
-    df_tum_veri=df_data_indikatorlu, # None veya boş olabilir
-    satis_tarihi_str=satis_tarihi_str,
-    tarama_tarihi_str=tarama_tarihi_str,
-    atlanmis_filtre_loglari=atlanmis_filtreler, # Boş olabilir
-    logger_param=fn_logger
-    )
     if not backtest_sonuclari: # Eğer backtest_core boş dict döndürürse (örn: kritik hata)
         fn_logger.warning("Backtest çalıştırma sonucu boş. Rapor bu duruma göre oluşturulacak.")
     fn_logger.info("[Adım 5/6] Basit Backtest Çalıştırma Tamamlandı.")


### PR DESCRIPTION
## Summary
- reformat `calistir_basit_backtest` call in `main.py`
- correctly unpack tuple results after the call

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68409cd5ff848325b3cfe69a5dc7e258