### PR TITLE
Fix missing MA period constant

### DIFF
--- a/config.py
+++ b/config.py
@@ -91,3 +91,12 @@ if not hasattr(sys.modules[__name__], "passive_filters"):
     passive_filters = ["T31"]  # D2
 if not hasattr(sys.modules[__name__], "OZEL_SUTUN_PARAMS"):
     OZEL_SUTUN_PARAMS: dict = {}  # D3
+
+# ---------------------------------------------------------------------------
+# Teknik analizde zorunlu olarak üretilecek hareketli ortalamalar
+# ---------------------------------------------------------------------------
+
+from typing import List  # noqa: E402
+
+# Basit/üstel vb. MA hesaplamalarında gereken pencere uzunlukları
+GEREKLI_MA_PERIYOTLAR: List[int] = [5, 8, 20, 50, 100, 200]


### PR DESCRIPTION
## Summary
- add a global constant `GEREKLI_MA_PERIYOTLAR` used in indicator calculations

## Testing
- `ruff check config.py`
- `flake8 config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f32d1f6508325895a12927b3bf08f