### PR TITLE
Update dependencies and CI install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       # Bütün bağımlılıkları (pytest dâhil) kur
       - run: |
           python -m pip install --upgrade pip
-          pip install --timeout 60 --retries 3 --upgrade setuptools
           pip install --timeout 60 --retries 3 -r requirements.txt
 
       - run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 pandas
 numpy
-pandas_ta
 holidays
-openpyxl
 jinja2
-xlsxwriter
 pytest>=7.4.0
 setuptools>=68.0.0
+pandas-ta @ git+https://github.com/twopirllc/pandas-ta.git@develop
+openpyxl>=3.1.0
+xlsxwriter>=3.2.0


### PR DESCRIPTION
## Summary
- use pandas-ta from GitHub develop branch
- pin openpyxl and xlsxwriter versions
- streamline CI Python install command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684d5bb606d88325a99fe96bed8a1fce