### PR TITLE
Handle missing prices by searching forward/backward

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -43,8 +43,23 @@ def _get_fiyat(
 
         veri_satiri = df_hisse_veri[df_hisse_veri["tarih"] == tarih]
         if veri_satiri.empty:
-            # log.debug(f"{hisse_kodu_log} için {tarih.strftime('%d.%m.%Y')} tarihinde veri bulunamadı ({zaman_sutun_adi} için).")
-            return np.nan
+            sonraki = df_hisse_veri[df_hisse_veri["tarih"] > tarih]
+            if not sonraki.empty:
+                tarih2 = sonraki["tarih"].min()
+            else:
+                onceki = df_hisse_veri[df_hisse_veri["tarih"] < tarih]
+                tarih2 = onceki["tarih"].max() if not onceki.empty else None
+
+            if tarih2 is not None:
+                log.info(
+                    f"{hisse_kodu_log} için {tarih.strftime('%d.%m.%Y')} tarihli fiyat bulunamadı. {tarih2.strftime('%d.%m.%Y')} tarihine kaydırıldı."
+                )
+                veri_satiri = df_hisse_veri[df_hisse_veri["tarih"] == tarih2]
+            else:
+                log.warning(
+                    f"{hisse_kodu_log} için {tarih.strftime('%d.%m.%Y')} ve civarındaki fiyat verisi bulunamadı."
+                )
+                return np.nan
 
         if zaman_sutun_adi in veri_satiri.columns:
             fiyat = veri_satiri[zaman_sutun_adi].iloc[0]

--- a/tests/test_backtest_core.py
+++ b/tests/test_backtest_core.py
@@ -50,5 +50,5 @@ def test_missing_buy_price_sets_data_gap():
         tarama_tarihi_str="07.03.2025",
     )
     row = rapor_df.iloc[0]
-    assert row["sebep_kodu"] == "DATA_GAP"
-    assert pd.isna(row["ort_getiri_%"])
+    assert row["sebep_kodu"] == "OK"
+    assert pd.notna(row["ort_getiri_%"])

--- a/tests/test_data_gap.py
+++ b/tests/test_data_gap.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import backtest_core
+
+
+def test_get_fiyat_moves_to_next_date():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA", "AAA"],
+            "tarih": [
+                pd.to_datetime("09.03.2025", dayfirst=True),
+                pd.to_datetime("11.03.2025", dayfirst=True),
+            ],
+            "close": [10.0, 11.0],
+        }
+    )
+
+    fiyat = backtest_core._get_fiyat(
+        df, pd.to_datetime("10.03.2025", dayfirst=True), "close"
+    )
+    assert fiyat == 11.0


### PR DESCRIPTION
## Summary
- shift _get_fiyat to nearest available date when price is missing
- adjust backtest_core tests to expect OK when buy price found via shift
- add regression test ensuring _get_fiyat moves forward to next date

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850084aedd083258eb098b08bd7af3a