### PR TITLE
Fix filter loader skip logic

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -176,7 +176,7 @@ def _apply_single_filter(df, kod, query):
         seç = df.query(query)
         # --- 0 hisse skip mekaniği ---
         if len(seç) < MIN_STOCKS_PER_FILTER:
-            logger.info(
+            logger.debug(
                 "Filter %s skipped (len=%s < %s)",
                 kod,
                 len(seç),

--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -248,7 +248,13 @@ def yukle_filtre_dosyasi(filtre_dosya_yolu_cfg=None, logger_param=None) -> pd.Da
     else:
         from finansal_analiz_sistemi.utils.normalize import normalize_filtre_kodu
 
-        df = pd.read_csv(path, sep=";")
+        df = pd.read_csv(
+            path,
+            sep=";",
+            dtype="string",
+            keep_default_na=False,
+            na_filter=False,
+        )
         df = normalize_filtre_kodu(df)
 
         # Hâlâ eksikse, erken ve anlaşılır hata ver.
@@ -256,6 +262,12 @@ def yukle_filtre_dosyasi(filtre_dosya_yolu_cfg=None, logger_param=None) -> pd.Da
             raise ValueError(
                 f"{path.name}: 'filtre_kodu' sütunu bulunamadı; CSV başlıklarını kontrol et."
             )
+
+    if "filtre_kodu" in df.columns:
+        df = df[df["filtre_kodu"].astype(str).str.strip() != ""]
+    for col in ("min", "max"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
     log.info(f"Filtre dosyası '{path}' başarıyla yüklendi. {len(df)} filtre bulundu.")
     return df
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_files = test_parquet_cache.py test_dtypes_ok.py
+python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py
 markers =
     slow: marks tests as slow

--- a/tests/test_filter_none_skipped.py
+++ b/tests/test_filter_none_skipped.py
@@ -1,0 +1,23 @@
+import sys
+import types
+
+import pandas as pd
+
+
+def test_filter_none_skipped(tmp_path, monkeypatch):
+    import logging
+
+    dummy = types.SimpleNamespace(
+        get_logger=logging.getLogger,
+        setup_logging=lambda: logging.getLogger(),
+    )
+    sys.modules["logging_config"] = dummy
+
+    from finansal_analiz_sistemi.data_loader import yukle_filtre_dosyasi
+
+    df = pd.DataFrame({"filtre_kodu": ["F1", "", None], "min": ["1", "2", "3"]})
+    p = tmp_path / "f.csv"
+    df.to_csv(p, sep=";", index=False)
+    out = yukle_filtre_dosyasi(p)
+    assert list(out["filtre_kodu"]) == ["F1"]
+    assert out["min"].dtype.kind in "fi"


### PR DESCRIPTION
## Summary
- sanitize filter loader
- ensure numeric columns convert correctly
- lower filter skip logging to debug level
- test that blank filter codes are removed
- run tests

## Testing
- `pytest -q`
- `python -m finansal_analiz_sistemi.cli --dosya big.csv`


------
https://chatgpt.com/codex/tasks/task_e_685d4ed552a08325a070dc9e621104ed