### PR TITLE
Add big_df fixture & recursion depth test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- TEST-04-A: big_df fixture & depth guard.
 - Added `max_filter_depth` setting (default 7) for filter recursion control.
 - Auto-generated columns like `volume_tl` during preprocessing.
 - Failure tracker entries now capture `reason` and `hint`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import pytest
 
 from utils.pandas_option_safe import ensure_option
@@ -19,3 +20,19 @@ def sample_filtreler():
 @pytest.fixture
 def sample_indikator_df():
     return pd.DataFrame({"close": [10, 11], "relative_volume": [1.2, 1.3]})
+
+
+@pytest.fixture
+def big_df():
+    """Large DataFrame fixture around 100 MB in memory."""
+    n = 90_000
+    return pd.DataFrame(
+        {
+            "tarih": pd.date_range("2025-01-01", periods=n, freq="B"),
+            "close": np.random.rand(n) * 100,
+            "open": np.random.rand(n) * 100,
+            "high": np.random.rand(n) * 100,
+            "low": np.random.rand(n) * 100,
+            "volume": np.random.randint(1_000_000, 10_000_000, n),
+        }
+    )

--- a/tests/test_max_depth.py
+++ b/tests/test_max_depth.py
@@ -1,0 +1,20 @@
+import pytest
+import pandas as pd
+import settings
+import filter_engine as fe
+
+
+def _nested(depth: int):
+    expr = "x>0"
+    for i in range(depth, 0, -1):
+        expr = {"code": f"F{i}", "sub_expr": expr}
+    return expr
+
+
+def test_max_depth_guard(monkeypatch):
+    df = pd.DataFrame({"x": [1]})
+    monkeypatch.setattr(settings, "MAX_FILTER_DEPTH", 5)
+    with pytest.raises(fe.QueryError):
+        fe.safe_eval(_nested(6), df)
+    monkeypatch.setattr(settings, "MAX_FILTER_DEPTH", 7)
+    fe.safe_eval(_nested(6), df)


### PR DESCRIPTION
## Summary
- add new `big_df` fixture in tests
- test max recursion depth enforcement
- document change in `CHANGELOG`

## Testing
- `flake8 tests/conftest.py tests/test_max_depth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a9b1f778832586f9c62f59c46f98