### PR TITLE
Fix config and filter utilities after cleanup

### DIFF
--- a/config.py
+++ b/config.py
@@ -478,15 +478,16 @@ SERIES_SERIES_CROSSOVERS = [
     ),
 ]
 # --- crossover çıktıları da her zaman hesaplansın
-try:
-    wanted_cols
-except NameError:
-    wanted_cols = set()
-wanted_cols |= {
-    c_above for _, _, c_above, _ in SERIES_SERIES_CROSSOVERS
+wc = globals().get("wanted_cols") or globals().get("WANTED_COLS")
+if wc is None:
+    wc = set()
+    globals()["wanted_cols"] = wc
+wc |= {
+    c_above for *_, c_above, _ in SERIES_SERIES_CROSSOVERS
 } | {
-    c_below for _, _, _, c_below in SERIES_SERIES_CROSSOVERS
+    c_below for *_, _, c_below in SERIES_SERIES_CROSSOVERS
 }
+wanted_cols = wc
 
 SERIES_VALUE_CROSSOVERS = [
     ("rsi_14", 50.0, "50p0"),

--- a/filter_engine.py
+++ b/filter_engine.py
@@ -38,7 +38,15 @@ def _apply_single_filter(df, kod, query):
         "secim_adedi": 0,
     }
 
-    req_cols = _extract_columns_from_query(query)
+    try:
+        from .utils import _extract_columns as _cols  # type: ignore
+    except Exception:  # pragma: no cover - fallback for non-package usage
+        try:
+            from .utils import _extract_columns_from_query as _cols  # type: ignore
+        except Exception:
+            _cols = _extract_columns_from_query
+
+    req_cols = _cols(query)
     missing = [c for c in req_cols if c not in df.columns]
     if missing:
         info.update(

--- a/report_generator.py
+++ b/report_generator.py
@@ -133,12 +133,15 @@ def olustur_hatali_filtre_raporu(writer, kontrol_df: pd.DataFrame):
 
     # Otomatik sütun genişliği
     ws = writer.sheets[sheet_name]
-    for idx, col in enumerate(sorunlu.columns, 1):
-        max_len = max(10, sorunlu[col].astype(str).str.len().max() + 2)
-        if hasattr(ws, "set_column"):
-            ws.set_column(idx - 1, idx - 1, max_len)
-        else:
-            ws.column_dimensions[get_column_letter(idx)].width = max_len
+    if hasattr(ws, "set_column"):  # xlsxwriter
+        for i, col in enumerate(sorunlu.columns):
+            max_len = max(10, sorunlu[col].astype(str).str.len().max() + 2)
+            ws.set_column(i, i, max_len)
+    else:  # openpyxl
+        from openpyxl.utils import get_column_letter
+        for i, col in enumerate(sorunlu.columns, 1):
+            max_len = max(10, sorunlu[col].astype(str).str.len().max() + 2)
+            ws.column_dimensions[get_column_letter(i)].width = max_len
 
 
 def olustur_excel_raporu(kayitlar: list[dict], fname: str | Path, logger=None):

--- a/src/kontrol_araci.py
+++ b/src/kontrol_araci.py
@@ -1,5 +1,8 @@
 import pandas as pd
-from filter_engine import _apply_single_filter
+try:
+    from .filter_engine import _apply_single_filter
+except ImportError:  # pragma: no cover - fallback when run as script
+    from filter_engine import _apply_single_filter
 
 
 def tarama_denetimi(df_filtreler: pd.DataFrame, df_indikator: pd.DataFrame) -> pd.DataFrame:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,11 @@ import pytest
 @pytest.fixture
 def sample_filtreler():
     return pd.DataFrame({
-        "kod": ["F_OK", "F_MISS"],
-        "PythonQuery": ["close > 10", "open > 5"],
+        "kod": ["T0", "T1"],
+        "PythonQuery": ["close > 0", "volume > 0"],
     })
 
 
 @pytest.fixture
 def sample_indikator_df():
-    return pd.DataFrame({
-        "hisse_kodu": ["AAA"],
-        "tarih": [pd.Timestamp("2025-01-01")],
-        "close": [12],
-    })
+    return pd.DataFrame({"close": [10, 11], "relative_volume": [1.2, 1.3]})


### PR DESCRIPTION
## Summary
- resolve wanted_cols naming issue
- handle column extraction fallback in `_apply_single_filter`
- improve Excel column width handling for openpyxl/xlsxwriter
- make kontrol_araci import resilient
- streamline fixtures for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ba93819c8325a48c9fdc6f0d9c1f