### PR TITLE
Fix Hypothesis SimpleNamespace hashing

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -2,6 +2,7 @@ import types
 
 # Ensure SimpleNamespace is hashable for Hypothesis set-operations
 if getattr(types.SimpleNamespace, "__hash__", None) is None:
+
     def _simple_namespace_hash(self) -> int:
         """Hash SimpleNamespace by identity, satisfies flake8 E731."""
         return id(self)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,10 @@
+import types
+
+# Ensure SimpleNamespace is hashable for Hypothesis set-operations
+if getattr(types.SimpleNamespace, "__hash__", None) is None:
+    def _simple_namespace_hash(self) -> int:
+        """Hash SimpleNamespace by identity, satisfies flake8 E731."""
+        return id(self)
+
+    # Bind the function once so Hypothesis can safely hash the stubs
+    types.SimpleNamespace.__hash__ = _simple_namespace_hash


### PR DESCRIPTION
## Summary
- make sure `types.SimpleNamespace` objects are hashable by defining a global `__hash__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa4525b0083258ad887ffb70e0972