### PR TITLE
Fix config constant for rich logging tests

### DIFF
--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -32,5 +32,9 @@ INDIKATOR_AD_ESLESTIRME.setdefault("its_9", "ichimoku_conversionline")
 # Environment flag
 IS_COLAB = globals().get("IS_COLAB", False)
 
+# Ensure the attribute exists for downstream imports
+if "IS_COLAB" not in globals():
+    IS_COLAB = False
+
 # Legacy `cfg` alias
 cfg = _sys.modules.setdefault("cfg", _sys.modules[__name__])


### PR DESCRIPTION
## Summary
- ensure `IS_COLAB` is always defined in `finansal_analiz_sistemi.config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef6daa9f88325bddab74c94ddfc9a