### PR TITLE
Fix summary logging for None filters

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -264,7 +264,8 @@ def yukle_filtre_dosyasi(filtre_dosya_yolu_cfg=None, logger_param=None) -> pd.Da
             )
 
     if "filtre_kodu" in df.columns:
-        df = df[df["filtre_kodu"].astype(str).str.strip() != ""]
+        col = df["filtre_kodu"]
+        df = df[col.notna() & col.astype(str).str.strip().ne("")]
     for col in ("min", "max"):
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py
+python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py
 markers =
     slow: marks tests as slow

--- a/run.py
+++ b/run.py
@@ -365,9 +365,10 @@ if __name__ == "__main__":
         logger.info(
             f"======= {os.path.basename(__file__).upper()} ANA BACKTEST SCRIPT TAMAMLANDI ======="
         )
+        summary_keys = [str(k) for k in atlanmis.keys() if k]
         summary_line = (
             f"LOG_SUMMARY | errors={log_counter.errors} | warnings={log_counter.warnings} | "
-            f"atlanan_filtre={','.join(atlanmis.keys()) if atlanmis else ''}"
+            f"atlanan_filtre={','.join(summary_keys)}"
         )
         logger.info(summary_line)
         if log_counter.errors > 0 and "rapor_path" in locals():

--- a/tests/test_join_handles_none.py
+++ b/tests/test_join_handles_none.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_join_handles_none():
+    data = {"F1": "msg", None: "err"}
+    result = ",".join(str(k) for k in data.keys() if k)
+    assert result == "F1"


### PR DESCRIPTION
## Summary
- filter out blank or None filter codes when loading CSV
- avoid TypeError when logging skipped filters
- add regression test

## Testing
- `pytest -q`
- ⚠️ `python -m run` *(fails: No module named 'pandas_ta')*


------
https://chatgpt.com/codex/tasks/task_e_685d7a3e6f3c8325a7a0cd3b02e9c2d4