### PR TITLE
Fix empty report writes

### DIFF
--- a/finansal_analiz_sistemi/report_utils.py
+++ b/finansal_analiz_sistemi/report_utils.py
@@ -1,0 +1,38 @@
+import logging
+from pathlib import Path
+import pandas as pd
+from utils.compat import safe_to_excel
+
+logger = logging.getLogger(__name__)
+
+
+def save_df_safe(df: pd.DataFrame, file_path: str | Path, name: str, allow_empty: bool = False) -> Path:
+    """Safely write dataframe to Excel.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Data to write.
+    file_path : str or Path
+        Target Excel file.
+    name : str
+        Name used for logging / sheet label.
+    allow_empty : bool, optional
+        If ``True`` empty dataframes produce an ``EMPTY_REPORT`` sheet instead of
+        raising ``ValueError``.
+    """
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if df.empty:
+        if not allow_empty:
+            logger.error("DataFrame '%s' empty", name)
+            raise ValueError("empty dataframe")
+        with pd.ExcelWriter(path, engine="openpyxl") as wr:
+            safe_to_excel(pd.DataFrame({"EMPTY_REPORT": []}), wr, sheet_name="EMPTY_REPORT", index=False)
+        logger.warning("Placeholder EMPTY_REPORT written to %s", path)
+    else:
+        with pd.ExcelWriter(path, engine="openpyxl") as wr:
+            safe_to_excel(df, wr, sheet_name=name, index=False)
+        logger.info("Saved %s with %d rows → %s", name, len(df), path)
+    return path

--- a/report_generator.py
+++ b/report_generator.py
@@ -14,6 +14,7 @@ from openpyxl.utils import get_column_letter
 import report_stats
 from logging_config import get_logger
 from utils.compat import safe_concat, safe_to_excel
+from finansal_analiz_sistemi.report_utils import save_df_safe
 
 logger = get_logger(__name__)
 
@@ -262,7 +263,7 @@ def kaydet_uc_sekmeli_excel(
     )
     logging.getLogger().addHandler(fh)
 
-    logger_param.info("Saved report to %s", fname)
+    logger_param.info("Saved report to %s (%d rows)", fname, len(ozet_df))
     logger_param.info("Per-run log file: %s", run_log)
     return fname
 
@@ -504,6 +505,11 @@ def generate_full_report(
     summary_df = summary_df.dropna(subset=["filtre_kodu"])
     detail_df = detail_df.dropna(subset=["filtre_kodu"])
 
+    if summary_df.empty:
+        save_df_safe(pd.DataFrame(), out_path, "EMPTY_REPORT", allow_empty=True)
+        logger_param.error("Summary dataframe empty")
+        raise ValueError("summary dataframe empty")
+
     # ----- ➤ sebep_aciklama'ları doldur (Hatalar sheet'inden) -----
     if error_list:
         from dataclasses import asdict, is_dataclass
@@ -657,7 +663,7 @@ def generate_full_report(
     )
     logging.getLogger().addHandler(fh)
 
-    logger_param.info("Rapor kaydedildi → %s", out_path)
+    logger_param.info("Rapor kaydedildi → %s (rows=%d)", out_path, len(summary_df))
     logger_param.info("Per-run log file: %s", run_log)
     return out_path
 

--- a/report_utils.py
+++ b/report_utils.py
@@ -2,6 +2,7 @@
 import pandas as pd
 from openpyxl.chart import BarChart, Reference
 from openpyxl.utils import get_column_letter
+from finansal_analiz_sistemi.report_utils import save_df_safe
 
 import report_stats
 

--- a/tests/test_report_utils.py
+++ b/tests/test_report_utils.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pandas as pd
+import pytest
 
 import report_utils
 
@@ -44,3 +45,17 @@ def test_build_stats_df_default_columns():
     ozet = report_utils.build_ozet_df(summary, detail)
     stats = report_utils.build_stats_df(ozet)
     assert list(stats.columns) == report_utils.DEFAULT_STATS_COLS
+
+
+def test_save_df_safe_raises(tmp_path):
+    path = tmp_path / "r.xlsx"
+    with pytest.raises(ValueError):
+        report_utils.save_df_safe(pd.DataFrame(), path, "Test")
+
+
+def test_save_df_safe_writes(tmp_path):
+    path = tmp_path / "r.xlsx"
+    df = pd.DataFrame({"a": [1]})
+    report_utils.save_df_safe(df, path, "Test")
+    assert path.exists() and path.stat().st_size > 0
+


### PR DESCRIPTION
## Summary
- add helper to safely write DataFrames
- guard against empty summaries when generating reports
- include row counts in info logs
- test new helper behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d86d696788325a51d6fe5c9c9f6af