### PR TITLE
Fix NaN handling in filtre_dogrulama

### DIFF
--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -26,9 +26,17 @@ def dogrula_filtre_dataframe(
     sorunlu = {}
     zorunlu_kolonlar = zorunlu_kolonlar or ["flag", "query"]
 
+    eksik_kolonlar = [c for c in zorunlu_kolonlar if c not in df_filtre.columns]
+    if eksik_kolonlar:
+        raise KeyError(
+            "Eksik zorunlu kolonlar: " + ", ".join(eksik_kolonlar)
+        )
+
     for idx, row in df_filtre.iterrows():
-        kod = row.get("flag") or f"satir_{idx}"
-        query = str(row.get("query", "")).strip()
+        kod_degeri = row.get("flag")
+        kod = f"satir_{idx}" if pd.isna(kod_degeri) else str(kod_degeri)
+        query_degeri = row.get("query", "")
+        query = "" if pd.isna(query_degeri) else str(query_degeri).strip()
 
         if not kod or kod.strip() == "":
             sorunlu[kod] = "Boş veya eksik flag (kod) değeri."

--- a/tests/test_filtre_dogrulama.py
+++ b/tests/test_filtre_dogrulama.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pandas as pd
+import pytest
 
 from filtre_dogrulama import dogrula_filtre_dataframe
 
@@ -22,8 +23,21 @@ def test_empty_python_query():
     assert "Query" in result["VALID"]
 
 
-def test_missing_python_query():
-    df = pd.DataFrame([{"flag": "VALID"}])
+def test_missing_python_query_value():
+    df = pd.DataFrame([{"flag": "VALID", "query": pd.NA}])
     result = dogrula_filtre_dataframe(df)
     assert "VALID" in result
     assert "Query" in result["VALID"]
+
+
+def test_nan_flag_value():
+    df = pd.DataFrame([{"flag": pd.NA, "query": "True"}])
+    result = dogrula_filtre_dataframe(df)
+    assert "satir_0" in result
+    assert "flag" in result["satir_0"]
+
+
+def test_missing_columns_raises_keyerror():
+    df = pd.DataFrame([{"FilterCode": "F1", "PythonQuery": "True"}])
+    with pytest.raises(KeyError):
+        dogrula_filtre_dataframe(df)


### PR DESCRIPTION
## Summary
- validate required columns in `dogrula_filtre_dataframe`
- handle `NaN` values for `flag` and `query`
- extend filter validation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685030e5f1b0832589d01e3707974626