### PR TITLE
Add helper-column and loader format regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Failure tracker entries now capture `reason` and `hint`.
 - 2025-06-22  Added Excel / Parquet support to filter loader (LOADER-02)
 - 2025-06-22  Added Rich color logs for Colab (LOG-03)
-- TEST-04-B: helper & loader tests.
 - TEST-04-C: memory & rich-logging tests; CI updates.
+- TEST-04-B: helper & loader tests.
 
 ## [0.9.2] – 2025-06-22
 ### Fixed

--- a/tests/test_helper_columns.py
+++ b/tests/test_helper_columns.py
@@ -1,6 +1,10 @@
 import preprocessor
+import pandas as pd
 
 
 def test_auto_columns_generated(big_df):
-    out = preprocessor.on_isle_hisse_verileri(big_df)
-    assert "volume_tl" in out.columns
+    slim = big_df.head(1000).copy()
+    slim["psar_long"] = slim["high"]
+    slim["psar_short"] = slim["low"]
+    out = preprocessor.on_isle_hisse_verileri(slim)
+    assert {"volume_tl", "psar"}.issubset(out.columns)

--- a/tests/test_helper_columns.py
+++ b/tests/test_helper_columns.py
@@ -1,5 +1,4 @@
 import preprocessor
-import pandas as pd
 
 
 def test_auto_columns_generated(big_df):

--- a/tests/test_loader_formats.py
+++ b/tests/test_loader_formats.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from finansal_analiz_sistemi.data_loader import yukle_filtre_dosyasi
 
+# regression test for new loader formats
+
 
 def test_excel_and_parquet(tmp_path):
     df = pd.DataFrame({"filtre_kodu": ["F1"], "notlar": [""]})


### PR DESCRIPTION
## Summary
- add coverage for helper column generation
- add regression note for loader format tests
- document TEST-04-B in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c6e9349c8325b7cbe9646538c549