### PR TITLE
Fix filter CSV header misalignment

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -1,16 +1,19 @@
 import glob
+
+# Stdlib / 3rd-party importlar en üstte olmalı
 import os
 from functools import lru_cache, partial
 from pathlib import Path
 
 import pandas as pd
 
-COLS = ["tarih", "filter_kodu", "python_query"]
-
 import config
 from data_loader_cache import DataLoaderCache
 from logging_config import get_logger
 from utils.compat import safe_concat
+
+# Sabitler
+COLS = ["tarih", "filter_kodu", "python_query"]
 
 # data_loader.py
 # -*- coding: utf-8 -*-

--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pandas as pd
 
+COLS = ["tarih", "filter_kodu", "python_query"]
+
 import config
 from data_loader_cache import DataLoaderCache
 from logging_config import get_logger
@@ -34,6 +36,24 @@ def _read_excel_cached(path: str) -> pd.DataFrame:
 def load_data(path: str) -> pd.DataFrame:
     """Read a CSV file using an in-memory cache."""
     df = pd.read_csv(path)
+    return df
+
+
+def load_filter_csv(path: str) -> pd.DataFrame:
+    """CSV'yi okunur ve kolon hizasını garanti eder."""
+
+    df = pd.read_csv(
+        path,
+        names=COLS,  # beklenen kolon listesi
+        header=None,  # dosya başlıksız
+        skiprows=1,  # ilk dummy satırı atla
+        sep=";",
+    )
+
+    # Güvenlik: kolonlar beklenenden farklıysa CI kırmızı olsun
+    if list(df.columns) != COLS:
+        raise ValueError(f"Beklenen kolonlar {COLS}, gelen: {df.columns}")
+
     return df
 
 

--- a/tests/test_header_alignment.py
+++ b/tests/test_header_alignment.py
@@ -1,0 +1,9 @@
+from finansal_analiz_sistemi.data_loader import load_filter_csv
+
+
+def test_header_alignment(tmp_path):
+    tmp = tmp_path / "15.csv"
+    tmp.write_text("dummy\n2025-01-01;MACD;close>vwap\n")
+
+    df = load_filter_csv(tmp)
+    assert list(df.columns) == ["tarih", "filter_kodu", "python_query"]


### PR DESCRIPTION
## Summary
- ensure filter CSV columns are parsed correctly
- test that filter CSV loads with proper headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2ed1048c83259582401a27518ea3