### PR TITLE
Fix imports and unused variables in indicator_calculator

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -21,10 +21,9 @@ from pandas_ta import psar as ta_psar
 import config
 import utils
 
-warnings.filterwarnings("ignore", category=pd.errors.PerformanceWarning)
-
 from utils.logging_setup import setup_logger, get_logger
-import logging
+
+warnings.filterwarnings("ignore", category=pd.errors.PerformanceWarning)
 
 setup_logger()
 logger = get_logger(__name__)
@@ -860,11 +859,8 @@ def hesapla_teknik_indikatorler_ve_kesisimler(
 
     _ekle_psar(df_islenmis_veri)
 
-    ta_strategy_params = config.TA_STRATEGY
     series_series_crossovers = config.SERIES_SERIES_CROSSOVERS
     series_value_crossovers = config.SERIES_VALUE_CROSSOVERS
-    ozel_sutun_params = config.OZEL_SUTUN_PARAMS
-    indikator_ad_eslestirme = config.INDIKATOR_AD_ESLESTIRME
 
     filtre_df = df_filters
     if filtre_df is None:


### PR DESCRIPTION
## Summary
- cleanup imports and warning filter placement
- drop unused vars inside `hesapla_teknik_indikatorler_ve_kesisimler`
- keep crossover config assignments used later

## Testing
- `pytest tests/test_indicator_calculator.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850711c6c788325a95a590eef4e8386