### PR TITLE
Upgrade pandas to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,14 @@ pytest -q
 
 ## Google Colab Hızlı Başlangıç
 
-> **Not:** Google Colab ortamı `pandas` 2.x ile gelir. Bu proje ise
-> `pandas==1.5.3` kullanır. Paketleri doğru sürümlerle yeniden kurmak için
-> `--force-reinstall` ve `--no-cache-dir` bayraklarını kullanmanız önerilir.
-
 1. Depoyu klonlayın ve klasöre geçin.
-2. Gereken paketleri yeniden kurun.
+2. Gereken paketleri kurun.
 3. Testleri ve örnek çalıştırmayı yapın.
 
 ```bash
 !git clone https://github.com/<KULLANICI>/finansal-analiz-sistemi.git
 %cd finansal-analiz-sistemi
-!pip install --force-reinstall --no-cache-dir -r requirements.txt
+!pip install -r requirements.txt
 !pytest -q
 !python main.py
 ```

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -112,11 +112,10 @@ def on_isle_hisse_verileri(
         try:
             # Olası farklı formatları dene (genellikle pd.to_datetime bunu otomatik yapar ama garanti olsun)
             df["tarih"] = pd.to_datetime(
-                df["tarih"], errors="coerce", dayfirst=True, infer_datetime_format=True
+                df["tarih"], errors="coerce", dayfirst=True
             )
             # errors='coerce' geçersiz tarihleri NaT (Not a Time) yapar.
             # dayfirst=True, dd.mm.yyyy formatını önceliklendirir.
-            # infer_datetime_format=True hızı artırabilir.
             fn_logger.info(
                 "'tarih' sütunu preprocessor'da başarıyla datetime formatına dönüştürüldü."
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pandas==1.5.3          # NumPy 1.x ile uyumlu
-numpy<2.0              # NumPy 1.x kullan
+pandas>=2.2
+numpy>=2.0,<3.0
+packaging<25,>=23.2
 pandas-ta==0.3.14b0    # pandas-ta, NumPy 1 ile uyumlu
 holidays               # tarih/tatil kontrolü için
 openpyxl>=3.1


### PR DESCRIPTION
## Summary
- update dependencies to pandas 2.x and numpy 2.x
- drop deprecated `infer_datetime_format` arg in preprocessor
- simplify Colab instructions in README

## Testing
- `pip install --force-reinstall -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df9e011a083259d18f9577639fa9d