### PR TITLE
Implement business day NaT handling

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+
+def fill_missing_business_day(df: pd.DataFrame, date_col: str = "tarih") -> pd.DataFrame:
+    """Shift rows with NaT in ``date_col`` to the previous business day.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input DataFrame containing a date column.
+    date_col : str, optional
+        Name of the date column, by default "tarih".
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame where NaT dates are replaced with the previous business day.
+    """
+    if date_col not in df.columns:
+        return df
+
+    df = df.copy()
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce")
+
+    dates = df[date_col]
+    next_valid = dates.fillna(method="bfill")
+    prev_valid = dates.fillna(method="ffill")
+
+    adjusted = next_valid - pd.offsets.BDay(1)
+    fallback = prev_valid - pd.offsets.BDay(1)
+
+    mask = dates.isna()
+    df.loc[mask, date_col] = adjusted.where(~next_valid.isna(), fallback)[mask]
+    return df

--- a/tests/test_data_gap.py
+++ b/tests/test_data_gap.py
@@ -5,6 +5,7 @@ import pandas as pd
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import backtest_core
+from src.preprocessor import fill_missing_business_day
 
 
 def test_get_fiyat_moves_to_next_date():
@@ -23,3 +24,16 @@ def test_get_fiyat_moves_to_next_date():
         df, pd.to_datetime("10.03.2025", dayfirst=True), "close"
     )
     assert fiyat == 11.0
+
+
+def test_fill_missing_business_day_shifts_nat():
+    raw = pd.DataFrame(
+        {
+            "tarih": [pd.NaT, pd.to_datetime("11.03.2025", dayfirst=True)],
+            "close": [10.0, 11.0],
+        }
+    )
+
+    out = fill_missing_business_day(raw, date_col="tarih")
+
+    assert out.loc[0, "tarih"] == pd.to_datetime("10.03.2025", dayfirst=True)


### PR DESCRIPTION
## Summary
- add `fill_missing_business_day` utility under `src`
- test shifting NaT dates to the prior business day

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851cb57fe448325a77d8df6ab6d1148