### PR TITLE
Suppress noisy warnings

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -25,6 +25,18 @@ import utils
 from utils.logging_setup import setup_logger, get_logger
 
 warnings.filterwarnings("ignore", category=pd.errors.PerformanceWarning)
+warnings.filterwarnings(
+    "ignore",
+    message="A value is trying to be set on a copy of a DataFrame or Series",
+    category=FutureWarning,
+    module="indicator_calculator",
+)
+warnings.filterwarnings(
+    "ignore",
+    message="Series.fillna with 'method' is deprecated",
+    category=FutureWarning,
+    module="indicator_calculator",
+)
 
 setup_logger()
 logger = get_logger(__name__)
@@ -312,7 +324,7 @@ def safe_ma(df: pd.DataFrame, n: int, kind: str = "sma", logger_param=None) -> N
             df[col] = df["close"].rolling(window=n, min_periods=1).mean()
         else:
             df[col] = df["close"].ewm(span=n, adjust=False, min_periods=1).mean()
-        df[col].fillna(method="bfill", inplace=True)
+        df[col] = df[col].bfill()
         local_logger.debug(f"'{col}' sütunu safe_ma ile eklendi.")
     except Exception as e:
         local_logger.error(f"'{col}' hesaplanırken hata: {e}", exc_info=False)

--- a/report_stats.py
+++ b/report_stats.py
@@ -3,6 +3,20 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from filtre_dogrulama import SEBEP_KODLARI
 import config
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message="The behavior of array concatenation with empty entries is deprecated",
+    category=FutureWarning,
+    module="report_stats",
+)
+warnings.filterwarnings(
+    "ignore",
+    message="Downcasting object dtype arrays on .fillna",
+    category=FutureWarning,
+    module="report_stats",
+)
 
 
 def build_ozet_df(summary_df: pd.DataFrame, detail_df: pd.DataFrame,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import warnings, pandas as pd, contextlib, io, pytest
+
+# pytest sırasında açık dosya uyarısını bastır
+warnings.filterwarnings(
+    "ignore",
+    message="Exception ignored in: <_io.FileIO",
+    category=pytest.PytestUnraisableExceptionWarning,
+)

--- a/tests/test_aciklama_filled.py
+++ b/tests/test_aciklama_filled.py
@@ -25,5 +25,6 @@ def test_aciklama_filled(tmp_path):
     }]
     path = tmp_path/"rapor.xlsx"
     generate_full_report(df_sum, df_det, errs, path, keep_legacy=True)
-    ozet = pd.read_excel(path,"Özet")
+    with pd.ExcelFile(path) as xls:
+        ozet = pd.read_excel(xls, "Özet")
     assert ozet.loc[ozet["filtre_kodu"]=="T2","sebep_aciklama"].iloc[0] == "demo hata metni"


### PR DESCRIPTION
## Summary
- add FutureWarning suppression to `report_stats`
- suppress chained assignment warnings in `indicator_calculator`
- modernize bfill usage
- prevent file handle warnings during pytest
- open Excel files via context manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f3e34a488325a59b21f390dff5b9