### PR TITLE
fix: update default filter depth

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -9,4 +9,4 @@ if os.path.exists(_cfg_path):
 else:
     _cfg = {}
 
-MAX_FILTER_DEPTH = _cfg.get("max_filter_depth", 5)
+MAX_FILTER_DEPTH = _cfg.get("max_filter_depth", 7)


### PR DESCRIPTION
## Summary
- update `MAX_FILTER_DEPTH` default to 7

## Testing
- `pre-commit run --files CHANGELOG.md settings.py`
- `pytest --cov=src --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685fae53d7c88325ac4f013d41b0a0d6