### PR TITLE
Add PSAR stability test

### DIFF
--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -91,3 +91,14 @@ def test_crossover_skips_when_column_missing():
         "ema_10_keser_ema_20_asagi",
     )
     assert result is None
+
+
+def test_psar_no_error():
+    """_calculate_combined_psar çalışırken istisna fırlatmamalı."""
+    df = pd.DataFrame({
+        "hisse_kodu": ["TEST"] * 3,
+        "psar_long":  [np.nan, 11.0, 12.0],
+        "psar_short": [10.0,   np.nan, np.nan],
+    })
+    result = ic._calculate_combined_psar(df)
+    assert len(result) == len(df)


### PR DESCRIPTION
## Summary
- test `_calculate_combined_psar` with missing psar values

## Testing
- `pytest -q tests/test_indicator_calculator.py::test_psar_no_error -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dcc5f72048325adbd380c995c2689