### PR TITLE
Fix SMA crossovers and filter query

### DIFF
--- a/config.py
+++ b/config.py
@@ -341,6 +341,7 @@ SERIES_SERIES_CROSSOVERS = [
     for a, b in zip(GEREKLI_MA_PERIYOTLAR[:-1], GEREKLI_MA_PERIYOTLAR[1:])
 ] + [
     ("sma_5", "sma_20", "sma_5_keser_sma_20_yukari", "sma_5_keser_sma_20_asagi"),
+    ("sma_10", "sma_50", "sma_10_keser_sma_50_yukari", "sma_10_keser_sma_50_asagi"),
     ("close", "sma_20", "close_keser_sma_20_yukari", "close_keser_sma_20_asagi"),
     ("close", "sma_50", "close_keser_sma_50_yukari", "close_keser_sma_50_asagi"),
     ("close", "sma_100", "close_keser_sma_100_yukari", "close_keser_sma_100_asagi"),

--- a/tests/test_filter_fix.py
+++ b/tests/test_filter_fix.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import filter_engine
+
+
+def test_t17_t500_ok():
+    df = pd.DataFrame({
+        "hisse_kodu": ["AAA"],
+        "tarih": [pd.Timestamp("2025-03-07")],
+        "relative_volume": [1.4],
+        "change_1w_percent": [10.0],
+        "sma_10_keser_sma_50_yukari": [True],
+        "close": [15.0],
+        "bbm_20_2": [10.0],
+        "adx_14": [25.0],
+    })
+
+    filters = pd.DataFrame(
+        {
+            "FilterCode": ["T17", "T500"],
+            "PythonQuery": [
+                "(relative_volume > 1.3) and (change_1w_percent < 15.0) and sma_10_keser_sma_50_yukari",
+                "(change_1w_percent < 15.0) and (close > bbm_20_2) and (adx_14 > 20.0)",
+            ],
+        }
+    )
+
+    result, _ = filter_engine.uygula_filtreler(df, filters, pd.Timestamp("2025-03-07"))
+
+    assert result["T17"]["sebep"] == "OK"
+    assert result["T500"]["sebep"] == "OK"


### PR DESCRIPTION
## Summary
- generate SMA10 vs SMA50 crossover columns
- validate filter corrections for T17 and T500

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850967a9310832584f3209ec016ac97