### PR TITLE
Fix warnings and add test checks

### DIFF
--- a/finansal_analiz_sistemi/utils/__init__.py
+++ b/finansal_analiz_sistemi/utils/__init__.py
@@ -1,0 +1,3 @@
+from .compat import transpose as swapaxes
+
+__all__ = ["swapaxes"]

--- a/finansal_analiz_sistemi/utils/compat.py
+++ b/finansal_analiz_sistemi/utils/compat.py
@@ -1,0 +1,8 @@
+"""Compatibility helpers for finansal_analiz_sistemi package."""
+
+import pandas as pd
+
+
+def transpose(df: pd.DataFrame) -> pd.DataFrame:
+    """swapaxes(0, 1) geçerli kalması için geriye uyumlu çözüm."""
+    return df.T

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -281,7 +281,9 @@ def on_isle_hisse_verileri(
                 # Tarihleri karşılaştırmadan önce normalize et (sadece tarih kısmı, saat
                 # bilgisi olmadan)
                 original_len = len(df)
-                df = df[~df["tarih"].dt.normalize().isin(tr_holidays)]
+                normalized_dates = pd.to_datetime(df["tarih"].dt.normalize())
+                holiday_dates = pd.to_datetime(tr_holidays)
+                df = df[~normalized_dates.isin(holiday_dates)]
                 rows_dropped_for_holidays = original_len - len(df)
                 if rows_dropped_for_holidays > 0:
                     fn_logger.info(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py
 markers =
-    slow: marks tests as slow
+    slow: yavaş testler
+filterwarnings =
+    error

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -35,7 +35,7 @@ def test_utils_setup_logger_adds_duplicate_filter_and_disables_propagation():
 
     lines = [line for line in stream.getvalue().splitlines() if "dup" in line]
     assert len(lines) == 2
-
+    logging.shutdown()
     root.handlers.clear()
     root.filters.clear()
     root.propagate = old_propagate

--- a/tests/test_marker_slow.py
+++ b/tests/test_marker_slow.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.slow
+def test_marker_slow():
+    assert True

--- a/tests/test_no_futurewarnings.py
+++ b/tests/test_no_futurewarnings.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_no_futurewarnings(tmp_path):
+    pkg_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "tests",
+            "-k",
+            "not test_no_futurewarnings",
+            "-W",
+            "ignore::ResourceWarning",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=pkg_root,
+        env={**os.environ, "PYTHONWARNINGS": "ignore::ResourceWarning"},
+    )
+    assert "WARNING" not in result.stdout


### PR DESCRIPTION
## Summary
- add transpose helper
- enforce holiday comparison with datetime
- add slow marker test and subprocess warning check
- clean up logger test
- document slow marker and fail on warnings

## Testing
- `pre-commit run --files tests/test_logging_setup.py tests/test_no_futurewarnings.py tests/test_marker_slow.py finansal_analiz_sistemi/utils/__init__.py finansal_analiz_sistemi/utils/compat.py preprocessor.py pytest.ini`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcd57c77c83258fb1199c8381b525