### PR TITLE
Add log rotation to prevent run.log bloat

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,6 +1,6 @@
 import logging
-from logging.handlers import RotatingFileHandler
 import os
+from logging.handlers import RotatingFileHandler
 
 # ——— Config ———
 LOG_DIR = os.getenv("LOG_DIR", "loglar")
@@ -9,8 +9,8 @@ os.makedirs(LOG_DIR, exist_ok=True)
 # Boyut bazlı rotasyon — 2 MB, 3 yedek
 handler = RotatingFileHandler(
     f"{LOG_DIR}/run.log",
-    maxBytes=2_000_000,   # 2 MB
-    backupCount=3,        # run.log, .1, .2, .3
+    maxBytes=2_000_000,  # 2 MB
+    backupCount=3,  # run.log, .1, .2, .3
     encoding="utf-8",
 )
 handler.setFormatter(

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,0 +1,22 @@
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+
+# ——— Config ———
+LOG_DIR = os.getenv("LOG_DIR", "loglar")
+os.makedirs(LOG_DIR, exist_ok=True)
+
+# Boyut bazlı rotasyon — 2 MB, 3 yedek
+handler = RotatingFileHandler(
+    f"{LOG_DIR}/run.log",
+    maxBytes=2_000_000,   # 2 MB
+    backupCount=3,        # run.log, .1, .2, .3
+    encoding="utf-8",
+)
+handler.setFormatter(
+    logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s")
+)
+
+root = logging.getLogger()
+root.setLevel(logging.INFO)
+root.addHandler(handler)


### PR DESCRIPTION
## Summary
- add `src/logging_config.py` to set up rotating logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2742efbc8325ada9edec640c3ded