### PR TITLE
Fix logging paths and report folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cikti/
 # Çıktılar
 raporlar/
 log/
+loglar/

--- a/report_generator.py
+++ b/report_generator.py
@@ -81,15 +81,15 @@ def add_error_sheet(writer, error_list: Iterable[tuple]):
 def olustur_ozet_rapor(
     sonuclar_listesi: list,
     cikti_klasoru: str,
-    logger=None,
+    logger_param=None,
 ) -> str | None:
-    if logger is None:
-        logger = logger
+    if logger_param is None:
+        logger_param = logger
     os.makedirs(cikti_klasoru, exist_ok=True)
     kayitlar = []
     for sonuc in sonuclar_listesi:
         if not isinstance(sonuc, dict):
-            logger.warning(
+            logger_param.warning(
                 "Beklenmeyen sonuç tipi: %s → %s",
                 type(sonuc),
                 sonuc,
@@ -97,7 +97,7 @@ def olustur_ozet_rapor(
             continue
         secilen = sonuc.get("hisseler", [])
         if not secilen:
-            logger.warning(
+            logger_param.warning(
                 "Filtre '%s' sonucu: Hiç hisse seçilmedi."
                 " Boş rapor satırı yazılacak.",
                 sonuc.get("filtre_kodu", "?"),
@@ -126,22 +126,22 @@ def olustur_ozet_rapor(
         f"ozet_rapor_{datetime.now():%Y%m%d_%H%M%S}.csv",
     )
     df.to_csv(dosya_adi, index=False, encoding="utf-8-sig")
-    logger.info("Özet rapor oluşturuldu: %s", dosya_adi)
+    logger_param.info("Özet rapor oluşturuldu: %s", dosya_adi)
     return dosya_adi
 
 
 def olustur_hisse_bazli_rapor(
     sonuclar_listesi: list,
     cikti_klasoru: str,
-    logger=None,
+    logger_param=None,
 ) -> str | None:
-    if logger is None:
-        logger = logger
+    if logger_param is None:
+        logger_param = logger
     os.makedirs(cikti_klasoru, exist_ok=True)
     detayli_kayitlar = []
     for sonuc in sonuclar_listesi:
         if not isinstance(sonuc, dict):
-            logger.warning("Geçersiz filtre sonucu tipi: %s", type(sonuc))
+            logger_param.warning("Geçersiz filtre sonucu tipi: %s", type(sonuc))
             continue
         filtre_kodu = sonuc.get("filtre_kodu", "")
         notlar = sonuc.get("notlar", "")
@@ -176,7 +176,7 @@ def olustur_hisse_bazli_rapor(
         f"hisse_bazli_rapor_{datetime.now():%Y%m%d_%H%M%S}.csv",
     )
     df.to_csv(dosya_adi, index=False, encoding="utf-8-sig")
-    logger.info("Hisse bazlı detaylı rapor oluşturuldu: %s", dosya_adi)
+    logger_param.info("Hisse bazlı detaylı rapor oluşturuldu: %s", dosya_adi)
     return dosya_adi
 
 

--- a/run.py
+++ b/run.py
@@ -5,19 +5,21 @@
 # Tuğrul Karaaslan & Gemini
 # Tarih: 18 Mayıs 2025 (Erken hata durdurma mantığı eklendi, loglama iyileştirildi)
 
-from utils.logging_setup import setup_logger
-from logging_config import get_logger
-import pandas as pd
-import sys
-import os
-import logging
-from pathlib import Path
 import argparse
+import logging
+import os
+import sys
 import traceback
+from pathlib import Path
+
+import pandas as pd
 import yaml
+
 import config
 import utils
+from logging_config import get_logger
 from utils.date_utils import parse_date
+from utils.logging_setup import setup_logger
 
 
 def _parse_date(dt_str: str) -> pd.Timestamp:
@@ -157,7 +159,7 @@ def raporla(rapor_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
         logger.info("Rapor verisi boş.")
         return
     ozet, detay, istat = _hazirla_rapor_alt_df(rapor_df)
-    out_path = Path("cikti/raporlar") / f"rapor_{pd.Timestamp.now():%Y%m%d_%H%M%S}.xlsx"
+    out_path = Path("raporlar") / f"rapor_{pd.Timestamp.now():%Y%m%d_%H%M%S}.xlsx"
     out_path.parent.mkdir(exist_ok=True)
     from utils.memory_profile import mem_profile
 
@@ -168,12 +170,12 @@ def raporla(rapor_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
 
 # Ana modülleri import et
 try:
-    from finansal_analiz_sistemi import data_loader
-    import preprocessor
-    import indicator_calculator
-    import filter_engine
     import backtest_core
+    import filter_engine
+    import indicator_calculator
+    import preprocessor
     import report_generator
+    from finansal_analiz_sistemi import data_loader
 
     logger.info("Tüm ana modüller başarıyla import edildi.")
 except ImportError as e_import_main:
@@ -204,6 +206,7 @@ def calistir_tum_sistemi(
         yeniden yükle.
     """
     import gc
+
     import filter_engine
     import utils.failure_tracker as ft
 
@@ -365,4 +368,4 @@ if __name__ == "__main__":
             ) as wr:
                 add_error_sheet(wr, log_counter.error_list)
         logging.shutdown()
-        utils.purge_old_logs("raporlar", days=7)
+        utils.purge_old_logs("loglar", days=7)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -5,10 +5,12 @@
 # Tuğrul Karaaslan & Gemini
 # Tarih: 18 Mayıs 2025 (Yorumlar eklendi, NaN yönetimi teyit edildi)
 
-import pandas as pd
-from logging_config import get_logger
 from functools import lru_cache
 from io import StringIO
+
+import pandas as pd
+
+from logging_config import get_logger
 
 logger = get_logger(__name__)
 
@@ -97,13 +99,13 @@ def extract_columns_from_filters_cached(
     return extract_columns_from_filters(df_filters, series_series, series_value)
 
 
-def purge_old_logs(dir_path: str = "raporlar", days: int = 7) -> None:
+def purge_old_logs(dir_path: str = "loglar", days: int = 7) -> None:
     """Delete ``.log`` files older than ``days`` in ``dir_path``.
 
     Parameters
     ----------
     dir_path : str, optional
-        Directory containing log files. Default is ``"raporlar"``.
+        Directory containing log files. Default is ``"loglar"``.
     days : int, optional
         Files older than this number of days will be removed. Default is ``7``.
     """

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -1,6 +1,6 @@
 import logging
-import sys
 import os
+import sys
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
@@ -53,7 +53,7 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
     if root.handlers:
         return _counter_filter
 
-    log_dir = os.path.join("cikti", "logs")
+    log_dir = os.path.join("loglar")
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, f"app_{datetime.now():%Y%m%d_%H%M%S}.log")
 


### PR DESCRIPTION
## Summary
- save default Excel reports in `raporlar/`
- keep logs in `loglar/` and purge them correctly
- fix logger parameter handling in `report_generator`
- ignore new `loglar/` folder

## Testing
- `pre-commit run --files run.py utils/__init__.py utils/logging_setup.py report_generator.py .gitignore`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aea6aab083258e003807c19adaf9