### PR TITLE
Apply patches to fix report generator and main

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -856,6 +856,7 @@ def _calculate_group_indicators_and_crossovers(
             axis=1,
         )
 
+    df_final_group = df_final_group.loc[:, ~df_final_group.columns.duplicated()]
     return df_final_group
 
 

--- a/main.py
+++ b/main.py
@@ -259,7 +259,7 @@ if __name__ == "__main__":
                 if_sheet_exists="replace",
                 engine="openpyxl",
             ) as wr:
-                report_generator.olustur_hatali_filtre_raporu(atlanmis, wr, df_ozet)
+                report_generator.olustur_hatali_filtre_raporu(wr, atlanmis)
         else:
             logger.info("Rapor verisi boş, Excel oluşturulmadı.")
 
@@ -267,14 +267,8 @@ if __name__ == "__main__":
             _run_gui(rapor_df, detay_df)
 
     except Exception as e_main_run:
-        logger.critical(
-            f"Ana çalıştırma (`if __name__ == '__main__':`) bloğunda BEKLENMEDİK KRİTİK HATA: {e_main_run}",
-            exc_info=True,
-        )
-        # yine de boş rapor yaz
-        empty = pd.DataFrame()
-        from report_generator import generate_full_report
-        generate_full_report(empty, empty, log_counter.error_list, out_path="cikti/rapor_empty.xlsx")
+        import traceback, sys
+        traceback.print_exc()
         sys.exit(1)
     finally:
         logger.info(

--- a/report_generator.py
+++ b/report_generator.py
@@ -239,7 +239,10 @@ def _write_stats_sheet(wr: pd.ExcelWriter, df: pd.DataFrame) -> None:
 
 
 def _write_error_sheet(wr: pd.ExcelWriter, err: Iterable) -> None:
-    pd.DataFrame(err).to_excel(wr, "Hatalar", index=False)
+    df = pd.DataFrame(err)
+    if df.empty:
+        df = pd.DataFrame({"bilgi": ["Hata yok"]})
+    df.to_excel(wr, "Hatalar", index=False)
 
 
 def generate_full_report(
@@ -267,8 +270,7 @@ def generate_full_report(
             index=False,
         )
         _write_stats_sheet(wr, summary_df)
-        if error_list:
-            _write_error_sheet(wr, error_list)
+        _write_error_sheet(wr, error_list)
     fn_logger.info("Rapor kaydedildi → %s", out_path)
     return str(out_path)
 

--- a/tests/test_report_format.py
+++ b/tests/test_report_format.py
@@ -25,3 +25,5 @@ def test_legacy_columns_preserved(tmp_path):
     assert xls.sheet_names[:2] == ["Özet", "Detay"]
     assert list(pd.read_excel(xls, "Özet").columns)  == LEGACY_SUMMARY_COLS
     assert list(pd.read_excel(xls, "Detay").columns) == LEGACY_DETAIL_COLS
+    assert "Hatalar" in xls.sheet_names, "Hatalar sayfası eksik!"
+    assert not pd.read_excel(xls, "Hatalar").empty, "Hatalar sayfası boş!"


### PR DESCRIPTION
## Summary
- streamline error handling in `main.py`
- ensure deduplication of columns in `indicator_calculator`
- produce a placeholder row when the error list is empty in `generate_full_report`
- update test to assert Hatalar sheet exists and is non-empty

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68528fe9bf40832588fc8da53382b327