### PR TITLE
Implement duplicate column checks

### DIFF
--- a/tests/test_no_duplicate_columns.py
+++ b/tests/test_no_duplicate_columns.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.pop("pandas_ta", None)
+
+from indicator_calculator import calculate_indicators
+
+def test_duplicate_columns():
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5]})
+    out = calculate_indicators(df.copy(), indicators=["ema_5", "ema_5"])
+    assert not out.columns.duplicated().any(), "Duplicate column oluştu!"


### PR DESCRIPTION
## Summary
- add `calculate_indicators` helper with duplicate column safeguard
- filter duplicate columns at the end of calculations
- test ensuring repeated indicator names don't create duplicate columns

## Testing
- `pytest tests/test_no_duplicate_columns.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530120f8c08325b20a343793ba2c93