### PR TITLE
Improve filter log messages and add tests

### DIFF
--- a/tests/test_log_contains_error_tags.py
+++ b/tests/test_log_contains_error_tags.py
@@ -1,0 +1,11 @@
+import re
+import logging
+from filter_engine import run_single_filter
+
+
+def test_log_has_query_error(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    # sahte filtre, parse hatası tetikle
+    run_single_filter("TERRIBLE_FILTER", "close > df['X']")
+    log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert re.search(r"QUERY_ERROR:", log_text), "Log QUERY_ERROR etiketi içermiyor"


### PR DESCRIPTION
## Summary
- handle `MissingColumnError` within filter engine
- refine error collection when a `QueryError` or missing column occurs
- expose `run_single_filter` helper for tests
- check for `QUERY_ERROR` tag in logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ff32e90c83259f30985c30d4dc26