### PR TITLE
Drop Python 3.9 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- adjust CI workflow to only test Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c396e31348325a34c777ca51bf072