### PR TITLE
Enable rotating logs and clean archives

### DIFF
--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -1,19 +1,14 @@
 """Package exports for convenience."""
 
-import datetime as dt
-import logging
 import pathlib
 from importlib import import_module
 
 from finansal_analiz_sistemi.log_tools import setup_logging as _setup_logging
+from utils.logging_setup import setup_logger
 
-_log_dir = pathlib.Path("log")
+_log_dir = pathlib.Path("loglar")
 _log_dir.mkdir(exist_ok=True)
-logging.basicConfig(
-    filename=_log_dir / f"run_{dt.date.today()}.txt",
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
+setup_logger()
 
 config = import_module("config")
 logging_config = import_module("finansal_analiz_sistemi.logging_config")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py
+python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py
 markers =
     slow: yavaş testler
 filterwarnings =

--- a/run.py
+++ b/run.py
@@ -379,4 +379,4 @@ if __name__ == "__main__":
             ) as wr:
                 add_error_sheet(wr, log_counter.error_list)
         logging.shutdown()
-        utils.purge_old_logs("loglar", days=7)
+        utils.purge_old_logs("loglar", days=30)

--- a/tests/test_rotate_logging.py
+++ b/tests/test_rotate_logging.py
@@ -1,0 +1,36 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+from utils import logging_setup
+
+
+def test_log_rotation(tmp_path, monkeypatch):
+    root = logging.getLogger()
+    old_handlers = root.handlers[:]
+    old_filters = root.filters[:]
+    root.handlers.clear()
+    root.filters.clear()
+    monkeypatch.chdir(tmp_path)
+
+    class TinyHandler(RotatingFileHandler):
+        def __init__(self, filename, *args, **kwargs):
+            super().__init__(filename, maxBytes=200, backupCount=1, encoding="utf-8")
+
+    monkeypatch.setattr(logging_setup, "RotatingFileHandler", TinyHandler)
+
+    logging_setup.setup_logger()
+    log = logging.getLogger("rotate")
+    for i in range(50):
+        log.info("%d %s", i, "x" * 20)
+    logging.shutdown()
+
+    log_dir = tmp_path / "loglar"
+    assert (log_dir / "rapor.log").exists()
+    assert (log_dir / "rapor.log.1").exists()
+
+    root.handlers.clear()
+    root.filters.clear()
+    for h in old_handlers:
+        root.addHandler(h)
+    for f in old_filters:
+        root.addFilter(f)

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -42,14 +42,14 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
 
     log_dir = os.path.join("loglar")
     os.makedirs(log_dir, exist_ok=True)
-    log_file = os.path.join(log_dir, f"app_{datetime.now():%Y%m%d_%H%M%S}.log")
+    log_file = os.path.join(log_dir, "rapor.log")
 
     formatter = logging.Formatter(
         "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
     )
 
     file_handler = RotatingFileHandler(
-        log_file, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
+        log_file, maxBytes=2_000_000, backupCount=20, encoding="utf-8"
     )
     console_handler = logging.StreamHandler(sys.stdout)
 

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -14,7 +14,7 @@ def purge_old_logs(
     """
     cutoff = datetime.now() - timedelta(days=keep_days)
     deleted = 0
-    for f in log_dir.glob("*.log"):
+    for f in log_dir.glob("*.log*"):
         if datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
             if dry_run:
                 print(f"[DRY-RUN] Would delete {f}")


### PR DESCRIPTION
## Summary
- rotate `rapor.log` at 2MB with up to 20 backups
- remove old rotated logs only if older than 30 days
- purge old log archives for 30 days at the end of `run.py`
- initialise logger in package `__init__`
- run rotation test via new `tests/test_rotate_logging.py`
- include new test in `pytest.ini`

## Testing
- `pytest -q`
- `pre-commit run --all-files`
- `python -m finansal_analiz_sistemi --output dummy.xlsx` *(fails: AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_685dd02327888325955f89390418bc21