### PR TITLE
Fix formatting for tests

### DIFF
--- a/tests/test_backtest_core_param.py
+++ b/tests/test_backtest_core_param.py
@@ -10,10 +10,14 @@ except Exception:
 DF = pd.DataFrame(
     {
         "hisse_kodu": ["AAA", "AAA"],
-        "tarih": [pd.to_datetime("09.03.2025", dayfirst=True), pd.to_datetime("11.03.2025", dayfirst=True)],
+        "tarih": [
+            pd.to_datetime("09.03.2025", dayfirst=True),
+            pd.to_datetime("11.03.2025", dayfirst=True),
+        ],
         "close": [10.0, 11.0],
     }
 )
+
 
 @pytest.mark.parametrize(
     "tarih,col,expected",

--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -1,10 +1,12 @@
+from pathlib import Path
+
 import pandas as pd
 import pytest
-from pathlib import Path
 
 from finansal_analiz_sistemi import data_loader
 
 CSV_CONTENT = "col\n1\n2\n3"
+
 
 @pytest.mark.parametrize("content,expected_rows", [(CSV_CONTENT, 3), ("col\n42", 1)])
 def test_load_data_param(tmp_path: Path, content: str, expected_rows: int):
@@ -21,6 +23,7 @@ def test_load_data_empty(tmp_path: Path):
     with pytest.raises(Exception):
         data_loader.load_data(str(p))
 
+
 @pytest.mark.parametrize("colname", ["Date", "Tarih", "tarih", "TARİH", "Unnamed: 0"])
 def test_standardize_date_column(colname):
     df = pd.DataFrame({colname: ["2025-03-07"]})
@@ -36,13 +39,15 @@ def test_standardize_date_column_no_match():
 
 
 def test_standardize_ohlcv_columns():
-    df = pd.DataFrame({
-        "Açılış": [1],
-        "Yüksek": [2],
-        "Düşük": [0],
-        "Kapanış": [1],
-        "Miktar": [10],
-    })
+    df = pd.DataFrame(
+        {
+            "Açılış": [1],
+            "Yüksek": [2],
+            "Düşük": [0],
+            "Kapanış": [1],
+            "Miktar": [10],
+        }
+    )
     out = data_loader._standardize_ohlcv_columns(df, "dummy")
     assert set(["open", "high", "low", "close", "volume"]).issubset(out.columns)
 

--- a/tests/test_standardize_ohlcv_columns.py
+++ b/tests/test_standardize_ohlcv_columns.py
@@ -3,6 +3,7 @@ import pytest
 
 from finansal_analiz_sistemi.data_loader import data_loader_standardize_ohlcv_columns
 
+
 @pytest.mark.parametrize(
     "raw_columns, expected_columns",
     [


### PR DESCRIPTION
## Summary
- apply Black and isort formatting across test suite

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `git push` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_685b07bc07048325923545edede454a4