### PR TITLE
Add date & strategy info to backtest results

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -77,6 +77,7 @@ def calistir_basit_backtest(filtrelenmis_hisseler: dict,
     alim_fiyat_sutunu = config.ALIM_ZAMANI # örn: 'open'
     satis_fiyat_sutunu = config.SATIS_ZAMANI # örn: 'open' veya 'close'
     komisyon_orani = config.KOMISYON_ORANI
+    strateji_adi = getattr(config, "UYGULANAN_STRATEJI", "basit_backtest")
 
     genel_sonuclar_dict = {}
     istisnalar = []
@@ -126,7 +127,16 @@ def calistir_basit_backtest(filtrelenmis_hisseler: dict,
             df_hisse_ozel = df_tum_veri[df_tum_veri['hisse_kodu'] == hisse_adi].copy()
             if df_hisse_ozel.empty:
                 # fn_logger.warning(f"'{hisse_adi}' için ana veride kayıt bulunamadı.")
-                bireysel_performanslar.append({'hisse_kodu': hisse_adi, 'alis_fiyati': np.nan, 'satis_fiyati': np.nan, 'getiri_yuzde': np.nan, 'not': 'Veri Yok'})
+                bireysel_performanslar.append({
+                    'hisse_kodu': hisse_adi,
+                    'alis_fiyati': np.nan,
+                    'satis_fiyati': np.nan,
+                    'getiri_yuzde': np.nan,
+                    'not': 'Veri Yok',
+                    'alis_tarihi': tarama_tarihi.strftime('%d.%m.%Y'),
+                    'satis_tarihi': satis_tarihi.strftime('%d.%m.%Y'),
+                    'uygulanan_strateji': strateji_adi
+                })
                 continue
 
             alis_fiyati = satis_fiyati = getiri_yuzde = np.nan
@@ -166,7 +176,10 @@ def calistir_basit_backtest(filtrelenmis_hisseler: dict,
                 'alis_fiyati': round(alis_fiyati,2) if pd.notna(alis_fiyati) else np.nan,
                 'satis_fiyati': round(satis_fiyati,2) if pd.notna(satis_fiyati) else np.nan,
                 'getiri_yuzde': round(getiri_yuzde, 2) if pd.notna(getiri_yuzde) else np.nan,
-                'not': hisse_notu
+                'not': hisse_notu,
+                'alis_tarihi': tarama_tarihi.strftime('%d.%m.%Y'),
+                'satis_tarihi': satis_tarihi.strftime('%d.%m.%Y'),
+                'uygulanan_strateji': strateji_adi
             })
 
         df_performans = pd.DataFrame(bireysel_performanslar)

--- a/config.py
+++ b/config.py
@@ -214,3 +214,6 @@ SERIES_VALUE_CROSSOVERS = [
 ALIM_ZAMANI = "open"
 SATIS_ZAMANI = "open"
 KOMISYON_ORANI = 0.001
+
+# Varsayılan backtest strateji adı. Değiştirilebilir.
+UYGULANAN_STRATEJI = "basit_backtest"

--- a/report_generator.py
+++ b/report_generator.py
@@ -36,8 +36,9 @@ def olustur_ozet_rapor(sonuclar_listesi: list, cikti_klasoru: str, logger=None):
     return dosya_adi
 
 def olustur_hisse_bazli_rapor(sonuclar_listesi: list, cikti_klasoru: str, logger=None):
-    """Her sonucun 'hisseler' listesinde 'getiri_yuzde' ve
-    ana sözlükte 'notlar' anahtarlarını bekler."""
+    """Her sonucun 'hisseler' listesinde 'alis_tarihi', 'satis_tarihi',
+    'uygulanan_strateji' ve 'getiri_yuzde' alanları ile ana sözlükte 'notlar'
+    anahtarlarını bekler."""
     os.makedirs(cikti_klasoru, exist_ok=True)
     detayli_kayitlar = []
 

--- a/tests/test_backtest_core.py
+++ b/tests/test_backtest_core.py
@@ -1,0 +1,29 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+import types
+
+sys.modules.setdefault('pandas_ta', types.SimpleNamespace(Strategy=lambda **kw: None))
+import backtest_core
+
+
+def test_bireysel_performanslar_contains_new_keys():
+    df = pd.DataFrame({
+        "hisse_kodu": ["AAA", "AAA"],
+        "tarih": [pd.to_datetime("07.03.2025", dayfirst=True), pd.to_datetime("10.03.2025", dayfirst=True)],
+        "open": [10, 12]
+    })
+    filtrelenmis = {"F1": ["AAA"]}
+    results, _ = backtest_core.calistir_basit_backtest(
+        filtrelenmis,
+        df,
+        satis_tarihi_str="10.03.2025",
+        tarama_tarihi_str="07.03.2025"
+    )
+    perf_df = results["F1"]["hisse_performanslari"]
+    assert {"alis_tarihi", "satis_tarihi", "uygulanan_strateji"}.issubset(perf_df.columns)
+    row = perf_df.iloc[0]
+    assert row["alis_tarihi"] == "07.03.2025"
+    assert row["satis_tarihi"] == "10.03.2025"
+    assert row["uygulanan_strateji"]

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,31 @@
+import os, sys
+after_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, after_path)
+
+import pandas as pd
+
+import report_generator
+
+
+def test_detayli_rapor_contains_new_fields(tmp_path):
+    sonuclar = [{
+        "filtre_kodu": "F1",
+        "hisseler": [
+            {
+                "hisse_kodu": "AAA",
+                "alis_fiyati": 10,
+                "satis_fiyati": 12,
+                "getiri_yuzde": 20,
+                "alis_tarihi": "07.03.2025",
+                "satis_tarihi": "10.03.2025",
+                "uygulanan_strateji": "basit_backtest"
+            }
+        ],
+        "tarama_tarihi": "07.03.2025",
+        "satis_tarihi": "10.03.2025",
+        "notlar": ""
+    }]
+    path = report_generator.olustur_hisse_bazli_rapor(sonuclar, tmp_path)
+    df = pd.read_csv(path)
+    assert {"alis_tarihi", "satis_tarihi", "uygulanan_strateji"}.issubset(df.columns)
+


### PR DESCRIPTION
## Summary
- store applied strategy and transaction dates in backtest results
- include these fields when generating detailed reports
- provide defaults via config
- test the additional keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cf12effc8325ad02adb44096cb50