### PR TITLE
Simplify backtest reporting

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -80,16 +80,13 @@ def _get_fiyat(
 
 
 def calistir_basit_backtest(
-    filtrelenmis_hisseler: dict,
+    filtre_sonuc_dict: dict,
     df_tum_veri: pd.DataFrame,
     satis_tarihi_str: str,
     tarama_tarihi_str: str,
-    atlanmis_filtre_loglari: dict | None = None,  # None olabileceğini belirt
     logger_param=None,
-) -> dict:
-    """
-    Filtrelenmiş hisseler üzerinde basit bir al-sat simülasyonu yapar ve getirileri hesaplar.
-    """
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Filtre sonuçlarını kullanarak basit backtest çalıştırır."""
     fn_logger = logger_param or get_logger(f"{__name__}.calistir_basit_backtest")
     fn_logger.info(
         f"Basit backtest çalıştırılıyor. Tarama: {tarama_tarihi_str}, Satış: {satis_tarihi_str}"
@@ -116,236 +113,48 @@ def calistir_basit_backtest(
     komisyon_orani = config.KOMISYON_ORANI
     strateji_adi = getattr(config, "UYGULANAN_STRATEJI", "basit_backtest")
 
-    genel_sonuclar_dict = {}
-    istisnalar = []
+    summary_records = []
+    detail_records = []
 
-    # Eğer bazı filtreler atlanmışsa, rapor için bunları başlangıçta ekle
-    if atlanmis_filtre_loglari:
-        for filtre_kodu, log_mesaji in atlanmis_filtre_loglari.items():
-            if filtre_kodu not in genel_sonuclar_dict:  # Sadece daha önce eklenmemişse
-                genel_sonuclar_dict[filtre_kodu] = {
-                    "hisse_sayisi": 0,
-                    "islem_yapilan_sayisi": 0,
-                    "ortalama_getiri": np.nan,
-                    "hisse_performanslari": pd.DataFrame(
-                        columns=[
-                            "hisse_kodu",
-                            "alis_fiyati",
-                            "satis_fiyati",
-                            "getiri_yuzde",
-                            "not",
-                        ]
-                    ),
-                    "notlar": [str(log_mesaji)],  # Gelen mesajı stringe çevir
-                }
+    for filtre_kodu, filtre_sonuc in filtre_sonuc_dict.items():
+        hisse_kodlari = filtre_sonuc.get("hisseler", [])
+        sebep = filtre_sonuc.get("sebep", "")
 
-    # Filtrelenmiş hisseler üzerinde dön
-    if not filtrelenmis_hisseler and not atlanmis_filtre_loglari:
-        fn_logger.warning(
-            "Filtrelenmiş hisse bulunmuyor ve atlanmış filtre logu da yok. Backtest için işlenecek veri yok."
-        )
-        # return genel_sonuclar_dict, istisnalar # Zaten boş olacak
-
-    for filtre_kodu, hisse_kodlari_listesi in filtrelenmis_hisseler.items():
-        fn_logger.debug(f"--- Filtre: '{filtre_kodu}' için backtest başlıyor ---")
-
-        # Not listesini mevcut sözlükten referans olarak al; yoksa giriş oluştur
-        if filtre_kodu not in genel_sonuclar_dict:
-            genel_sonuclar_dict[filtre_kodu] = {
-                "hisse_sayisi": 0,
-                "islem_yapilan_sayisi": 0,
-                "ortalama_getiri": np.nan,
-                "hisse_performanslari": pd.DataFrame(
-                    columns=[
-                        "hisse_kodu",
-                        "alis_fiyati",
-                        "satis_fiyati",
-                        "getiri_yuzde",
-                        "not",
-                    ]
-                ),
-                "notlar": [],
-            }
-
-        current_filtre_notlari = genel_sonuclar_dict[filtre_kodu]["notlar"]
-
-        if not hisse_kodlari_listesi:  # Eğer bu filtre için hisse listesi boşsa
-            if not any(
-                "Bu filtreye uyan hisse yok." in note for note in current_filtre_notlari
-            ):
-                current_filtre_notlari.append("Bu filtreye uyan hisse yok.")
-
-            # genel_sonuclar_dict'te bu filtre için bir giriş oluştur veya güncelle
-            genel_sonuclar_dict[filtre_kodu].update(
+        hisse_getirileri = []
+        for kod in hisse_kodlari:
+            df_hisse = df_tum_veri[df_tum_veri["hisse_kodu"] == kod]
+            alis = _get_fiyat(df_hisse, tarama_tarihi, alim_fiyat_sutunu, fn_logger)
+            satis = _get_fiyat(df_hisse, satis_tarihi, satis_fiyat_sutunu, fn_logger)
+            if pd.notna(alis) and pd.notna(satis):
+                getiri = (satis / alis - 1 - komisyon_orani) * 100
+            else:
+                getiri = np.nan
+            basari = "BAŞARILI" if pd.notna(getiri) and getiri > 0 else "BAŞARISIZ"
+            detail_records.append(
                 {
-                    "hisse_sayisi": 0,
-                    "islem_yapilan_sayisi": 0,
-                    "ortalama_getiri": np.nan,
-                    "hisse_performanslari": pd.DataFrame(
-                        columns=[
-                            "hisse_kodu",
-                            "alis_fiyati",
-                            "satis_fiyati",
-                            "getiri_yuzde",
-                            "not",
-                        ]
-                    ),
+                    "filtre_kodu": filtre_kodu,
+                    "hisse_kodu": kod,
+                    "getiri_yuzde": round(getiri, 2) if pd.notna(getiri) else np.nan,
+                    "basari": basari,
                 }
             )
-            genel_sonuclar_dict[filtre_kodu]["notlar"] = list(
-                set(current_filtre_notlari)
-            )
-            continue  # Sonraki filtreye geç
+            hisse_getirileri.append(getiri)
 
-        bireysel_performanslar = []
-        hisse_sayisi_filtreye_uyan = len(hisse_kodlari_listesi)
-        # fn_logger.info(f"Filtre '{filtre_kodu}': {hisse_sayisi_filtreye_uyan} hisse için işlem yapılacak.")
+        getiriler_seri = pd.Series(hisse_getirileri, dtype=float).dropna()
+        ortalama = getiriler_seri.mean() if not getiriler_seri.empty else np.nan
+        sebep_kodu = sebep
+        if sebep == "OK" and getiriler_seri.empty:
+            sebep_kodu = "DATA_GAP"
 
-        for hisse_adi in hisse_kodlari_listesi:
-            df_hisse_ozel = df_tum_veri[df_tum_veri["hisse_kodu"] == hisse_adi].copy()
-            if df_hisse_ozel.empty:
-                # fn_logger.warning(f"'{hisse_adi}' için ana veride kayıt bulunamadı.")
-                bireysel_performanslar.append(
-                    {
-                        "hisse_kodu": hisse_adi,
-                        "alis_fiyati": np.nan,
-                        "satis_fiyati": np.nan,
-                        "getiri_yuzde": np.nan,
-                        "not": "Veri Yok",
-                        "alis_tarihi": tarama_tarihi.strftime("%d.%m.%Y"),
-                        "satis_tarihi": satis_tarihi.strftime("%d.%m.%Y"),
-                        "uygulanan_strateji": strateji_adi,
-                    }
-                )
-                continue
-
-            REQUIRED = {"open", "high", "low", "close", "volume"}
-            if not REQUIRED.issubset(df_hisse_ozel.columns):
-                fn_logger.warning(
-                    f"{hisse_adi}: zorunlu OHLCV kolonları eksik – hisse atlandı"
-                )
-                continue
-
-            alis_fiyati = satis_fiyati = getiri_yuzde = np.nan
-            hisse_notu = ""
-
-            try:
-                pivot = df_hisse_ozel.pivot(
-                    index="tarih", columns="hisse_kodu", values="close"
-                )
-                alis_fiyati, satis_fiyati = (
-                    pivot.loc[tarama_tarihi, hisse_adi],
-                    pivot.loc[satis_tarihi, hisse_adi],
-                )
-                getiriler = satis_fiyati / alis_fiyati - 1 - komisyon_orani
-                getiri_yuzde = getiriler * 100
-                hisse_notu = "Başarılı"
-            except KeyError:
-                fn_logger.warning("close kolonu eksik – hisse atlandı")
-                hisse_notu = "close kolonu eksik"
-            except Exception as e_hisse_backtest:
-                hisse_notu = f"Backtest sırasında hata: {e_hisse_backtest}"
-                fn_logger.error(
-                    f"{hisse_adi} için backtest hatası: {e_hisse_backtest}",
-                    exc_info=False,
-                )
-
-            if pd.isna(alis_fiyati) or pd.isna(satis_fiyati):
-                istisnalar.append(
-                    {
-                        "filtre_kodu": filtre_kodu,
-                        "hisse_kodu": hisse_adi,
-                        "neden": "Alış veya satış fiyatı eksik",
-                    }
-                )
-
-            bireysel_performanslar.append(
-                {
-                    "hisse_kodu": hisse_adi,
-                    "alis_fiyati": (
-                        round(alis_fiyati, 2) if pd.notna(alis_fiyati) else np.nan
-                    ),
-                    "satis_fiyati": (
-                        round(satis_fiyati, 2) if pd.notna(satis_fiyati) else np.nan
-                    ),
-                    "getiri_yuzde": (
-                        round(getiri_yuzde, 2) if pd.notna(getiri_yuzde) else np.nan
-                    ),
-                    "not": hisse_notu,
-                    "alis_tarihi": tarama_tarihi.strftime("%d.%m.%Y"),
-                    "satis_tarihi": satis_tarihi.strftime("%d.%m.%Y"),
-                    "uygulanan_strateji": strateji_adi,
-                }
-            )
-
-        df_performans = pd.DataFrame(bireysel_performanslar)
-        gecerli_getiriler = df_performans.get(
-            "getiri_yuzde", pd.Series(dtype=float)
-        ).dropna()
-        ortalama_getiri = (
-            gecerli_getiriler.mean() if not gecerli_getiriler.empty else np.nan
-        )
-
-        # Notları topla
-        if not df_performans.empty:
-            basarisiz_notlar = (
-                df_performans[df_performans["not"] != "Başarılı"]["not"]
-                .unique()
-                .tolist()
-            )
-            if basarisiz_notlar:
-                current_filtre_notlari.extend(basarisiz_notlar)
-        elif (
-            hisse_sayisi_filtreye_uyan > 0
-        ):  # Hisse vardı ama performans df'i boş kaldıysa (hepsinde veri yoksa vs.)
-            current_filtre_notlari.append(
-                "Filtreye uyan hisseler için performans verisi üretilemedi."
-            )
-
-        if (
-            not current_filtre_notlari
-        ):  # Eğer hiç not yoksa (başarılı atlanmış veya hisse yok notu dahil)
-            if hisse_sayisi_filtreye_uyan > 0 and len(gecerli_getiriler) == 0:
-                current_filtre_notlari.append(
-                    "Tüm hisseler için alım/satım fiyatı bulunamadı veya getiri hesaplanamadı."
-                )
-            elif hisse_sayisi_filtreye_uyan > 0 and len(gecerli_getiriler) > 0:
-                current_filtre_notlari.append("Tüm işlemler başarılı veya ek not yok.")
-            # Eğer hisse_sayisi_filtreye_uyan == 0 ise zaten en başta "Bu filtreye uyan hisse yok" notu eklenmişti.
-
-        genel_sonuclar_dict[filtre_kodu].update(
+        summary_records.append(
             {
-                "hisse_sayisi": hisse_sayisi_filtreye_uyan,
-                "islem_yapilan_sayisi": len(gecerli_getiriler),
-                "ortalama_getiri": (
-                    round(ortalama_getiri, 2) if pd.notna(ortalama_getiri) else np.nan
-                ),
-                "hisse_performanslari": df_performans,
+                "filtre_kodu": filtre_kodu,
+                "ort_getiri_%": round(ortalama, 2) if pd.notna(ortalama) else np.nan,
+                "sebep_kodu": sebep_kodu,
             }
         )
-        genel_sonuclar_dict[filtre_kodu]["notlar"] = list(set(current_filtre_notlari))
 
-    fn_logger.info("Tüm filtreler için basit backtest tamamlandı.")
+    rapor_df = pd.DataFrame(summary_records).sort_values("filtre_kodu")
+    detay_df = pd.DataFrame(detail_records)
 
-    rapor_kayitlar = [
-        {
-            "filtre_kodu": k,
-            "hisse_sayisi": v.get("hisse_sayisi", 0),
-            "islem_yapilan_sayisi": v.get("islem_yapilan_sayisi", 0),
-            "ortalama_getiri": v.get("ortalama_getiri"),
-        }
-        for k, v in genel_sonuclar_dict.items()
-    ]
-
-    rapor_df = pd.DataFrame(rapor_kayitlar).sort_values("filtre_kodu")
-
-    if rapor_df.empty:
-        fn_logger.warning("Rapor DataFrame'i bos.")
-        return rapor_df, None
-
-    rapor_dosyasi = Path("raporlar") / f"rapor_{datetime.now():%Y%m%d_%H%M%S}.xlsx"
-    rapor_dosyasi.parent.mkdir(exist_ok=True)
-
-    rapor_df.to_excel(rapor_dosyasi, index=False)
-
-    return rapor_df, rapor_dosyasi
+    return rapor_df, detay_df

--- a/main.py
+++ b/main.py
@@ -195,12 +195,11 @@ def calistir_tum_sistemi(
         "[Adım 5/6] Basit Backtest Çalıştırma (backtest_core) Başlatılıyor..."
     )
     # df_data_indikatorlu None veya boş olabilir, backtest_core bunu handle etmeli
-    rapor_df, rapor_dosyasi = backtest_core.calistir_basit_backtest(
-        filtrelenmis_hisseler=filtrelenmis_hisseler_dict,  # Boş olabilir
-        df_tum_veri=df_data_indikatorlu,  # None veya boş olabilir
+    rapor_df, detay_df = backtest_core.calistir_basit_backtest(
+        filtre_sonuc_dict=filtrelenmis_hisseler_dict,
+        df_tum_veri=df_data_indikatorlu,
         satis_tarihi_str=satis_tarihi_str,
         tarama_tarihi_str=tarama_tarihi_str,
-        atlanmis_filtre_loglari=atlanmis_filtreler,  # Boş olabilir
         logger_param=fn_logger,
     )
     if rapor_df is None or rapor_df.empty:

--- a/tests/test_backtest_core.py
+++ b/tests/test_backtest_core.py
@@ -25,42 +25,30 @@ def test_bireysel_performanslar_contains_new_keys():
             "volume": [1000, 1100],
         }
     )
-    filtrelenmis = {"F1": ["AAA"]}
-    rapor_df, _ = backtest_core.calistir_basit_backtest(
-        filtrelenmis, df, satis_tarihi_str="10.03.2025", tarama_tarihi_str="07.03.2025"
+    filtre_sonuc = {"F1": {"hisseler": ["AAA"], "sebep": "OK", "hisse_sayisi": 1}}
+    rapor_df, detay_df = backtest_core.calistir_basit_backtest(
+        filtre_sonuc, df, satis_tarihi_str="10.03.2025", tarama_tarihi_str="07.03.2025"
     )
-    assert set(rapor_df.columns) == {
-        "filtre_kodu",
-        "hisse_sayisi",
-        "islem_yapilan_sayisi",
-        "ortalama_getiri",
-    }
-    row = rapor_df.iloc[0]
-    assert row["filtre_kodu"] == "F1"
-    assert row["hisse_sayisi"] == 1
+    assert set(rapor_df.columns) == {"filtre_kodu", "ort_getiri_%", "sebep_kodu"}
+    assert {"filtre_kodu", "hisse_kodu", "getiri_yuzde", "basari"}.issubset(detay_df.columns)
+    assert detay_df.iloc[0]["basari"] == "BAŞARILI"
 
 
-def test_missing_close_column_skips_stock():
+def test_missing_buy_price_sets_data_gap():
     df = pd.DataFrame(
         {
-            "hisse_kodu": ["AAA", "AAA"],
-            "tarih": [
-                pd.to_datetime("07.03.2025", dayfirst=True),
-                pd.to_datetime("10.03.2025", dayfirst=True),
-            ],
-            "open": [10, 12],
-            "high": [11, 13],
-            "low": [9, 11],
-            "volume": [1000, 1100],
+            "hisse_kodu": ["AAA"],
+            "tarih": [pd.to_datetime("10.03.2025", dayfirst=True)],
+            "close": [12.5],
         }
     )
-    filtrelenmis = {"F1": ["AAA"]}
-    rapor_df, _ = backtest_core.calistir_basit_backtest(
-        filtrelenmis,
+    filtre_sonuc = {"F1": {"hisseler": ["AAA"], "sebep": "OK", "hisse_sayisi": 1}}
+    rapor_df, detay_df = backtest_core.calistir_basit_backtest(
+        filtre_sonuc,
         df,
         satis_tarihi_str="10.03.2025",
         tarama_tarihi_str="07.03.2025",
     )
     row = rapor_df.iloc[0]
-    assert row["islem_yapilan_sayisi"] == 0
-    assert pd.isna(row["ortalama_getiri"])
+    assert row["sebep_kodu"] == "DATA_GAP"
+    assert pd.isna(row["ort_getiri_%"])


### PR DESCRIPTION
## Summary
- rename `calistir_basit_backtest` parameter to `filtre_sonuc_dict`
- streamline backtest to output per-stock success and filter averages
- adjust main entry to new API
- update tests for changed behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef39c041083258ee97528d2b2b3b4