### PR TITLE
Add classicpivots crossover and test

### DIFF
--- a/config.py
+++ b/config.py
@@ -187,6 +187,7 @@ SERIES_SERIES_CROSSOVERS = [
     ('close', 'sma_21', 'close_keser_sma_21_yukari', 'close_keser_sma_21_asagi'),
     ('close', 'ema_21', 'close_keser_ema_21_yukari', 'close_keser_ema_21_asagi'),
     ('close', 'bbm_20_2', 'close_keser_bbm_20_2_yukari', 'close_keser_bbm_20_2_asagi'),
+    ('close', 'classicpivots_1h_p', 'close_keser_classicpivots_1h_p_yukari', 'close_keser_classicpivots_1h_p_asagi'),
     ('close', 'ema_5', 'close_keser_ema_5_yukari', 'close_keser_ema_5_asagi'),
     ('close', 'ema_10', 'close_keser_ema_10_yukari', 'close_keser_ema_10_asagi'),
     ('ema_50', 'close', 'ema_50_keser_close_yukari', 'ema_50_keser_close_asagi'),

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# Ensure real pandas_ta is used in this test
+sys.modules.pop("pandas_ta", None)
+
+import pandas as pd
+import numpy as np
+
+import indicator_calculator as ic
+
+
+def test_classicpivots_crossover_column_exists():
+    data = {
+        "hisse_kodu": ["AAA"] * 30,
+        "tarih": pd.date_range("2024-01-01", periods=30, freq="D"),
+        "open": np.linspace(1, 30, 30),
+        "high": np.linspace(1, 30, 30) + 1,
+        "low": np.linspace(1, 30, 30) - 1,
+        "close": np.linspace(1, 30, 30),
+        "volume": np.arange(30)
+    }
+    df = pd.DataFrame(data)
+    result = ic.hesapla_teknik_indikatorler_ve_kesisimler(df)
+    assert "classicpivots_1h_p" in result.columns
+    assert "close_keser_classicpivots_1h_p_yukari" in result.columns


### PR DESCRIPTION
## Summary
- enable filter usage of classicpivots_1h_p by adding close crossover
- ensure pandas_ta real module is loaded for indicator tests
- cover classicpivots indicator and crossover in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422e5354688325b52e18bfbd2e82ff