### PR TITLE
Implement OHLCV pre-validation in backtest

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -217,6 +217,11 @@ def calistir_basit_backtest(
                 )
                 continue
 
+            REQUIRED = {"open", "high", "low", "close", "volume"}
+            if not REQUIRED.issubset(df_hisse_ozel.columns):
+                fn_logger.warning(f"{hisse_adi}: eksik OHLCV – atlandı")
+                continue
+
             alis_fiyati = satis_fiyati = getiri_yuzde = np.nan
             hisse_notu = ""
 

--- a/tests/test_backtest_core.py
+++ b/tests/test_backtest_core.py
@@ -12,8 +12,15 @@ import config
 def test_bireysel_performanslar_contains_new_keys():
     df = pd.DataFrame({
         "hisse_kodu": ["AAA", "AAA"],
-        "tarih": [pd.to_datetime("07.03.2025", dayfirst=True), pd.to_datetime("10.03.2025", dayfirst=True)],
-        "open": [10, 12]
+        "tarih": [
+            pd.to_datetime("07.03.2025", dayfirst=True),
+            pd.to_datetime("10.03.2025", dayfirst=True),
+        ],
+        "open": [10, 12],
+        "high": [11, 13],
+        "low": [9, 11],
+        "close": [10.5, 12.5],
+        "volume": [1000, 1100],
     })
     filtrelenmis = {"F1": ["AAA"]}
     results, _ = backtest_core.calistir_basit_backtest(
@@ -28,3 +35,28 @@ def test_bireysel_performanslar_contains_new_keys():
     assert row["alis_tarihi"] == "07.03.2025"
     assert row["satis_tarihi"] == "10.03.2025"
     assert row["uygulanan_strateji"] == config.UYGULANAN_STRATEJI
+
+
+def test_missing_close_column_skips_stock():
+    df = pd.DataFrame({
+        "hisse_kodu": ["AAA", "AAA"],
+        "tarih": [
+            pd.to_datetime("07.03.2025", dayfirst=True),
+            pd.to_datetime("10.03.2025", dayfirst=True),
+        ],
+        "open": [10, 12],
+        "high": [11, 13],
+        "low": [9, 11],
+        "volume": [1000, 1100],
+    })
+    filtrelenmis = {"F1": ["AAA"]}
+    results, _ = backtest_core.calistir_basit_backtest(
+        filtrelenmis,
+        df,
+        satis_tarihi_str="10.03.2025",
+        tarama_tarihi_str="07.03.2025",
+    )
+    perf_df = results["F1"]["hisse_performanslari"]
+    assert perf_df.empty
+    assert results["F1"]["islem_yapilan_sayisi"] == 0
+    assert pd.isna(results["F1"]["ortalama_getiri"])


### PR DESCRIPTION
## Summary
- skip stocks missing OHLCV data in `calistir_basit_backtest`
- update tests for new validation
- add regression test for missing close column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8fcc3e648325914fb12ff67a9bd6