### PR TITLE
Fix CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # finansal-analiz-sistemi
-[![CI](https://github.com/<your-username>/finansal-analiz-sistemi/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-username>/finansal-analiz-sistemi/actions/workflows/ci.yml)
+[![CI](https://github.com/owner/finansal-analiz-sistemi/actions/workflows/ci.yml/badge.svg)](https://github.com/owner/finansal-analiz-sistemi/actions/workflows/ci.yml)
 ChatGPT ile geliştirilen backtest otomasyon projesi
 
 ## Geliştirme Ortamı Kurulumu


### PR DESCRIPTION
## Summary
- replace `<your-username>` placeholder with a generic `owner` in README
- keep CI badge link and image pointing to the same repo

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f76cefb48325a3efc28b0c746e3b