### PR TITLE
Add log cleanup util with dry-run filter

### DIFF
--- a/tests/test_log_clean.py
+++ b/tests/test_log_clean.py
@@ -1,0 +1,23 @@
+import os, time, pytest
+from pathlib import Path
+
+from utils.log_cleaner import purge_old_logs
+
+
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_purge_old_logs(tmp_path: Path, dry_run: bool):
+    old = tmp_path / "old.log"
+    new = tmp_path / "new.log"
+
+    old.write_text("x")
+    new.write_text("y")
+
+    # 10 gün geriye çek
+    old_time = time.time() - 10 * 86400
+    os.utime(old, (old_time, old_time))
+
+    removed = purge_old_logs(tmp_path, days=7, dry_run=dry_run)
+
+    assert removed == (0 if dry_run else 1)
+    assert new.exists()
+    assert old.exists() is dry_run

--- a/tests/test_log_clean.py
+++ b/tests/test_log_clean.py
@@ -1,5 +1,8 @@
-import os, time, pytest
+import os
+import time
 from pathlib import Path
+
+import pytest
 
 from utils.log_cleaner import purge_old_logs
 

--- a/utils/log_cleaner.py
+++ b/utils/log_cleaner.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-import logging
 
 _LOG = logging.getLogger(__name__)
 

--- a/utils/log_cleaner.py
+++ b/utils/log_cleaner.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+import logging
+
+_LOG = logging.getLogger(__name__)
+
+
+def purge_old_logs(
+    dir_path: str | Path = "loglar",
+    days: int = 7,
+    *,
+    dry_run: bool = False,
+) -> int:
+    """Belirtilen klasördeki *.log dosyalarını yaş filtresiyle sil.
+
+    Args:
+        dir_path: Log dosyalarının bulunduğu klasör.
+        days: Kaç günden eski dosyalar silinsin.
+        dry_run: *True* ise sadece hangi dosyaların silineceğini INFO ile yazar.
+
+    Returns
+    -------
+    int
+        Silinen dosya sayısı (dry-run modunda her zaman *0*).
+    """
+
+    cutoff = datetime.now() - timedelta(days=days)
+    deleted = 0
+    for fp in Path(dir_path).glob("*.log"):
+        if datetime.fromtimestamp(fp.stat().st_mtime) < cutoff:
+            _LOG.info("%s %s", "Would delete" if dry_run else "Deleted", fp)
+            if not dry_run:
+                fp.unlink(missing_ok=True)
+                deleted += 1
+    return deleted


### PR DESCRIPTION
## Summary
- implement `purge_old_logs` in new `utils/log_cleaner.py`
- test log cleanup behaviour in dry-run and normal modes

## Testing
- `pytest tests/test_log_clean.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3e19282483259cce87a8602fc8bd