### PR TITLE
Add Excel Hatalar sheet reporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,6 +199,13 @@ if __name__ == "__main__":
             out_path.parent.mkdir(parents=True, exist_ok=True)
             rapor_path = report_generator.generate_full_report(sonuc_dict, out_path)
             print(f"Rapor oluşturuldu → {rapor_path}")
+            with pd.ExcelWriter(
+                out_path,
+                mode="a",
+                if_sheet_exists="replace",
+                engine="openpyxl",
+            ) as wr:
+                report_generator.olustur_hatali_filtre_raporu(atlanmis, wr)
         else:
             logger.info("Rapor verisi boş, Excel oluşturulmadı.")
 

--- a/report_generator.py
+++ b/report_generator.py
@@ -105,24 +105,20 @@ def olustur_hisse_bazli_rapor(sonuclar_listesi: list, cikti_klasoru: str, logger
     return dosya_adi
 
 
-def olustur_hatali_filtre_raporu(
-    hatalar_listesi: list, cikti_klasoru: str, logger=None
-):
-    """'hatalar_listesi' elemanlarının 'filtre_kodu' ve 'notlar' anahtarları
-    içerdiği varsayılır."""
-    if not hatalar_listesi:
+def olustur_hatali_filtre_raporu(atlanmis_dict: dict, writer) -> pd.DataFrame | None:
+    """Write skipped filter information into an Excel sheet named 'Hatalar'."""
+
+    if not atlanmis_dict:
         return None
-    if logger is None:
-        logger = fn_logger
-    os.makedirs(cikti_klasoru, exist_ok=True)
-    df = pd.DataFrame(hatalar_listesi)
-    dosya_adi = os.path.join(
-        cikti_klasoru,
-        f"hatali_filtre_raporu_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv",
+
+    df = pd.DataFrame(
+        [(k, v) for k, v in atlanmis_dict.items()],
+        columns=["filtre_kodu", "hata_mesaji"],
     )
-    df.to_csv(dosya_adi, index=False, encoding="utf-8-sig")
-    logger.info(f"Hatalı filtre raporu oluşturuldu: {dosya_adi}")
-    return dosya_adi
+
+    df.to_excel(writer, sheet_name="Hatalar", index=False)
+    fn_logger.info("Hatalı filtre raporu Excel'e yazıldı.")
+    return df
 
 
 def olustur_excel_raporu(kayitlar: list[dict], fname: str | Path, logger=None):

--- a/tests/test_hatalar_sheet.py
+++ b/tests/test_hatalar_sheet.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pandas as pd
+import openpyxl
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import report_generator
+
+
+def test_hatalar_sheet(tmp_path):
+    fname = tmp_path / "test.xlsx"
+    # create base workbook
+    with pd.ExcelWriter(fname) as w:
+        pd.DataFrame({"a": [1]}).to_excel(w, sheet_name="Sheet1", index=False)
+
+    atlanmis = {"F1": "err"}
+    with pd.ExcelWriter(fname, mode="a", if_sheet_exists="replace", engine="openpyxl") as wr:
+        report_generator.olustur_hatali_filtre_raporu(atlanmis, wr)
+
+    wb = openpyxl.load_workbook(fname)
+    assert "Hatalar" in wb.sheetnames
+    assert wb["Hatalar"].max_row > 1
+    wb.close()

--- a/tests/test_log_summary.py
+++ b/tests/test_log_summary.py
@@ -17,6 +17,8 @@ def test_log_summary_present(caplog):
             f"warnings={log_counter.warnings} | atlanan_filtre="
         )
         logger.info(summary)
-    assert "LOG_SUMMARY" in caplog.text
+
+    lines = [l for l in caplog.text.splitlines() if "LOG_SUMMARY" in l]
+    assert any("errors=" in l and "atlanan_filtre=" in l for l in lines)
     assert log_counter.errors == 0
     assert log_counter.warnings <= 5


### PR DESCRIPTION
## Summary
- write skipped filters to Excel via `olustur_hatali_filtre_raporu`
- append "Hatalar" sheet in `main.py`
- test presence of "Hatalar" sheet
- validate log summary line content

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685000b8fe6883259214d8a72b4f982d