### PR TITLE
Fix pandas_ta import for newer numpy

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,14 @@
 
 import os
 import logging
+import numpy as np
+
+# pandas_ta bazı ortamlarda numpy.NaN sabitini kullanarak yükleniyor.
+# NumPy 2.x sürümlerinde bu sabit olmadığı için import hatası
+# yaşanmaması için eksikse tanımlama yapıyoruz.
+if not hasattr(np, "NaN"):
+    np.NaN = np.nan
+
 import pandas_ta as ta
 import sys
 

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -6,8 +6,15 @@
 # Tarih: 19 Mayıs 2025 (Tüm özel fonksiyonlar eklendi, reset_index düzeltildi, filtre uyumu artırıldı v2)
 
 import pandas as pd
-import pandas_ta as ta
 import numpy as np
+
+# numpy>=2.0 paketlerinde `NaN` sabiti kaldırıldı. pandas_ta halen bu adı
+# kullandığından import sırasında hata oluşabiliyor. Eğer `np.NaN` mevcut
+# değilse `np.nan` değerini aynı isimle tanımlayarak uyumluluk sağlanır.
+if not hasattr(np, "NaN"):
+    np.NaN = np.nan
+
+import pandas_ta as ta
 import config
 import utils
 


### PR DESCRIPTION
## Summary
- ensure numpy.NaN is defined before importing pandas_ta
- patch both `indicator_calculator.py` and `config.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421543916483258cd855a760722b59