### PR TITLE
fix: robust TEMA20 fallback + hypothesis hash shim (final green)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,11 @@
+import types
+
 import numpy as np
 import pandas as pd
 import pytest
+
+if not hasattr(types.SimpleNamespace, "__hash__"):
+    types.SimpleNamespace.__hash__ = lambda self: id(self)
 
 
 @pytest.fixture

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -480,8 +480,16 @@ def calculate_chunked(df: pd.DataFrame, active_inds: list[str]) -> None:
 
 
 def _tema20(series: pd.Series) -> pd.Series:
-    """TEMA 20 – pandas_ta."""
-    return ta.tema(series, length=20)
+    """TEMA 20 – pandas_ta fallback."""
+    if hasattr(ta, "tema"):
+        try:
+            return ta.tema(series, length=20)
+        except Exception:  # pragma: no cover - manual fallback
+            pass
+    ema1 = series.ewm(span=20, adjust=False).mean()
+    ema2 = ema1.ewm(span=20, adjust=False).mean()
+    ema3 = ema2.ewm(span=20, adjust=False).mean()
+    return (3 * ema1) - (3 * ema2) + ema3
 
 
 def _ekle_psar(df: pd.DataFrame) -> None:


### PR DESCRIPTION
## Summary
- handle pandas_ta missing or failing when computing TEMA20
- ensure `types.SimpleNamespace` is hashable for Hypothesis

## Testing
- `pre-commit run --files indicator_calculator.py conftest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f280b396483258b5ccab2ca92da9a