### PR TITLE
Fix pandas-ta installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       # Proje paketlenmedi; setup.py yok → requirements.txt kullan.
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
+          pip install pandas-ta==0.3.14b0
           pip install --timeout 60 -r requirements.txt
           pip install --timeout 60 matplotlib xlsxwriter streamlit
 


### PR DESCRIPTION
## Summary
- ensure pandas-ta==0.3.14b0 gets installed during CI setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ab443e0c8325a5a8c91f18730a5d