### PR TITLE
fix: silence SettingWithCopyWarning (phase-1)

### DIFF
--- a/report_stats.py
+++ b/report_stats.py
@@ -38,6 +38,7 @@ def normalize_pct(series):
 
 def _normalize_pct(s: pd.Series) -> pd.Series:
     """Convert whole-number percentages to fractional scale (÷100 once)."""
+    s = s.copy()
     mask = s.abs() > 1.5
     s.loc[mask] = s.loc[mask] / 100
     return s.round(2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from utils.pandas_option_safe import ensure_option
 
 ensure_option("future.no_silent_downcasting", True)
+pd.options.mode.chained_assignment = "raise"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- raise errors on chained assignment during tests
- avoid SettingWithCopyWarning in `_normalize_pct`

## Testing
- `pre-commit run --files tests/conftest.py report_stats.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c3b2ed508325a27784286cbeafd8