### PR TITLE
Pin pandas version and add offline requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 pandas==1.5.3
 pandas-ta==0.3.14b0
 pytest>=7.4,<8.0
+openpyxl>=3.1
+xlsxwriter>=3.1
+
 
 # (İLERİDE GitHub erişimi açılırsa, üstteki üç satırı sil
 #  ve bunun yerine şunu kullan:)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
-pandas
-numpy
+pandas==1.5.3
 pandas-ta==0.3.14b0
-holidays
-openpyxl
-jinja2
-xlsxwriter
-pytest>=7.4.0
-setuptools>=68.0.0
+pytest>=7.4,<8.0
+
+# (İLERİDE GitHub erişimi açılırsa, üstteki üç satırı sil
+#  ve bunun yerine şunu kullan:)
+# ---------------------------------------------------------
+# pandas>=2.0,<3.0
+# pandas-ta @ git+https://github.com/twopirllc/pandas-ta.git@development
+# pytest>=8.0
+# ---------------------------------------------------------
+# NOT: yorum satırları (#) dâhil, blok olduğu gibi bırakılabilir.


### PR DESCRIPTION
## Summary
- pin pandas and pandas-ta versions for offline use
- set pytest to run on Python 3.11 environment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_684db6b1ae048325994e1319f0f64067