### PR TITLE
Fix duplicate logs with time window

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py
+python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py
 markers =
     slow: marks tests as slow

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from finansal_analiz_sistemi.log_tools import DuplicateFilter
-from utils.logging_setup import setup_logger, CounterFilter
+from utils.logging_setup import CounterFilter, setup_logger
 
 
 def test_utils_setup_logger_adds_duplicate_filter_and_disables_propagation():
@@ -21,9 +21,7 @@ def test_utils_setup_logger_adds_duplicate_filter_and_disables_propagation():
 
     assert isinstance(counter, CounterFilter)
     assert root.propagate is False
-    assert any(
-        isinstance(f, DuplicateFilter) for h in root.handlers for f in h.filters
-    )
+    assert any(isinstance(f, DuplicateFilter) for h in root.handlers for f in h.filters)
 
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,47 @@
+import io
+import logging
+import time
+
+from finansal_analiz_sistemi.log_tools import DuplicateFilter
+from utils.logging_setup import setup_logger, CounterFilter
+
+
+def test_utils_setup_logger_adds_duplicate_filter_and_disables_propagation():
+    root = logging.getLogger()
+    old_handlers = root.handlers[:]
+    old_filters = root.filters[:]
+    old_propagate = root.propagate
+
+    root.handlers.clear()
+    root.filters.clear()
+    root.propagate = True
+    root.setLevel(logging.INFO)
+
+    counter = setup_logger()
+
+    assert isinstance(counter, CounterFilter)
+    assert root.propagate is False
+    assert any(
+        isinstance(f, DuplicateFilter) for h in root.handlers for f in h.filters
+    )
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(DuplicateFilter(window=0.2))
+    root.addHandler(handler)
+
+    root.info("dup")
+    root.info("dup")
+    time.sleep(0.25)
+    root.info("dup")
+
+    lines = [line for line in stream.getvalue().splitlines() if "dup" in line]
+    assert len(lines) == 2
+
+    root.handlers.clear()
+    root.filters.clear()
+    root.propagate = old_propagate
+    for h in old_handlers:
+        root.addHandler(h)
+    for f in old_filters:
+        root.addFilter(f)

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -4,20 +4,7 @@ import sys
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
-
-class NoDuplicateFilter(logging.Filter):
-    """Filter that removes consecutive duplicate log messages."""
-
-    def __init__(self):
-        super().__init__("no-dup")
-        self.last = None
-
-    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
-        current = (record.levelno, record.getMessage())
-        if current == self.last:
-            return False
-        self.last = current
-        return True
+from finansal_analiz_sistemi.log_tools import DuplicateFilter
 
 
 class CounterFilter(logging.Filter):
@@ -68,10 +55,11 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
 
     for handler in (file_handler, console_handler):
         handler.setFormatter(formatter)
-        handler.addFilter(NoDuplicateFilter())
+        handler.addFilter(DuplicateFilter())
         handler.addFilter(_counter_filter)
 
     logging.basicConfig(level=level, handlers=[console_handler, file_handler])
+    root.propagate = False
     return _counter_filter
 
 


### PR DESCRIPTION
## Summary
- use `DuplicateFilter` in logging setup
- disable propagation on the root logger
- cover new behaviour with tests

## Testing
- `pytest -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_685dc8edefc48325b4d72b8c370f12e3