### PR TITLE
Fix missing config defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """Global yapılandırma sabitleri."""
 
 from pathlib import Path
+import sys
 
 # Flag to indicate the application is running in Google Colab
 IS_COLAB: bool = False
@@ -35,3 +36,33 @@ DTYPES_MAP: dict[str, str] = {
 
 # chunk size for indicator calculation
 CHUNK_SIZE: int = 1
+
+# ---------------------------------------------------------------------------
+# Optional defaults
+if "ALIM_ZAMANI" not in globals():
+    ALIM_ZAMANI = "open"
+
+if "TR_HOLIDAYS_REMOVE" not in globals():
+    TR_HOLIDAYS_REMOVE = False
+
+if "OHLCV_MAP" not in globals():
+    OHLCV_MAP = {
+        "Açılış": "open",
+        "OPEN": "open",
+        "Yüksek": "high",
+        "HIGH": "high",
+        "Düşük": "low",
+        "LOW": "low",
+        "Kapanış": "close",
+        "CLOSE": "close",
+        "Miktar": "volume",
+        "VOLUME": "volume",
+    }
+
+if "INDIKATOR_AD_ESLESTIRME" not in globals():
+    INDIKATOR_AD_ESLESTIRME: dict = {}
+
+if "SERIES_SERIES_CROSSOVERS" not in globals():
+    SERIES_SERIES_CROSSOVERS: list = []
+
+sys.modules.setdefault("cfg", sys.modules[__name__])

--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib import import_module
 
-config = import_module("config")
+config = import_module("finansal_analiz_sistemi.config")
 logging_config = import_module("finansal_analiz_sistemi.logging_config")
 
 __all__ = ["config", "logging_config"]

--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -1,0 +1,15 @@
+"""Package level configuration wrapper."""
+
+from importlib import import_module
+import sys
+
+_base = import_module("config")
+
+# Expose attributes from base config
+ALIM_ZAMANI = getattr(_base, "ALIM_ZAMANI")
+TR_HOLIDAYS_REMOVE = getattr(_base, "TR_HOLIDAYS_REMOVE")
+OHLCV_MAP = getattr(_base, "OHLCV_MAP")
+INDIKATOR_AD_ESLESTIRME = getattr(_base, "INDIKATOR_AD_ESLESTIRME")
+SERIES_SERIES_CROSSOVERS = getattr(_base, "SERIES_SERIES_CROSSOVERS")
+
+sys.modules.setdefault("cfg", sys.modules[__name__])

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,0 +1,20 @@
+import importlib
+
+import config
+
+CONSTANTS = [
+    "ALIM_ZAMANI",
+    "TR_HOLIDAYS_REMOVE",
+    "OHLCV_MAP",
+    "INDIKATOR_AD_ESLESTIRME",
+    "SERIES_SERIES_CROSSOVERS",
+]
+
+def test_config_has_defaults():
+    for name in CONSTANTS:
+        assert hasattr(config, name)
+
+
+def test_cfg_alias():
+    mod = importlib.import_module("cfg")
+    assert mod is config


### PR DESCRIPTION
## Summary
- provide optional constants in `config.py`
- expose these via `finansal_analiz_sistemi.config`
- ensure package __init__ uses the new module
- test that defaults and legacy alias are present

## Testing
- `pytest tests/test_preprocessor.py::test_on_isle_hisse_verileri_invalid_dates_dropped_and_numeric tests/test_config_defaults.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e2e016230832595d38f00f2c46e88