### PR TITLE
Fix date parsing to support ISO format

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Temel script `main.py` aşağıdaki parametreleri kabul eder:
 
 ```bash
 python main.py --tarama 01.01.2025 --satis 05.01.2025 [--gui]
+python main.py --tarama 2025-03-07 --satis 2025-03-10
 ```
+(GG.AA.YYYY biçimi de desteklenir)
 
-* `--tarama` ve `--satis` tarihleri `dd.mm.yyyy` formatındadır.
+* `--tarama` ve `--satis` tarihleri `yyyy-mm-dd` formatındadır.
 * `--gui` verildiğinde sonuçlar basit bir Streamlit arayüzünde görüntülenir.
 
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,14 @@ import utils
 import report_utils
 
 
+def _parse_date(dt_str: str) -> pd.Timestamp:
+    """Parse date from 'DD.MM.YYYY' or ISO 'YYYY-MM-DD'."""
+    try:
+        return pd.to_datetime(dt_str, format="%Y-%m-%d", dayfirst=False)
+    except ValueError:
+        return pd.to_datetime(dt_str, format="%d.%m.%Y", dayfirst=True)
+
+
 def _hazirla_rapor_alt_df(rapor_df: pd.DataFrame):
     """Rapor için örnek özet, detay ve istatistik DataFrame'leri üretir."""
     if rapor_df is None or rapor_df.empty:
@@ -182,10 +190,14 @@ def calistir_tum_sistemi(
     df_filtre_kurallari, df_raw = veri_yukle(force_excel_reload_param)
     df_processed = on_isle(df_raw)
     df_indicator = indikator_hesapla(df_processed)
-    tarama_dt = pd.to_datetime(tarama_tarihi_str, format="%d.%m.%Y")
+    tarama_dt = _parse_date(tarama_tarihi_str)
+    satis_dt = _parse_date(satis_tarihi_str)
     filtre_sonuclar, atlanmis = filtre_uygula(df_indicator, tarama_dt)
     rapor_df, detay_df = backtest_yap(
-        df_indicator, filtre_sonuclar, tarama_tarihi_str, satis_tarihi_str
+        df_indicator,
+        filtre_sonuclar,
+        tarama_tarihi_str,
+        satis_tarihi_str,
     )
     raporla(rapor_df, detay_df)
     return rapor_df, detay_df, atlanmis

--- a/tests/test_date_parse_iso.py
+++ b/tests/test_date_parse_iso.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import types
+import importlib
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_parse_date_iso(monkeypatch):
+    for m in [
+        "data_loader",
+        "preprocessor",
+        "indicator_calculator",
+        "filter_engine",
+        "backtest_core",
+        "report_generator",
+    ]:
+        monkeypatch.setitem(sys.modules, m, types.ModuleType(m))
+
+    import main
+    importlib.reload(main)
+
+    assert main._parse_date("2025-03-07") == pd.Timestamp("2025-03-07")
+    assert main._parse_date("07.03.2025") == pd.Timestamp("2025-03-07")


### PR DESCRIPTION
## Summary
- enhance main date parsing to handle YYYY-MM-DD
- add regression test for new date parser
- show ISO example in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python main.py --tarama 2025-03-07 --satis 2025-03-10` *(fails: filtre dosyası bulunamadı)*

------
https://chatgpt.com/codex/tasks/task_e_68508a94290c832581fba4e28dcc95ce