### PR TITLE
Fix Dockerfile dependency mismatch

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -14,6 +14,10 @@ pandas==2.2.2
     # via -r requirements.txt
 portalocker==3.2.0
     # via -r requirements.txt
+et-xmlfile==2.0.0
+    # via openpyxl
+openpyxl==3.1.5
+    # via -r requirements.txt
 psutil==7.0.0
     # via -r requirements.txt
 pyarrow==20.0.0


### PR DESCRIPTION
## Summary
- ensure openpyxl is included in requirements.lock

## Testing
- `pre-commit run --files requirements.lock`
- `pytest -q`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fb2ea8fe483259025796a0b0217f8