### PR TITLE
Fix xlsxwriter dependency issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = []
 python = "^3.11"
 pandas-ta = "0.3.14b0"
 cachetools = "6.1.0"
+xlsxwriter = "^3.1"
 
 [tool.flake8]
 max-line-length = 88

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+try:  # noqa: WPS434
+    import xlsxwriter  # type: ignore
+except Exception as exc:  # pragma: no cover - guard for optional dep
+    raise RuntimeError(
+        "XlsxWriter is required for Excel export. Install with 'pip install xlsxwriter>=3.1'"
+    ) from exc
+
 import logging
 import os
 import uuid

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-try:  # noqa: WPS434
-    import xlsxwriter  # type: ignore
-except Exception as exc:  # pragma: no cover - guard for optional dep
+import importlib.util
+
+if (
+    importlib.util.find_spec("xlsxwriter") is None
+):  # pragma: no cover - guard for optional dep
     raise RuntimeError(
         "XlsxWriter is required for Excel export. Install with 'pip install xlsxwriter>=3.1'"
-    ) from exc
+    )
 
 import logging
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ openpyxl>=3.1
 plotly>=5
 kaleido>=0.2
 hypothesis~=6.99
+xlsxwriter>=3.1


### PR DESCRIPTION
## Summary
- ensure XlsxWriter is listed as a required dependency
- guard report generator with a friendly error when XlsxWriter missing

## Testing
- `pip install -q xlsxwriter>=3.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e2aa140d883259d516419e290c430