### PR TITLE
Add auto stage hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,11 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: git-add-all
+        name: Auto-stage modified files
+        entry: git add -u
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add hook to auto-stage files in pre-commit config

## Testing
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: pandas)*
- `git push` *(fails: no configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68584ddafe508325ac46ff9d7857a44d