### PR TITLE
Fix missing indicators

### DIFF
--- a/config.py
+++ b/config.py
@@ -241,7 +241,7 @@ SERIES_VALUE_CROSSOVERS = [
     ('stochrsi_d', 20.0, '20p0'), ('stochrsi_d', 80.0, '80p0'),
     ('cmf_20', 0.0, '0p0'), ('cmf_20', 0.2, '0p2'), ('cmf_20', -0.2, 'eksi0p2'),
     ('cci_20', 100.0, '100p0'), ('cci_20', -100.0, 'eksi100p0'), ('cci_20', 0.0, '0p0'),
-    ('mom_10', 0.0, '0p0'), ('mom_10', 1.0, '1p0'),
+    ('momentum_10', 0.0, '0p0'), ('momentum_10', 1.0, '1p0'),
     ('mfi_14', 20.0, '20p0'), ('mfi_14', 80.0, '80p0'), ('mfi_14', 50.0, '50p0'),
     ('AROONOSC_14', 0.0, '0p0'), # Büyük harfle eşleşecek
     ('ppo_line', 0.0, '0p0')

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -23,3 +23,21 @@ def test_classicpivots_crossover_column_exists():
     result = ic.hesapla_teknik_indikatorler_ve_kesisimler(df)
     assert "classicpivots_1h_p" in result.columns
     assert "close_keser_classicpivots_1h_p_yukari" in result.columns
+
+
+def test_fallback_indicators_created_when_missing():
+    data = {
+        "hisse_kodu": ["AAA"] * 50,
+        "tarih": pd.date_range("2024-01-01", periods=50, freq="D"),
+        "open": np.linspace(1, 50, 50),
+        "high": np.linspace(1, 50, 50) + 1,
+        "low": np.linspace(1, 50, 50) - 1,
+        "close": np.linspace(1, 50, 50),
+        "volume": np.arange(50)
+    }
+    df = pd.DataFrame(data)
+    result = ic.hesapla_teknik_indikatorler_ve_kesisimler(df)
+    # pandas_ta normalde sma_200/ema_200 üretmez; fallback mekanizmasi NaN da olsa kolon eklemeli
+    assert "sma_200" in result.columns
+    assert "ema_200" in result.columns
+    assert "momentum_10" in result.columns


### PR DESCRIPTION
## Summary
- ensure fallback calculation for key indicators
- keep momentum column names consistent with filters
- add regression test for fallback calculations

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c4269214083259c548771e0a6db0f