### PR TITLE
Resolve dependency conflicts and fix tests

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -30,7 +30,6 @@ try:  # pragma: no cover - optional indicator
     from pandas_ta import psar as ta_psar
 except Exception:  # pragma: no cover - missing indicator
     ta_psar = None  # type: ignore[misc]
-from pandas_ta import tema
 
 import config
 import utils
@@ -482,7 +481,7 @@ def calculate_chunked(df: pd.DataFrame, active_inds: list[str]) -> None:
 
 def _tema20(series: pd.Series) -> pd.Series:
     """TEMA 20 – pandas_ta."""
-    return tema(series, length=20)
+    return ta.tema(series, length=20)
 
 
 def _ekle_psar(df: pd.DataFrame) -> None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py
+    test_no_pkg_conflict.py
 markers =
     slow: yavaş testler
 filterwarnings =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==24.4.2
-cachetools>=6.1.0
+cachetools<6.0,>=5.3
 flake8==7.0.0
-hypothesis==6.*
-pandas-ta>=0.3.14      # teknik indikatör kütüphanesi
+hypothesis~=6.99
+pandas_ta==0.3.14      # teknik indikatör kütüphanesi
 psutil
 xlsxwriter>=3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-cachetools>=6.1.0
+cachetools<6.0,>=5.3
 click >= 8.1
 pandas >= 2.2
 portalocker >= 2.8
 psutil>=5.9
 pyarrow >= 16
-pandas_ta==0.3.14b0
+pandas_ta==0.3.14
 openpyxl>=3.1
 plotly>=5
 kaleido>=0.2

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -4,7 +4,7 @@ import pytest
 
 ta = pytest.importorskip("pandas_ta")
 if not hasattr(ta, "psar"):
-    pytest.skip("psar not available")
+    pytest.skip("psar not available", allow_module_level=True)
 
 from run import run_pipeline  # noqa: E402
 

--- a/tests/test_indicator_calc_hyp.py
+++ b/tests/test_indicator_calc_hyp.py
@@ -1,11 +1,17 @@
-import pandas as pd
 import pytest
-from hypothesis import given
-from hypothesis import strategies as st
+
+try:  # pytest < 8 does not support allow_module_level
+    pytest.importorskip("hypothesis", allow_module_level=True)
+except TypeError:  # pragma: no cover - fallback
+    pytest.importorskip("hypothesis")
+
+import pandas as pd  # noqa: E402
+from hypothesis import given  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
 
 ta = pytest.importorskip("pandas_ta")
 if not hasattr(ta, "psar"):
-    pytest.skip("psar not available")
+    pytest.skip("psar not available", allow_module_level=True)
 
 import indicator_calculator as ic  # noqa: E402
 

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -8,7 +8,7 @@ import pytest
 
 ta = pytest.importorskip("pandas_ta")
 if not hasattr(ta, "psar"):
-    pytest.skip("psar not available")
+    pytest.skip("psar not available", allow_module_level=True)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.modules.pop("pandas_ta", None)  # Ensure real pandas_ta is used in this test

--- a/tests/test_no_pkg_conflict.py
+++ b/tests/test_no_pkg_conflict.py
@@ -1,0 +1,28 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_no_pkg_conflict():
+    pkg_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "check"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "tests",
+            "-k",
+            "not test_no_pkg_conflict",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=pkg_root,
+    )
+    assert "ERROR" not in result.stdout

--- a/tests/test_risk_manager_hyp.py
+++ b/tests/test_risk_manager_hyp.py
@@ -1,9 +1,16 @@
-import pandas as pd
-from hypothesis import given
-from hypothesis import strategies as st
+import pytest
 
-import src.kontrol_araci as kontrol_araci
-from src.preprocessor import fill_missing_business_day
+try:  # pytest < 8 does not support allow_module_level
+    pytest.importorskip("hypothesis", allow_module_level=True)
+except TypeError:  # pragma: no cover - fallback
+    pytest.importorskip("hypothesis")
+
+import pandas as pd  # noqa: E402
+from hypothesis import given  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+import src.kontrol_araci as kontrol_araci  # noqa: E402
+from src.preprocessor import fill_missing_business_day  # noqa: E402
 
 min_dt = pd.Timestamp("1970-01-01").to_pydatetime()
 max_dt = pd.Timestamp("2262-04-11").to_pydatetime()


### PR DESCRIPTION
## Summary
- pin cachetools to <6
- pin pandas_ta to 0.3.14
- pin hypothesis in dev requirements
- handle missing `hypothesis` in tests
- call pandas_ta.tema directly
- add package conflict test
- update pytest configuration

## Testing
- `pip install -r requirements.txt`
- `pip check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd9a6029083258fb8aad1ada14525