### PR TITLE
Silence E501 in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E203,W503,E501
+extend-ignore = E203, W503, E501
 per-file-ignores =
     finansal_analiz_sistemi/main.py:F401
     tests/test_report_exists.py:F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,13 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-        args: ["--check"]
+        args: ["--check", "."]
+        pass_filenames: false
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:
       - id: flake8
-        args: ["--max-line-length=88"]
+        args: [--extend-ignore=E501]
   - repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
## Summary
- ignore E501 in flake8 config
- update pre-commit config to run Black globally and pass the ignore flag to Flake8

## Testing
- `black . && pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68581852f8ec832598dcdd64514231bb