### PR TITLE
Add scan audit module

### DIFF
--- a/kontrol_araci.py
+++ b/kontrol_araci.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from filter_engine import _apply_single_filter
+
+
+def tarama_denetimi(df_filtreler: pd.DataFrame, df_indikator: pd.DataFrame) -> pd.DataFrame:
+    """Tüm filtreleri tek tek çalıştırıp _apply_single_filter çıktısını toplar."""
+    kayitlar = []
+    for _, sat in df_filtreler.iterrows():
+        _, info = _apply_single_filter(
+            df_indikator,
+            sat["kod"],
+            sat["PythonQuery"],
+        )
+        kayitlar.append(info)
+    return pd.DataFrame(kayitlar)

--- a/tests/test_kontrol_araci.py
+++ b/tests/test_kontrol_araci.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import kontrol_araci
+
+
+def test_tarama_denetimi_collects_info():
+    df_filtreler = pd.DataFrame({
+        "kod": ["F1", "F2"],
+        "PythonQuery": ["close > 10", "open > 5"],
+    })
+
+    df_indikator = pd.DataFrame({
+        "hisse_kodu": ["AAA"],
+        "tarih": [pd.Timestamp("2025-03-01")],
+        "close": [5],
+    })
+
+    result = kontrol_araci.tarama_denetimi(df_filtreler, df_indikator)
+
+    assert list(result.columns) == [
+        "kod",
+        "tip",
+        "durum",
+        "sebep",
+        "eksik_sutunlar",
+        "nan_sutunlar",
+        "secim_adedi",
+    ]
+
+    row_f1 = result[result["kod"] == "F1"].iloc[0]
+    assert row_f1["durum"] == "BOS"
+    assert row_f1["secim_adedi"] == 0
+
+    row_f2 = result[result["kod"] == "F2"].iloc[0]
+    assert row_f2["durum"] == "CALISTIRILAMADI"
+    assert "open" in row_f2["eksik_sutunlar"]


### PR DESCRIPTION
## Summary
- implement `tarama_denetimi` to audit filter scans
- add unit test for the new function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851b5a62eb08325be2a0bce82d59a8e