### PR TITLE
Implement safe log purge with dry-run option

### DIFF
--- a/tests/test_purge_old_logs.py
+++ b/tests/test_purge_old_logs.py
@@ -1,0 +1,15 @@
+from utils.purge_old_logs import purge_old_logs
+
+
+def test_purge_dry_run(tmp_path):
+    old = tmp_path / "old.log"
+    old.write_text("")
+    old.touch()
+    new = tmp_path / "new.log"
+    new.write_text("")
+    import os
+    import time
+
+    os.utime(old, (time.time() - 864000,) * 2)  # 10 gün
+    deleted = purge_old_logs(log_dir=tmp_path, keep_days=7, dry_run=True)
+    assert deleted == 1 and old.exists() and new.exists()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@
 
 from functools import lru_cache
 from io import StringIO
+from pathlib import Path
 
 import pandas as pd
 
@@ -99,17 +100,12 @@ def extract_columns_from_filters_cached(
     return extract_columns_from_filters(df_filters, series_series, series_value)
 
 
-def purge_old_logs(dir_path: str = "loglar", days: int = 7):
-    """Delete .log files older than days in the loglar/ directory.
-    Returns the number of deleted files."""
+def purge_old_logs(dir_path: str = "loglar", days: int = 7, dry_run: bool = False):
+    """Delete ``*.log`` files older than ``days`` in ``dir_path``.
 
-    import glob
-    import os
-    import time
+    Parameters match the legacy helper for backward compatibility.
+    """
 
-    deleted = 0
-    for fp in glob.glob(f"{dir_path}/*.log"):
-        if time.time() - os.path.getmtime(fp) > days * 24 * 3600:
-            os.remove(fp)
-            deleted += 1
-    return deleted
+    from .purge_old_logs import purge_old_logs as _impl
+
+    return _impl(log_dir=Path(dir_path), keep_days=days, dry_run=dry_run)

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def purge_old_logs(
+    *, log_dir: Path = Path("loglar"), keep_days: int = 7, dry_run: bool = False
+) -> int:
+    """Purge ``*.log`` files older than ``keep_days`` days in ``log_dir``.
+
+    Returns the number of files considered for deletion.
+    """
+    cutoff = datetime.now() - timedelta(days=keep_days)
+    deleted = 0
+    for f in log_dir.glob("*.log"):
+        if datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
+            if dry_run:
+                print(f"[DRY-RUN] Would delete {f}")
+            else:
+                f.unlink()
+            deleted += 1
+    return deleted
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Purge old log files.")
+    ap.add_argument("--days", type=int, default=7, help="Silinecek log yaşı (gün)")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dosyaları gerçekten silme, sadece listele",
+    )
+    args = ap.parse_args()
+    n = purge_old_logs(keep_days=args.days, dry_run=args.dry_run)
+    print(f"{n} file(s) processed.")


### PR DESCRIPTION
## Summary
- add a dedicated `utils/purge_old_logs.py` script
- route old helper through new script in `utils/__init__`
- provide test for dry-run behavior

## Testing
- `flake8`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685ae58403188325ab80c48ed37d4dcd