### PR TITLE
Fix PSAR close crossover naming

### DIFF
--- a/config.py
+++ b/config.py
@@ -470,7 +470,23 @@ SERIES_SERIES_CROSSOVERS = [
         "ichimoku_conversionline_keser_close_yukari",
         "ichimoku_conversionline_keser_close_asagi",
     ),
+    (
+        "psar",
+        "close",
+        "psar_keser_close_yukari",
+        "psar_keser_close_asagi",
+    ),
 ]
+# --- crossover çıktıları da her zaman hesaplansın
+try:
+    wanted_cols
+except NameError:
+    wanted_cols = set()
+wanted_cols |= {
+    c_above for _, _, c_above, _ in SERIES_SERIES_CROSSOVERS
+} | {
+    c_below for _, _, _, c_below in SERIES_SERIES_CROSSOVERS
+}
 
 SERIES_VALUE_CROSSOVERS = [
     ("rsi_14", 50.0, "50p0"),


### PR DESCRIPTION
## Summary
- include PSAR vs close crossover in the config
- always compute crossover output columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a706ee1c8325b5e78ccfec1cc6cb