### PR TITLE
Fix missing config constants

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,3 +66,14 @@ if "SERIES_SERIES_CROSSOVERS" not in globals():
     SERIES_SERIES_CROSSOVERS: list = []
 
 sys.modules.setdefault("cfg", sys.modules[__name__])
+
+import sys as _sys
+
+if not hasattr(_sys.modules[__name__], "SATIS_ZAMANI"):
+    SATIS_ZAMANI = globals().get("ALIM_ZAMANI", "close")
+
+if not hasattr(_sys.modules[__name__], "SERIES_VALUE_CROSSOVERS"):
+    SERIES_VALUE_CROSSOVERS: list = []
+
+if not hasattr(_sys.modules[__name__], "cfg"):
+    cfg = _sys.modules[__name__]

--- a/config.py
+++ b/config.py
@@ -67,13 +67,11 @@ if "SERIES_SERIES_CROSSOVERS" not in globals():
 
 sys.modules.setdefault("cfg", sys.modules[__name__])
 
-import sys as _sys
-
-if not hasattr(_sys.modules[__name__], "SATIS_ZAMANI"):
+if not hasattr(sys.modules[__name__], "SATIS_ZAMANI"):
     SATIS_ZAMANI = globals().get("ALIM_ZAMANI", "close")
 
-if not hasattr(_sys.modules[__name__], "SERIES_VALUE_CROSSOVERS"):
+if not hasattr(sys.modules[__name__], "SERIES_VALUE_CROSSOVERS"):
     SERIES_VALUE_CROSSOVERS: list = []
 
-if not hasattr(_sys.modules[__name__], "cfg"):
-    cfg = _sys.modules[__name__]
+if not hasattr(sys.modules[__name__], "cfg"):
+    cfg = sys.modules[__name__]


### PR DESCRIPTION
## Summary
- add missing SATIS_ZAMANI default
- ensure SERIES_VALUE_CROSSOVERS exists
- expose module as `cfg`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f094c3ee483259c65863cc6f0674b