### PR TITLE
Fix config yaml loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,11 +3,22 @@
 import sys  # isort: skip
 from pathlib import Path
 
+import yaml
+
 # Flag to indicate the application is running in Google Colab
 IS_COLAB: bool = False
 
 CACHE_PATH: Path = Path("veri/birlesik_hisse_verileri.parquet")
 DEFAULT_CSV_PATH: Path = Path("data/raw/all_prices.csv")
+
+# Load optional configuration overrides from 'config.yml'
+_CFG_FILE = Path(__file__).with_suffix(".yml")
+if _CFG_FILE.exists():
+    with _CFG_FILE.open() as f:
+        _CFG = yaml.safe_load(f) or {}
+        globals().update(_CFG)
+else:
+    _CFG = {}
 
 # dtype downcast mappings for CSV reading
 DTYPES: dict[str, str] = {
@@ -89,6 +100,8 @@ if not hasattr(sys.modules[__name__], "get"):
 
 if not hasattr(sys.modules[__name__], "passive_filters"):
     passive_filters = ["T31"]  # D2
+if not hasattr(sys.modules[__name__], "filter_weights"):
+    filter_weights: dict = {}
 if not hasattr(sys.modules[__name__], "OZEL_SUTUN_PARAMS"):
     OZEL_SUTUN_PARAMS: dict = {}  # D3
 

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -19,3 +19,9 @@ def test_config_has_defaults():
 def test_cfg_alias():
     mod = importlib.import_module("cfg")
     assert mod is config
+
+
+def test_yaml_values_loaded():
+    """YAML'deki değerler modüle yüklenmeli."""
+    assert config.get("filter_weights", {}).get("T31") == 0.0
+    assert "T31" in config.get("passive_filters", [])


### PR DESCRIPTION
## Summary
- read configuration overrides from `config.yml` into `config` module
- expose empty defaults for `filter_weights`
- verify YAML values in config tests

## Testing
- `pre-commit run --files config.py tests/test_config_defaults.py`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fb50c99348325b6a088a62b1ee14c