### PR TITLE
Fix wildcard import

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,6 @@
 max-line-length = 250
 extend-ignore = E203,W503
 per-file-ignores =
-    finansal_analiz_sistemi/main.py:F401,F403
+    finansal_analiz_sistemi/main.py:F401
     tests/test_report_exists.py:F401
     tests/test_smoke_report.py:F401,E401

--- a/finansal_analiz_sistemi/main.py
+++ b/finansal_analiz_sistemi/main.py
@@ -3,4 +3,13 @@ import runpy
 if __name__ == "__main__":
     runpy.run_module("run", run_name="__main__")
 else:
-    from run import *  # noqa: F401,F403
+    from run import (
+        veri_yukle,
+        on_isle,
+        indikator_hesapla,
+        filtre_uygula,
+        backtest_yap,
+        raporla,
+        calistir_tum_sistemi,
+        run_pipeline,
+    )  # noqa: F401


### PR DESCRIPTION
## Summary
- stop using `from run import *` in package entrypoint
- adjust flake8 ignore rules for main module

## Testing
- `pytest -q -m "not slow" --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68573fe905348325ad24d56bb497f9c8