### PR TITLE
Add fallback for psar column in filter engine

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -140,6 +140,12 @@ def uygula_filtreler(
         eksik_sutunlar = [
             s for s in kullanilan_sutunlar if s not in df_tarama_gunu.columns
         ]
+        if {"psar_long", "psar_short"} <= set(df_tarama_gunu.columns) and "psar" in eksik_sutunlar:
+            # psar_long/short varsa birleşik psar hesaplanmamış; uyar, devam et
+            df_tarama_gunu["psar"] = df_tarama_gunu["psar_long"].fillna(df_tarama_gunu["psar_short"])
+            eksik_sutunlar = [
+                s for s in kullanilan_sutunlar if s not in df_tarama_gunu.columns
+            ]
         if eksik_sutunlar:
             hata_mesaji = f"Eksik sütunlar: {', '.join(eksik_sutunlar)}"
             fn_logger.error(f"Filtre '{filtre_kodu}' sorgusunda {hata_mesaji}.")


### PR DESCRIPTION
## Summary
- handle missing `psar` column when `psar_long` and `psar_short` exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db32eb5ec83258e04900afa63a186