### PR TITLE
Add ExcelFile cache for faster Excel reads

### DIFF
--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -2,6 +2,7 @@
 import os
 
 import pandas as pd
+from src.utils.excel_reader import open_excel_cached
 from cachetools import TTLCache
 
 CACHE: TTLCache = TTLCache(maxsize=256, ttl=4 * 60 * 60)  # 4 saat LRU+TTL
@@ -32,7 +33,7 @@ class DataLoaderCache:
             return self.loaded_data[key]
 
         try:
-            xls = pd.ExcelFile(filepath, **kwargs)
+            xls = open_excel_cached(filepath, **kwargs)
             self.loaded_data[key] = xls
             if self.logger:
                 self.logger.info(f"ExcelFile yüklendi: {filepath}")

--- a/gui/app.py
+++ b/gui/app.py
@@ -1,12 +1,13 @@
 import pandas as pd
 import streamlit as st
+from src.utils.excel_reader import open_excel_cached
 
 st.title("Rapor Görüntüleyici")
 
 uploaded = st.file_uploader("Rapor Excel’i (.xlsx) seç", type="xlsx")
 if uploaded:
     with st.spinner("Yükleniyor..."):
-        xls = pd.ExcelFile(uploaded)
+        xls = open_excel_cached(uploaded)
         tab1, tab2 = st.tabs(["Özet", "Hatalar"])
         with tab1:
             df_ozet = pd.read_excel(xls, "Özet")

--- a/log_to_health.py
+++ b/log_to_health.py
@@ -10,6 +10,7 @@ from openpyxl.formatting.rule import CellIsRule
 from openpyxl.styles import Font, PatternFill
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows as _to_rows
+from src.utils.excel_reader import open_excel_cached
 
 from utils.compat import safe_concat
 
@@ -56,7 +57,7 @@ def generate(log_path: str | os.PathLike, excel_paths: list[str | os.PathLike]) 
         if not os.path.exists(p):
             continue
         try:
-            xl = pd.ExcelFile(p)
+            xl = open_excel_cached(p)
         except Exception:
             continue
         if "Özet" in xl.sheet_names:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the src package."""

--- a/src/utils/excel_reader.py
+++ b/src/utils/excel_reader.py
@@ -1,0 +1,35 @@
+"""Excel reading utilities with simple caching."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import pandas as pd
+
+# Global cache mapping absolute file paths to ``ExcelFile`` objects
+_excel_cache: Dict[str, pd.ExcelFile] = {}
+
+
+def open_excel_cached(path: str, **kwargs: Any) -> pd.ExcelFile:
+    """Return a cached ``ExcelFile`` object for the given path."""
+    abs_path = os.path.abspath(os.fspath(path))
+    if abs_path not in _excel_cache:
+        _excel_cache[abs_path] = pd.ExcelFile(abs_path, **kwargs)
+    return _excel_cache[abs_path]
+
+
+def read_excel_cached(path: str, sheet_name: str, **kwargs: Any) -> pd.DataFrame:
+    """Parse ``sheet_name`` from a cached Excel workbook."""
+    xls = open_excel_cached(path)
+    return xls.parse(sheet_name=sheet_name, **kwargs)
+
+
+def clear_cache() -> None:
+    """Clear the internal ExcelFile cache and close workbooks."""
+    for xls in _excel_cache.values():
+        try:
+            xls.close()
+        except Exception:
+            pass
+    _excel_cache.clear()


### PR DESCRIPTION
## Summary
- cache ExcelFile objects in new `src.utils.excel_reader`
- use the cached reader in `DataLoaderCache`, GUI, and health report generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c513c39788325b7739016226c3569