### PR TITLE
feat(cli): unify package entry point

### DIFF
--- a/finansal_analiz_sistemi/__main__.py
+++ b/finansal_analiz_sistemi/__main__.py
@@ -1,3 +1,5 @@
+"""`python -m finansal_analiz_sistemi` shortcut."""
 import runpy
 
-runpy.run_module("run", run_name="__main__")
+runpy.run_module("finansal_analiz_sistemi.main", run_name="__main__")
+

--- a/finansal_analiz_sistemi/main.py
+++ b/finansal_analiz_sistemi/main.py
@@ -1,15 +1,44 @@
-import runpy
+"""Paketin tek giriş noktası.
 
-if __name__ == "__main__":
-    runpy.run_module("run", run_name="__main__")
-else:
-    from run import (
-        veri_yukle,
-        on_isle,
-        indikator_hesapla,
-        filtre_uygula,
-        backtest_yap,
-        raporla,
-        calistir_tum_sistemi,
-        run_pipeline,
-    )  # noqa: F401
+`python -m finansal_analiz_sistemi --tarama …` veya
+`from finansal_analiz_sistemi import main; main.main(...)`
+ikisi de aynı davranışı gösterir.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from run import calistir_tum_sistemi
+
+
+def main(
+    tarama: str,
+    satis: str,
+    output: str = "rapor.xlsx",
+    log: str | None = None,
+) -> None:
+    """Tam rapor akışını çalıştır."""
+    out_path = Path(output).expanduser().resolve()
+    log_path = Path(log).expanduser().resolve() if log else None
+
+    calistir_tum_sistemi(
+        tarama_tarihi=tarama,
+        satis_tarihi=satis,
+        output_path=out_path,
+        log_path=log_path,
+    )
+    print(f"✅ Rapor yazıldı → {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    parser = argparse.ArgumentParser(
+        description="Finansal analiz tam rapor üreticisi"
+    )
+    parser.add_argument("--tarama", required=True, help="YYYY-MM-DD")
+    parser.add_argument("--satis", required=True, help="YYYY-MM-DD")
+    parser.add_argument("--output", default="rapor.xlsx")
+    parser.add_argument("--log", default=None)
+    args = parser.parse_args()
+    main(args.tarama, args.satis, args.output, args.log)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,10 @@ line-length = 88
 [tool.flake8]
 max-line-length = 88
 extend-ignore   = ["E203", "W503", "E501"]
+
+[project]
+name = "finansal-analiz-sistemi"
+version = "0.1.0"
+
+[project.scripts]
+finansal-analiz = "finansal_analiz_sistemi.main:main"


### PR DESCRIPTION
## Summary
- refactor main module with a single `main()` entry
- add `__main__.py` proxy so `python -m finansal_analiz_sistemi` works
- expose script via pyproject `project.scripts`

## Testing
- `pip install -e . --no-build-isolation --no-use-pep517`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6859355cbb6c83259f9b825b2af77976