### PR TITLE
Add TEMA 20 indicator

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -18,6 +18,7 @@ if not hasattr(np, "NaN"):
 
 import pandas_ta as ta
 from pandas_ta import psar as ta_psar
+from pandas_ta import tema
 import config
 import utils
 
@@ -322,6 +323,11 @@ def safe_get(df: pd.DataFrame, col: str) -> pd.Series | None:
         logger.debug(f"{col} eksik – crossover atlandı")
         return None
     return df[col]
+
+
+def _tema20(series: pd.Series) -> pd.Series:
+    """TEMA 20 – pandas_ta."""
+    return tema(series, length=20)
 
 
 def _ekle_psar(df: pd.DataFrame) -> None:
@@ -713,6 +719,10 @@ def _calculate_group_indicators_and_crossovers(
     if "ema_8" not in df_final_group.columns and "close" in df_final_group.columns:
         manual_cols["ema_8"] = df_final_group["close"].ewm(span=8, adjust=False).mean()
         local_logger.debug(f"{hisse_kodu}: 'ema_8' sütunu manuel olarak hesaplandı.")
+
+    if "tema_20" not in df_final_group.columns and "close" in df_final_group.columns:
+        manual_cols["tema_20"] = _tema20(df_final_group["close"])
+        local_logger.debug(f"{hisse_kodu}: 'tema_20' sütunu manuel olarak hesaplandı.")
 
     for period in config.GEREKLI_MA_PERIYOTLAR:
         safe_ma(df_final_group, period, "sma", local_logger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy==2.0.2
 packaging==24.2
 jedi>=0.19.1
 pandas-ta==0.3.14b0    # pandas-ta, NumPy 2 ile uyumlu
+pandas_ta>=0.3.14
 holidays               # tarih/tatil kontrolü için
 openpyxl>=3.1
 xlsxwriter>=3.1

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -58,6 +58,7 @@ def test_fallback_indicators_created_when_missing():
     assert "sma_200" in result.columns
     assert "ema_200" in result.columns
     assert "momentum_10" in result.columns
+    assert "tema_20" in result.columns
 
 
 @pytest.mark.parametrize("bars", [30, 60, 252])


### PR DESCRIPTION
## Summary
- compute `tema_20` indicator using pandas_ta
- ensure `tema_20` produced even when pandas-ta skips it
- require `pandas_ta>=0.3.14`
- expect `tema_20` column in indicator calculator tests

## Testing
- `pip install openpyxl plotly kaleido >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pip install xlsxwriter >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bc587bf883258f6e78e0da50e516