### PR TITLE
Suppress DataFrame.swapaxes warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,6 @@
 python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py
 markers =
     slow: uzun süren test
-filterwarnings = error
+filterwarnings =
+    error
+    ignore:.*DataFrame\.swapaxes.*deprecated.*:FutureWarning


### PR DESCRIPTION
## Summary
- extend `filterwarnings` in `pytest.ini` to silence DataFrame.swapaxes deprecation warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f02f284288325901f44d9261ccef9