### PR TITLE
Fix conditional formatting range in health report

### DIFF
--- a/log_to_health.py
+++ b/log_to_health.py
@@ -29,6 +29,8 @@ def _format_header(ws):
 
 
 def _apply_return_colors(ws, column_index):
+    if ws.max_row < 2:
+        return
     letter = get_column_letter(column_index)
     rng = f"{letter}2:{letter}{ws.max_row}"
     ws.conditional_formatting.add(


### PR DESCRIPTION
## Summary
- prevent `_apply_return_colors` from creating invalid ranges when the sheet has no data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850728332448325abdfadf64cf6bafa