### PR TITLE
Implement generate_full_report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --timeout 60 --retries 3 --upgrade setuptools
           pip install --timeout 60 --retries 3 -r requirements.txt
+          pip install --timeout 60 --retries 3 --upgrade kaleido
 
       - run: pytest -q
       - name: Run simple backtest

--- a/report_generator.py
+++ b/report_generator.py
@@ -185,7 +185,9 @@ def generate_full_report(sonuc_dict: dict, out_xlsx: str | Path) -> Path:
     tarama_tarihi = sonuc_dict.get("tarama_tarihi", "")
     satis_tarihi = sonuc_dict.get("satis_tarihi", "")
 
-    ozet_df = report_utils.build_ozet_df(summary_df, detail_df, tarama_tarihi, satis_tarihi)
+    ozet_df = report_utils.build_ozet_df(
+        summary_df, detail_df, tarama_tarihi, satis_tarihi
+    )
     detay_df = report_utils.build_detay_df(summary_df, detail_df)
     stats_df = report_utils.build_stats_df(ozet_df)
 
@@ -214,6 +216,9 @@ def generate_full_report(sonuc_dict: dict, out_xlsx: str | Path) -> Path:
 
         ws_stats = w.sheets["İstatistik"]
         ws_stats.set_row(0, None, fmt_bold)
+        ws_stats.autofilter(0, 0, len(stats_df), len(report_utils.DEFAULT_STATS_COLS) - 1)
+
+        ws_chart.set_row(0, None, fmt_bold)
 
     return out_xlsx
 

--- a/report_utils.py
+++ b/report_utils.py
@@ -1,0 +1,55 @@
+# report_utils.py
+import pandas as pd
+from pathlib import Path
+import report_stats
+
+# Default column orders for generated reports
+DEFAULT_OZET_COLS = [
+    "filtre_kodu",
+    "hisse_sayisi",
+    "ort_getiri_%",
+    "en_yuksek_%",
+    "en_dusuk_%",
+    "islemli",
+    "sebep_kodu",
+    "sebep_aciklama",
+    "tarama_tarihi",
+    "satis_tarihi",
+]
+
+DEFAULT_DETAY_COLS = [
+    "filtre_kodu",
+    "hisse_kodu",
+    "getiri_%",
+    "basari",
+    "strateji",
+    "sebep_kodu",
+]
+
+DEFAULT_STATS_COLS = [
+    "toplam_filtre",
+    "islemli",
+    "işlemsiz",
+    "hatalı",
+    "genel_başarı_%",
+    "genel_ortalama_%",
+]
+
+
+def build_ozet_df(summary_df: pd.DataFrame, detail_df: pd.DataFrame, tarama_tarihi: str = "", satis_tarihi: str = "") -> pd.DataFrame:
+    df = report_stats.build_ozet_df(summary_df, detail_df, tarama_tarihi, satis_tarihi)
+    return df.reindex(columns=DEFAULT_OZET_COLS)
+
+
+def build_detay_df(summary_df: pd.DataFrame, detail_df: pd.DataFrame, strateji: str | None = None) -> pd.DataFrame:
+    df = report_stats.build_detay_df(summary_df, detail_df, strateji)
+    return df.reindex(columns=DEFAULT_DETAY_COLS)
+
+
+def build_stats_df(ozet_df: pd.DataFrame) -> pd.DataFrame:
+    df = report_stats.build_stats_df(ozet_df)
+    return df.reindex(columns=DEFAULT_STATS_COLS)
+
+
+def plot_summary_stats(ozet_df: pd.DataFrame, detail_df: pd.DataFrame, std_threshold: float = 5.0):
+    return report_stats.plot_summary_stats(ozet_df, detail_df, std_threshold)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ holidays               # tarih/tatil kontrolü için
 openpyxl>=3.1
 xlsxwriter>=3.1
 plotly>=5.20
+kaleido>=0.2.1
 pytest>=7.4.0
 
 # (İLERİDE GitHub erişimi açılırsa, üstteki üç satırı sil

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -111,3 +111,11 @@ def test_generate_full_report(tmp_path):
     header = [c.value for c in wb["Özet"][1]]
     assert "sebep_kodu" in header
     wb.close()
+
+    img = tmp_path / "summary.png"
+    assert img.exists()
+
+    import zipfile
+    with zipfile.ZipFile(out) as zf:
+        images = [n for n in zf.namelist() if n.startswith("xl/media/")]
+        assert images

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -84,3 +84,30 @@ def test_kaydet_raporlar_appends(tmp_path):
     names = wb.sheetnames
     assert {"Sheet1", "Özet", "Detay", "İstatistik"}.issubset(names)
     wb.close()
+
+def test_generate_full_report(tmp_path):
+    summary = pd.DataFrame({
+        "filtre_kodu": ["F1"],
+        "ort_getiri_%": [1.0],
+        "sebep_kodu": ["OK"],
+    })
+    detail = pd.DataFrame({
+        "filtre_kodu": ["F1"],
+        "hisse_kodu": ["AAA"],
+        "getiri_yuzde": [1.0],
+        "basari": ["BAŞARILI"],
+    })
+    sonuc = {
+        "summary": summary,
+        "detail": detail,
+        "tarama_tarihi": "01.01.2025",
+        "satis_tarihi": "02.01.2025",
+    }
+    out = tmp_path / "full.xlsx"
+    report_generator.generate_full_report(sonuc, out)
+
+    wb = openpyxl.load_workbook(out)
+    assert wb.sheetnames[:4] == ["Özet", "Detay", "İstatistik", "Grafikler"]
+    header = [c.value for c in wb["Özet"][1]]
+    assert "sebep_kodu" in header
+    wb.close()


### PR DESCRIPTION
## Summary
- add report utilities with column defaults
- extend report generator with `generate_full_report`
- test four-sheet Excel report generation

## Testing
- `pip install -r requirements.txt`
- `pip install kaleido`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f01d1928883258ba55347f0fb994f