### PR TITLE
Improve empty report handling

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -185,6 +185,13 @@ def generate_full_report(sonuc_dict: dict, out_xlsx: str | Path) -> Path:
     tarama_tarihi = sonuc_dict.get("tarama_tarihi", "")
     satis_tarihi = sonuc_dict.get("satis_tarihi", "")
 
+    if summary_df is None or getattr(summary_df, "empty", False):
+        out_xlsx = Path(out_xlsx)
+        out_xlsx.parent.mkdir(parents=True, exist_ok=True)
+        with pd.ExcelWriter(out_xlsx, engine="xlsxwriter") as w:
+            pd.DataFrame({"Uyari": ["Filtre bulunamadi"]}).to_excel(w, sheet_name="Uyari", index=False)
+        return out_xlsx
+
     ozet_df = report_utils.build_ozet_df(
         summary_df, detail_df, tarama_tarihi, satis_tarihi
     )


### PR DESCRIPTION
## Summary
- return empty DataFrames from `calistir_tum_sistemi` instead of `None`
- skip full report creation when report data is empty
- create minimal Excel with warning when `generate_full_report` gets empty data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3c1ab6108325834daae0595255de