### PR TITLE
Fix missing indicator columns

### DIFF
--- a/config.py
+++ b/config.py
@@ -117,7 +117,7 @@ TA_STRATEGY = ta.Strategy(
         {"kind": "cci", "length": 20, "col_names": ("cci_20",)},
         {"kind": "cmo", "length": 14, "col_names": ("cmo_14",)},
         {"kind": "roc", "length": 12, "col_names": ("roc_12",)},
-        {"kind": "mom", "length": 10, "col_names": ("mom_10",)},
+        {"kind": "mom", "length": 10, "col_names": ("momentum_10",)},
         {
             "kind": "ppo",
             "fast": 12,
@@ -219,6 +219,7 @@ INDIKATOR_AD_ESLESTIRME = {
     "supertl_7_3.0": "supertrend_long_7_3",
     "superts_7_3.0": "supertrend_short_7_3",
     "vwap_d": "vwap",
+    "mom_10": "momentum_10",
     "dmp_14": "positivedirectionalindicator_14",
     "dmn_14": "negativedirectionalindicator_14",
     "aroonu_14": "aroonu_14",

--- a/filter_engine.py
+++ b/filter_engine.py
@@ -167,6 +167,16 @@ def uygula_filtreler(
         eksik_sutunlar = [
             s for s in kullanilan_sutunlar if s not in df_tarama_gunu.columns
         ]
+        if (
+            "volume_tl" in eksik_sutunlar
+            and {"volume", "close"} <= set(df_tarama_gunu.columns)
+        ):
+            df_tarama_gunu["volume_tl"] = (
+                df_tarama_gunu["volume"] * df_tarama_gunu["close"]
+            )
+            eksik_sutunlar = [
+                s for s in kullanilan_sutunlar if s not in df_tarama_gunu.columns
+            ]
         if {"psar_long", "psar_short"} <= set(
             df_tarama_gunu.columns
         ) and "psar" in eksik_sutunlar:

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -21,3 +21,21 @@ def test_no_stock_reason_for_empty_result():
     assert result["F1"]["sebep"] == "NO_STOCK"
     assert result["F1"]["hisse_sayisi"] == 0
 
+
+def test_volume_tl_generated_if_missing():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"],
+            "tarih": [pd.Timestamp("2025-03-01")],
+            "close": [10],
+            "volume": [5],
+        }
+    )
+    filters = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["volume_tl > 0"]})
+
+    result, _ = filter_engine.uygula_filtreler(
+        df, filters, pd.Timestamp("2025-03-01")
+    )
+    assert result["F1"]["sebep"] == "OK"
+    assert result["F1"]["hisse_sayisi"] == 1
+


### PR DESCRIPTION
## Summary
- map `mom_10` to `momentum_10`
- output `momentum_10` directly from pandas_ta
- auto-generate `volume_tl` column if missing
- test filter engine fallback for `volume_tl`

## Testing
- `pytest tests/test_filter_engine.py::test_volume_tl_generated_if_missing -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3abaafb48325b4d3b3298451b444