### PR TITLE
Add regression memory test + ci slow skip

### DIFF
--- a/tests/test_report_memory.py
+++ b/tests/test_report_memory.py
@@ -16,6 +16,9 @@ def test_generate_full_report_memory(tmp_path, big_df):
             "filtre_kodu": ["F1"],
             "tarih": [pd.Timestamp.now()],
             "sebep_kodu": ["OK"],
+            "ort_getiri_%": [0.0],
+            "getiri_%": [0.0],
+            "basari": ["OK"],
         }
     )
 


### PR DESCRIPTION
## Summary
- simplify memory regression test
- (other changes already present in repo: docs with coverage badge, CI skip slow tests by default)

## Testing
- `flake8 tests/test_report_memory.py tests/test_rich_logging.py`
- `black tests/test_report_memory.py tests/test_rich_logging.py --line-length 88`
- `pytest -q tests/test_rich_logging.py -m "not slow" --cov . --cov-report=term-missing`
- `pre-commit run --files tests/test_report_memory.py tests/test_rich_logging.py README.md CHANGELOG.md .github/workflows/ci.yml` *(fails: pyarrow missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856cecc98a483258a00abafb34562cd