### PR TITLE
Add regression test for report legacy columns

### DIFF
--- a/tests/test_report_format.py
+++ b/tests/test_report_format.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from report_generator import (
+    generate_full_report,
+    LEGACY_SUMMARY_COLS,
+    LEGACY_DETAIL_COLS,
+)
+
+
+def test_legacy_columns_preserved(tmp_path):
+    path = tmp_path / "rapor.xlsx"
+    generate_full_report(
+        pd.DataFrame(columns=LEGACY_SUMMARY_COLS),
+        pd.DataFrame(columns=LEGACY_DETAIL_COLS),
+        [],
+        path,
+        keep_legacy=True,
+    )
+    xls = pd.ExcelFile(path)
+    assert xls.sheet_names[:2] == ["Özet", "Detay"]
+    assert list(pd.read_excel(xls, "Özet").columns)  == LEGACY_SUMMARY_COLS
+    assert list(pd.read_excel(xls, "Detay").columns) == LEGACY_DETAIL_COLS


### PR DESCRIPTION
## Summary
- add regression test to ensure legacy summary and detail columns are preserved

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685250c7b8448325bd9d2b1db4476eeb