### PR TITLE
Fix 'kod' KeyError by mapping FilterCode

### DIFF
--- a/src/kontrol_araci.py
+++ b/src/kontrol_araci.py
@@ -16,6 +16,10 @@ def tarama_denetimi(
         ["kod", "tip", "durum", "sebep",
          "eksik_sutunlar", "nan_sutunlar", "secim_adedi"]
     """
+    # --- HOT-PATCH C2: kolon uyum katmanı -----------------
+    if "kod" not in df_filtreler.columns and "FilterCode" in df_filtreler.columns:
+        df_filtreler = df_filtreler.rename(columns={"FilterCode": "kod"})
+    # ------------------------------------------------------
     kayıtlar = []
     for _, sat in df_filtreler.iterrows():
         _, info = _apply_single_filter(df_indikator, sat["kod"], sat["PythonQuery"])


### PR DESCRIPTION
## Summary
- hot-patch `tarama_denetimi` to rename `FilterCode` column to `kod`

## Testing
- `flake8 src/kontrol_araci.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0ef4d5588325a01ba90418ee7b4f