### PR TITLE
Implement multi-sheet Excel writer

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -140,3 +140,25 @@ def olustur_excel_raporu(sonuclar_listesi: list, cikti_klasoru: str, logger=None
     if logger:
         logger.info(f"Excel raporu oluşturuldu: {dosya_adi}")
     return dosya_adi
+
+
+def kaydet_uc_sekmeli_excel(
+    fname: str,
+    ozet_df: pd.DataFrame,
+    detay_df: pd.DataFrame,
+    istatistik_df: pd.DataFrame,
+):
+    """Üç DataFrame'i tek seferde aynı Excel dosyasına kaydet."""
+
+    os.makedirs(os.path.dirname(fname) or ".", exist_ok=True)
+
+    with pd.ExcelWriter(
+        fname,
+        engine="xlsxwriter",
+        mode="w",
+    ) as w:
+        ozet_df.to_excel(w, sheet_name="Özet", index=False)
+        detay_df.to_excel(w, sheet_name="Detay", index=False)
+        istatistik_df.to_excel(w, sheet_name="İstatistik", index=False)
+
+    return fname

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -2,6 +2,8 @@ import os, sys
 after_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, after_path)
 
+import pandas as pd
+import openpyxl
 import report_generator
 
 
@@ -30,4 +32,17 @@ def test_excel_report_file_size(tmp_path):
 
     path = report_generator.olustur_excel_raporu(sonuclar, tmp_path)
     assert os.path.getsize(path) < 100 * 1024
+
+
+def test_uc_sekmeli_excel_yaz(tmp_path):
+    df1 = pd.DataFrame({"a": [1]})
+    df2 = pd.DataFrame({"b": [2]})
+    df3 = pd.DataFrame({"c": [3]})
+
+    fname = tmp_path / "multi.xlsx"
+    report_generator.kaydet_uc_sekmeli_excel(str(fname), df1, df2, df3)
+
+    wb = openpyxl.load_workbook(fname)
+    assert len(wb.sheetnames) == 3
+    wb.close()
 


### PR DESCRIPTION
## Summary
- add `kaydet_uc_sekmeli_excel` helper in `report_generator`
- write new unit test for creating a three-sheet workbook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8d4769e083259601909bc8b50b34