### PR TITLE
Improve empty data handling

### DIFF
--- a/tests/test_empty_summary_warns.py
+++ b/tests/test_empty_summary_warns.py
@@ -1,0 +1,30 @@
+import logging
+
+import openpyxl
+import pandas as pd
+
+import report_generator
+from utils.compat import safe_to_excel
+
+
+def test_generate_summary_warns_on_empty(caplog):
+    with caplog.at_level(logging.WARNING):
+        df = report_generator.generate_summary([])
+    assert df.empty
+    assert "sonuç listesi boş" in caplog.text
+    assert (
+        list(df.columns)[: len(report_generator.EXPECTED_COLUMNS)]
+        == report_generator.EXPECTED_COLUMNS
+    )
+
+
+def test_safe_to_excel_warns(tmp_path, caplog):
+    file = tmp_path / "empty.xlsx"
+    with caplog.at_level(logging.WARNING):
+        with pd.ExcelWriter(file) as wr:
+            safe_to_excel(pd.DataFrame(), wr, sheet_name="Test", index=False)
+    assert file.exists()
+    assert "boş" in caplog.text
+    wb = openpyxl.load_workbook(file)
+    assert "Test" in wb.sheetnames
+    wb.close()

--- a/utils/compat/__init__.py
+++ b/utils/compat/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 import pandas as pd
@@ -13,7 +14,14 @@ def safe_concat(frames: List[pd.DataFrame], **kwargs) -> pd.DataFrame:
 
 
 def safe_to_excel(df: pd.DataFrame, wr, *, sheet_name: str, **kwargs) -> None:
-    """Keyword-only ``sheet_name`` for pandas>=3 and backward compatible."""
+    """Keyword-only ``sheet_name`` for pandas>=3 and backward compatible.
+
+    Logs a warning when ``df`` is empty to alert the caller.
+    """
+    if df.empty:
+        logging.getLogger(__name__).warning(
+            "Excel sheet '%s' boş – yine de yazılıyor", sheet_name
+        )
     df.to_excel(excel_writer=wr, sheet_name=sheet_name, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- warn on empty results in `generate_summary`
- log warning when attempting to write empty sheets
- upgrade report save logs to warn when data is empty
- test warnings for empty summary and Excel sheet

## Testing
- `pre-commit run --files report_generator.py utils/compat/__init__.py tests/test_empty_summary_warns.py`
- `pytest -q`
- `pytest -q tests/test_empty_summary_warns.py`
- `pytest -q tests/test_parquet_cache.py tests/test_dtypes_ok.py tests/test_filter_none_skipped.py tests/test_join_handles_none.py tests/test_empty_summary_warns.py`

------
https://chatgpt.com/codex/tasks/task_e_685db43b88948325959515812e4715f7