### PR TITLE
Fix pandas-ta install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas >= 2.2
 portalocker >= 2.8
 psutil>=5.9
 pyarrow >= 16
-pandas_ta==0.3.14b0
+pandas-ta==0.3.14b0
 openpyxl>=3.1
 plotly>=5
 kaleido>=0.2


### PR DESCRIPTION
## Summary
- pin `pandas-ta==0.3.14b0` by replacing the underscored package

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f25ad37f88325ba84b595902fcc99