### PR TITLE
Fix module import handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ try:
     logger.info("Tüm ana modüller başarıyla import edildi.")
 except ImportError as e_import_main:
     logger.critical(f"Temel modüllerden biri import edilemedi: {e_import_main}. Sistem durduruluyor.", exc_info=True)
-    sys.exit(1) # Kritik hata, devam etme
+    raise ImportError(e_import_main)
 
 def calistir_tum_sistemi(tarama_tarihi_str: str,
     satis_tarihi_str: str,


### PR DESCRIPTION
## Summary
- raise `ImportError` if core modules fail to load instead of exiting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dd51ae8308325bb606d24d53e78cb