### PR TITLE
Implement centralized reason mapping for filter failures

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -122,9 +122,11 @@ def safe_eval(expr, df, depth: int = 0, visited=None):
             FAILED_FILTERS.append({"filtre_kodu": expr.get("code"), "hata": str(e)})
             logger.warning("QUERY_ERROR %s", e)
             try:
+                from utils.error_map import get_reason_hint
                 from utils.failure_tracker import log_failure
 
-                log_failure("filters", expr.get("code", "unknown"), str(e))
+                reason, hint = get_reason_hint(e)
+                log_failure("filters", expr.get("code", "unknown"), reason, hint)
             except Exception:
                 pass
             raise
@@ -193,9 +195,11 @@ def _apply_single_filter(df, kod, query):
     except Exception as e:
         info.update(durum="HATA", sebep=str(e)[:120])
         try:
+            from utils.error_map import get_reason_hint
             from utils.failure_tracker import log_failure
 
-            log_failure("filters", kod, str(e))
+            reason, hint = get_reason_hint(e)
+            log_failure("filters", kod, reason, hint)
         except Exception:
             pass
         return None, info
@@ -230,9 +234,11 @@ def run_single_filter(kod: str, query: str) -> dict:
         )
         logger.warning(f"QUERY_ERROR: {kod} – {msg}")
         try:
+            from utils.error_map import get_reason_hint
             from utils.failure_tracker import log_failure
 
-            log_failure("filters", kod, msg)
+            reason, hint = get_reason_hint(qe)
+            log_failure("filters", kod, reason, hint)
         except Exception:
             pass
     except MissingColumnError as me:
@@ -248,9 +254,11 @@ def run_single_filter(kod: str, query: str) -> dict:
         )
         logger.warning(f"GENERIC: {kod} – {msg}")
         try:
+            from utils.error_map import get_reason_hint
             from utils.failure_tracker import log_failure
 
-            log_failure("filters", kod, msg)
+            reason, hint = get_reason_hint(me)
+            log_failure("filters", kod, reason, hint)
         except Exception:
             pass
     return atlanmis
@@ -431,9 +439,11 @@ def uygula_filtreler(
             )
             fn_logger.warning(f"QUERY_ERROR: {filtre_kodu} – {msg}")
             try:
+                from utils.error_map import get_reason_hint
                 from utils.failure_tracker import log_failure
 
-                log_failure("filters", filtre_kodu, msg)
+                reason, hint = get_reason_hint(qe)
+                log_failure("filters", filtre_kodu, reason, hint)
             except Exception:
                 pass
             continue
@@ -450,9 +460,11 @@ def uygula_filtreler(
             )
             fn_logger.warning(f"GENERIC: {filtre_kodu} – {msg}")
             try:
+                from utils.error_map import get_reason_hint
                 from utils.failure_tracker import log_failure
 
-                log_failure("filters", filtre_kodu, msg)
+                reason, hint = get_reason_hint(me)
+                log_failure("filters", filtre_kodu, reason, hint)
             except Exception:
                 pass
             continue

--- a/tests/test_failed_reason_hint.py
+++ b/tests/test_failed_reason_hint.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+import filter_engine
+from report_generator import (
+    LEGACY_DETAIL_COLS,
+    LEGACY_SUMMARY_COLS,
+    generate_full_report,
+)
+from utils.failure_tracker import failures
+
+
+def _generate_failure():
+    df = pd.DataFrame({"x": [1]})
+    filter_engine._apply_single_filter(df, "T0", "0/0")
+
+
+def _build_report(tmp_path):
+    out = tmp_path / "fail.xlsx"
+    summary = pd.DataFrame(columns=LEGACY_SUMMARY_COLS)
+    detail = pd.DataFrame(columns=LEGACY_DETAIL_COLS)
+    generate_full_report(summary, detail, [], out)
+    return pd.read_excel(out, "filters_failed")
+
+
+def test_reason_hint_filled(tmp_path):
+    failures.clear()
+    _generate_failure()
+    df = _build_report(tmp_path)
+    assert df[["reason", "hint"]].notna().all(axis=None)

--- a/utils/error_map.py
+++ b/utils/error_map.py
@@ -1,0 +1,20 @@
+from typing import Dict, Tuple
+
+REASON_MAP: Dict[str, Tuple[str, str]] = {
+    "ZeroDivisionError": (
+        "S\u0131f\u0131ra B\u00f6lme",
+        "B\u00f6l\u00fcnen de\u011feri s\u0131f\u0131rdan farkl\u0131 yap",
+    ),
+    "KeyError": (
+        "Veri Alan\u0131 Yok",
+        "hisse_kodu / tarih s\u00fctunu eksik olabilir",
+    ),
+}
+
+DEFAULT_REASON: Tuple[str, str] = ("Bilinmeyen Hata", "Detay i\u00e7in loglara bak")
+
+
+def get_reason_hint(exc: Exception, locale: str = "tr") -> Tuple[str, str]:
+    """Return a user friendly reason/hint tuple for given exception."""
+
+    return REASON_MAP.get(type(exc).__name__, DEFAULT_REASON)


### PR DESCRIPTION
## Summary
- map common exceptions to Turkish reason/hint pairs
- log mapped reasons in `filter_engine`
- ensure filters_failed sheet has filled reason/hint columns
- add test for reason/hint population

## Testing
- `black .`
- `isort filter_engine.py utils/error_map.py tests/test_failed_reason_hint.py`
- `flake8`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685ad6e54b048325878f71c4dbef1a08