### PR TITLE
Implement new None-safe cross helpers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,3 +64,20 @@ def test_crosses_below_misaligned_index_returns_false():
     result = crosses_below(s1, s2)
     expected = pd.Series([False, False, False, False], index=s1.index)
     pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("func", [crosses_above, crosses_below])
+def test_cross_functions_with_none_returns_false(func):
+    s = pd.Series([1, 2, 3])
+    result = func(None, s)
+    expected = pd.Series([False, False, False], index=s.index, dtype=bool)
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_cross_functions_all_nan_do_not_fail():
+    s_nan = pd.Series([np.nan, np.nan, np.nan])
+    expected = pd.Series([False, False, False], index=s_nan.index, dtype=bool)
+    result_above = crosses_above(s_nan, s_nan)
+    result_below = crosses_below(s_nan, s_nan)
+    pd.testing.assert_series_equal(result_above, expected)
+    pd.testing.assert_series_equal(result_below, expected)

--- a/utils.py
+++ b/utils.py
@@ -21,91 +21,56 @@ except ImportError:
         logger.warning("logger_setup.py bulunamadı, utils.py kendi temel logger'ını kullanıyor.")
 
 
-def crosses_above(s1: pd.Series, s2: pd.Series) -> pd.Series:
-    """
-    s1 serisinin s2 serisini yukarı doğru kesip kesmediğini kontrol eder.
-    (Önceki periyotta s1 < s2 iken, mevcut periyotta s1 > s2 olması durumu)
+def crosses_above(s1: pd.Series | None, s2: pd.Series | None) -> pd.Series:
+    """s1 serisinin s2 serisini yukarı doğru kesip kesmediğini kontrol eder."""
+    common_index = None
+    if s1 is not None:
+        common_index = s1.index
+    elif s2 is not None:
+        common_index = s2.index
 
-    Args:
-        s1 (pd.Series): İlk seri.
-        s2 (pd.Series): İkinci seri (veya s1 ile aynı indekse sahip skaler değer serisi).
+    if s1 is None or s2 is None:
+        return pd.Series(False, index=common_index, dtype=bool)
 
-    Returns:
-        pd.Series: Kesişimin olduğu yerlerde True, diğerlerinde False içeren boolean Seri.
-    """
     try:
-        if not (isinstance(s1, pd.Series) and isinstance(s2, pd.Series)):
-            logger.warning(f"crosses_above: Beklenmeyen tipte girdiler. s1: {type(s1)}, s2: {type(s2)}", exc_info=False)
-            # Mümkünse s1'in index'iyle boş bir seri dön, değilse tamamen boş seri.
-            idx = getattr(s1, 'index', getattr(s2, 'index', None))
-            return pd.Series(False, index=idx, dtype=bool) if idx is not None else pd.Series(dtype=bool)
-
-        if s1.empty or s2.empty or len(s1) < 2 or len(s2) < 2: # Kesişim için en az 2 periyot gerekir
-            # logger.debug(f"crosses_above: Yetersiz veri. s1_len: {len(s1)}, s2_len: {len(s2)}")
-            return pd.Series(False, index=s1.index, dtype=bool)
-
-        # Bir önceki periyottaki değerler
-        s1_prev = s1.shift(1)
-        s2_prev = s2.shift(1)
-
-        # Herhangi bir NaN varsa o satırda kesişim False olmalı
-        nan_mask = pd.isna(s1) | pd.isna(s1_prev) | pd.isna(s2) | pd.isna(s2_prev)
-
-        # Kesişim koşulu: Önceki periyotta s1 < s2 VE mevcut periyotta s1 > s2
-        condition = (s1_prev < s2_prev) & (s1 > s2)
-
-        result = pd.Series(condition, index=s1.index, dtype=bool)
-        result[nan_mask] = False # NaN içeren satırlarda kesişim olmaz
-        return result
-
+        nan_mask = s1.isna() | s2.isna()
+        out = (s1.shift(1) < s2.shift(1)) & (s1 >= s2)
+        out[nan_mask] = False
+        out = out.astype(bool)
+        if not out.index.equals(s1.index):
+            out = out.reindex(s1.index, fill_value=False)
+        return out
     except Exception as e:
-        s1_name = getattr(s1, 'name', 's1_unnamed')
-        s2_name = getattr(s2, 'name', 's2_unnamed')
-        logger.error(f"crosses_above fonksiyonunda ({s1_name} vs {s2_name}) kritik hata: {e}", exc_info=False)
-        idx = getattr(s1, 'index', None)
-        return pd.Series(False, index=idx, dtype=bool) if idx is not None else pd.Series(dtype=bool)
+        logger.error(
+            f"crosses_above fonksiyonunda kritik hata: {e}", exc_info=False
+        )
+        return pd.Series(False, index=common_index, dtype=bool)
 
 
-def crosses_below(s1: pd.Series, s2: pd.Series) -> pd.Series:
-    """
-    s1 serisinin s2 serisini aşağı doğru kesip kesmediğini kontrol eder.
-    (Önceki periyotta s1 > s2 iken, mevcut periyotta s1 < s2 olması durumu)
+def crosses_below(s1: pd.Series | None, s2: pd.Series | None) -> pd.Series:
+    """s1 serisinin s2'yi aşağı doğru kesip kesmediğini kontrol eder."""
+    common_index = None
+    if s1 is not None:
+        common_index = s1.index
+    elif s2 is not None:
+        common_index = s2.index
 
-    Args:
-        s1 (pd.Series): İlk seri.
-        s2 (pd.Series): İkinci seri (veya s1 ile aynı indekse sahip skaler değer serisi).
+    if s1 is None or s2 is None:
+        return pd.Series(False, index=common_index, dtype=bool)
 
-    Returns:
-        pd.Series: Kesişimin olduğu yerlerde True, diğerlerinde False içeren boolean Seri.
-    """
     try:
-        if not (isinstance(s1, pd.Series) and isinstance(s2, pd.Series)):
-            logger.warning(f"crosses_below: Beklenmeyen tipte girdiler. s1: {type(s1)}, s2: {type(s2)}", exc_info=False)
-            idx = getattr(s1, 'index', getattr(s2, 'index', None))
-            return pd.Series(False, index=idx, dtype=bool) if idx is not None else pd.Series(dtype=bool)
-
-        if s1.empty or s2.empty or len(s1) < 2 or len(s2) < 2:
-            # logger.debug(f"crosses_below: Yetersiz veri. s1_len: {len(s1)}, s2_len: {len(s2)}")
-            return pd.Series(False, index=s1.index, dtype=bool)
-
-        s1_prev = s1.shift(1)
-        s2_prev = s2.shift(1)
-
-        nan_mask = pd.isna(s1) | pd.isna(s1_prev) | pd.isna(s2) | pd.isna(s2_prev)
-
-        # Kesişim koşulu: Önceki periyotta s1 > s2 VE mevcut periyotta s1 < s2
-        condition = (s1_prev > s2_prev) & (s1 < s2)
-
-        result = pd.Series(condition, index=s1.index, dtype=bool)
-        result[nan_mask] = False
-        return result
-
+        nan_mask = s1.isna() | s2.isna()
+        out = (s1.shift(1) > s2.shift(1)) & (s1 <= s2)
+        out[nan_mask] = False
+        out = out.astype(bool)
+        if not out.index.equals(s1.index):
+            out = out.reindex(s1.index, fill_value=False)
+        return out
     except Exception as e:
-        s1_name = getattr(s1, 'name', 's1_unnamed')
-        s2_name = getattr(s2, 'name', 's2_unnamed')
-        logger.error(f"crosses_below fonksiyonunda ({s1_name} vs {s2_name}) kritik hata: {e}", exc_info=False)
-        idx = getattr(s1, 'index', None)
-        return pd.Series(False, index=idx, dtype=bool) if idx is not None else pd.Series(dtype=bool)
+        logger.error(
+            f"crosses_below fonksiyonunda kritik hata: {e}", exc_info=False
+        )
+        return pd.Series(False, index=common_index, dtype=bool)
 
 # safe_pct_change gibi diğer yardımcı fonksiyonlar buraya eklenebilir.
 # Şimdilik sadece kesişimler var.


### PR DESCRIPTION
## Summary
- simplify `crosses_above` and `crosses_below` helpers
- return False series when any input is `None`
- handle all-NaN input without crashing
- add unit tests for these edge cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5fb9eed083259d3cf7c578bbb175