### PR TITLE
Use dotenv for API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 *.log
 raporlar/
 cikti/
+.env
 

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ import os
 import logging
 import numpy as np
 import yaml
+from dotenv import load_dotenv
 
 # pandas_ta bazı ortamlarda numpy.NaN sabitini kullanarak yükleniyor.
 # NumPy 2.x sürümlerinde bu sabit olmadığı için import hatası
@@ -19,6 +20,7 @@ if not hasattr(np, "NaN"):
 
 import pandas_ta as ta
 import sys
+load_dotenv()
 
 # Temel Dizinler
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -29,6 +31,7 @@ FILTRE_DOSYA_YOLU = os.path.join(VERI_KLASORU, "15.csv")
 PARQUET_ANA_DOSYA_YOLU = os.path.join(VERI_KLASORU, "birlesik_hisse_verileri.parquet")
 LOG_DOSYA_YOLU = os.path.join(BASE_DIR, "finansal_analiz_sistemi.log")
 CSV_OZET_DOSYA_ADI = "backtest_ozet_raporu.csv"
+API_KEY = os.getenv("API_KEY")
 
 _cfg_path = os.path.join(os.path.dirname(__file__), "config.yml")
 if os.path.exists(_cfg_path):

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ if not hasattr(np, "NaN"):
 
 import pandas_ta as ta
 import sys
+
 load_dotenv()
 
 # Temel Dizinler

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ xlsxwriter>=3.1
 plotly>=5.20
 kaleido>=0.2.1
 rich>=13.7.1
+python-dotenv
 pytest>=7.4.0
 
 # (İLERİDE GitHub erişimi açılırsa, üstteki üç satırı sil


### PR DESCRIPTION
## Summary
- read API_KEY from `.env`
- ignore `.env` in git
- require python-dotenv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574c97a790832598b2d4944174d547