### PR TITLE
Update crossover helpers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,10 +65,11 @@ def test_crosses_below_misaligned_index_length_matches_intersection():
 
 
 @pytest.mark.parametrize("func", [crosses_above, crosses_below])
-def test_cross_functions_with_none_raises(func):
+def test_cross_functions_with_none_returns_empty_false_series(func):
     s = pd.Series([1, 2, 3])
-    with pytest.raises(AttributeError):
-        func(None, s)
+    result = func(None, s)
+    expected = pd.Series(False, index=[])
+    pd.testing.assert_series_equal(result, expected)
 
 
 def test_cross_functions_all_nan_do_not_fail():

--- a/utils.py
+++ b/utils.py
@@ -27,15 +27,22 @@ except ImportError:
         )
 
 
-def crosses_above(a: pd.Series, b: pd.Series) -> pd.Series:
-    """Return True where ``a`` crosses ``b`` upwards."""
+def _align(a: pd.Series, b: pd.Series):
     x, y = a.align(b, join="inner")
+    return x, y
+
+
+def crosses_above(a: pd.Series, b: pd.Series) -> pd.Series:
+    if a is None or b is None:
+        return pd.Series(False, index=[])
+    x, y = _align(a, b)
     return (x.shift(1) < y.shift(1)) & (x >= y)
 
 
-def crosses_below(a: pd.Series, b: pd.Series) -> pd.Series:
-    """Return True where ``a`` crosses ``b`` downwards."""
-    x, y = a.align(b, join="inner")
+def crosses_below(a, b):
+    if a is None or b is None:
+        return pd.Series(False, index=[])
+    x, y = _align(a, b)
     return (x.shift(1) > y.shift(1)) & (x <= y)
 
 


### PR DESCRIPTION
## Summary
- add `_align` helper
- update crossover functions to handle `None`
- adapt tests to expect empty results when series are `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca9d73b848325a013c44556bceaf0