### PR TITLE
Silence fillna warning in report generator

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -5,10 +5,17 @@ from pathlib import Path
 from datetime import datetime
 from typing import Iterable
 
-import pandas as pd
 from openpyxl.utils import get_column_letter
 import xlsxwriter
 from utils.logging_setup import get_logger, setup_logger
+
+import warnings, pandas as pd
+warnings.filterwarnings(
+    "ignore",
+    message="Downcasting object dtype arrays on .fillna",
+    category=FutureWarning,
+    module="report_generator",
+)
 
 setup_logger()
 fn_logger = get_logger(__name__)

--- a/tests/test_error_list.py
+++ b/tests/test_error_list.py
@@ -17,5 +17,6 @@ def test_error_list_writes_sheet(tmp_path):
         path,
         keep_legacy=True,
     )
-    assert "Hatalar" in pd.ExcelFile(path).sheet_names
+    with pd.ExcelFile(path) as xls:
+        assert "Hatalar" in xls.sheet_names
 

--- a/tests/test_error_sheet_presence.py
+++ b/tests/test_error_sheet_presence.py
@@ -36,13 +36,13 @@ def test_hatalar_sheet_not_empty_and_matches(tmp_path):
     path = tmp_path / "rapor.xlsx"
     generate_full_report(df_sum, df_det, err_list, path, keep_legacy=True)
 
-    xls = pd.ExcelFile(path)
-    assert "Hatalar" in xls.sheet_names, "'Hatalar' sheet'i yok!"
+    with pd.ExcelFile(path) as xls:
+        assert "Hatalar" in xls.sheet_names, "'Hatalar' sheet'i yok!"
 
-    hatalar_df = pd.read_excel(xls, "Hatalar")
-    assert not hatalar_df.empty, "'Hatalar' sheet'i boş!"
+        hatalar_df = pd.read_excel(xls, "Hatalar")
+        assert not hatalar_df.empty, "'Hatalar' sheet'i boş!"
 
-    # Özet’te OK olmayan satır sayısı == Hatalar sheet satır sayısı
-    ozet_df = pd.read_excel(xls, "Özet")
-    n_bad = (ozet_df["sebep_kodu"] != "OK").sum()
-    assert len(hatalar_df) == n_bad, "Hatalar sayısı uyumsuz!"
+        # Özet’te OK olmayan satır sayısı == Hatalar sheet satır sayısı
+        ozet_df = pd.read_excel(xls, "Özet")
+        n_bad = (ozet_df["sebep_kodu"] != "OK").sum()
+        assert len(hatalar_df) == n_bad, "Hatalar sayısı uyumsuz!"

--- a/tests/test_report_format.py
+++ b/tests/test_report_format.py
@@ -42,14 +42,14 @@ def test_legacy_columns_preserved(tmp_path):
         path,
         keep_legacy=True,
     )
-    xls = pd.ExcelFile(path)
-    assert xls.sheet_names[:2] == ["Özet", "Detay"]
-    assert list(pd.read_excel(xls, "Özet").columns) == LEGACY_SUMMARY_COLS
-    assert list(pd.read_excel(xls, "Detay").columns) == LEGACY_DETAIL_COLS
-    assert len(pd.read_excel(xls, "Özet")) >= 1
-    assert len(pd.read_excel(xls, "Detay")) >= 1
-    assert "Hatalar" in xls.sheet_names, "Hatalar sayfası eksik!"
-    assert not pd.read_excel(xls, "Hatalar").empty, "Hatalar sayfası boş!"
+    with pd.ExcelFile(path) as xls:
+        assert xls.sheet_names[:2] == ["Özet", "Detay"]
+        assert list(pd.read_excel(xls, "Özet").columns) == LEGACY_SUMMARY_COLS
+        assert list(pd.read_excel(xls, "Detay").columns) == LEGACY_DETAIL_COLS
+        assert len(pd.read_excel(xls, "Özet")) >= 1
+        assert len(pd.read_excel(xls, "Detay")) >= 1
+        assert "Hatalar" in xls.sheet_names, "Hatalar sayfası eksik!"
+        assert not pd.read_excel(xls, "Hatalar").empty, "Hatalar sayfası boş!"
 
 
 def test_error_sheet_not_empty(tmp_path):


### PR DESCRIPTION
## Summary
- suppress pandas FutureWarning in `report_generator`
- ensure ExcelFile objects are properly closed in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685312ea9df48325a5b90f977c8c04fe