### PR TITLE
Fix workflow uses matrix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install deps
         run: |
           pip install -q pip-tools


### PR DESCRIPTION
## Summary
- ensure GitHub Actions setup-python step uses matrix `python-version`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing:skip-covered`


------
https://chatgpt.com/codex/tasks/task_e_685fab6f92148325b50d23771d509c6d