### PR TITLE
Add Excel/Parquet support for filter loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `max_filter_depth` setting (default 7) for filter recursion control.
 - Auto-generated columns like `volume_tl` during preprocessing.
 - Failure tracker entries now capture `reason` and `hint`.
+- 2025-06-22  Added Excel / Parquet support to filter loader (LOADER-02)
 
 ## [0.9.2] – 2025-06-22
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ python main.py --tarama 2025-03-07 --satis 2025-03-10
 
 * `--tarama` ve `--satis` tarihleri `yyyy-mm-dd` formatındadır.
 * `--gui` verildiğinde sonuçlar basit bir Streamlit arayüzünde görüntülenir.
+* Filtre dosyaları CSV (`;` ayracıyla), Excel (.xlsx/.xls - ilk sayfa) veya Parquet (.parquet) formatında olabilir.
 
 
 ## Otomatik Sağlık Raporu

--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -39,9 +39,9 @@ def dogrula_filtre_dataframe(
         if not kod or kod.strip() == "":
             sorunlu[kod] = "Boş veya eksik flag (kod) değeri."
         elif not re.match(r"^[A-Z0-9_\-]+$", kod):
-            sorunlu[
-                kod
-            ] = "Geçersiz karakterler içeren flag. Sadece A-Z, 0-9, _ ve - izinli."
+            sorunlu[kod] = (
+                "Geçersiz karakterler içeren flag. Sadece A-Z, 0-9, _ ve - izinli."
+            )
 
         if "query" not in row or not query:
             sorunlu[kod] = sorunlu.get(kod, "") + " Query sütunu boş veya eksik."

--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -39,9 +39,9 @@ def dogrula_filtre_dataframe(
         if not kod or kod.strip() == "":
             sorunlu[kod] = "Boş veya eksik flag (kod) değeri."
         elif not re.match(r"^[A-Z0-9_\-]+$", kod):
-            sorunlu[kod] = (
-                "Geçersiz karakterler içeren flag. Sadece A-Z, 0-9, _ ve - izinli."
-            )
+            sorunlu[
+                kod
+            ] = "Geçersiz karakterler içeren flag. Sadece A-Z, 0-9, _ ve - izinli."
 
         if "query" not in row or not query:
             sorunlu[kod] = sorunlu.get(kod, "") + " Query sütunu boş veya eksik."

--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -1,0 +1,6 @@
+import runpy
+
+if __name__ == "__main__":
+    runpy.run_module("data_loader", run_name="__main__")
+else:
+    from data_loader import *  # noqa: F401,F403

--- a/tests/test_filter_loader_formats.py
+++ b/tests/test_filter_loader_formats.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import tempfile
+from pathlib import Path
+
+from finansal_analiz_sistemi.data_loader import yukle_filtre_dosyasi
+
+
+def test_filter_loader_formats():
+    df = pd.DataFrame({"filtre_kodu": ["F1"], "notlar": [""]})
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "filter.xlsx"
+        df.to_excel(p, index=False)
+        assert yukle_filtre_dosyasi(p).equals(df)
+        q = Path(td) / "filter.parquet"
+        df.to_parquet(q)
+        assert yukle_filtre_dosyasi(q).equals(df)


### PR DESCRIPTION
## Summary
- support Excel and Parquet in `yukle_filtre_dosyasi`
- mention accepted filter formats in README
- log change in CHANGELOG
- expose `data_loader` under package for tests
- add regression test for loader formats

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pip install pytest-cov pyarrow`
- `pytest -q --cov=. --cov-report=xml`
- `black --check .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_68568b9a92488325a025410e87d12dc7