### PR TITLE
Remove unused warning filter

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -9,14 +9,8 @@ from openpyxl.utils import get_column_letter
 import xlsxwriter
 from utils.logging_setup import get_logger, setup_logger
 
-import warnings, pandas as pd
+import pandas as pd
 import report_stats
-warnings.filterwarnings(
-    "ignore",
-    message="Downcasting object dtype arrays on .fillna",
-    category=FutureWarning,
-    module="report_generator",
-)
 
 setup_logger()
 fn_logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- drop unused `warnings.filterwarnings` call in `report_generator`

## Testing
- `pylint main.py report_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ac5f080c8325abf5d80342df82d5