### PR TITLE
Fix unused import in data_loader

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -14,7 +14,6 @@ from functools import lru_cache, partial
 from data_loader_cache import DataLoaderCache
 
 from utils.logging_setup import setup_logger, get_logger
-import logging
 
 setup_logger()
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- remove unused `logging` import from `data_loader.py`

## Testing
- `python -m py_compile data_loader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68502a86ed488325995d9e322192e2ce