### PR TITLE
fix: correct default type

### DIFF
--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -23,7 +23,7 @@ sys.modules.setdefault("cfg", sys.modules[__name__])
 SATIS_ZAMANI = globals().get("SATIS_ZAMANI", "close")
 
 # Empty default for value crossovers
-SERIES_VALUE_CROSSOVERS = globals().get("SERIES_VALUE_CROSSOVERS", {})
+SERIES_VALUE_CROSSOVERS = globals().get("SERIES_VALUE_CROSSOVERS", [])
 
 # Ensure Ichimoku alias exists
 INDIKATOR_AD_ESLESTIRME = globals().get("INDIKATOR_AD_ESLESTIRME", {})


### PR DESCRIPTION
## Summary
- fix incorrect default data type for SERIES_VALUE_CROSSOVERS

## Testing
- `pre-commit run --files finansal_analiz_sistemi/config.py`
- `pytest -q`
- `pytest --cov=config --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb4f0b13c8325b35f2b4896aa056e