### PR TITLE
Fix unhashable SimpleNamespace in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
+# Hypothesis scans sys.modules during test collection.  Our tests inject
+# ``types.SimpleNamespace`` objects as stubs, but these are not hashable by
+# default, which leads to ``TypeError`` when Hypothesis tries to create a set
+# from module values.  Provide a simple ``__hash__`` implementation early so
+# that test collection succeeds regardless of import order.
 if not hasattr(types.SimpleNamespace, "__hash__"):
     types.SimpleNamespace.__hash__ = lambda self: id(self)
 


### PR DESCRIPTION
## Summary
- document why SimpleNamespace gets a custom `__hash__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2c8523b88325988993862861ac2e