### PR TITLE
fix: improve filter validation

### DIFF
--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -35,19 +35,23 @@ def dogrula_filtre_dataframe(
 
     for idx, row in df_filtre.iterrows():
         kod_degeri = row.get("flag")
-        kod = f"satir_{idx}" if pd.isna(kod_degeri) else str(kod_degeri)
+        kod_raw = "" if pd.isna(kod_degeri) else str(kod_degeri).strip()
+        kod = kod_raw or f"satir_{idx}"
         query_degeri = row.get("query", "")
         query = "" if pd.isna(query_degeri) else str(query_degeri).strip()
 
-        if not kod or kod.strip() == "":
+        if not kod_raw:
             sorunlu[kod] = "Boş veya eksik flag (kod) değeri."
-        elif not re.match(r"^[A-Z0-9_\-]+$", kod):
+        elif not re.match(r"^[A-Z0-9_\-]+$", kod_raw):
             sorunlu[kod] = (
                 "Geçersiz karakterler içeren flag. Sadece A-Z, 0-9, _ ve - izinli."
             )
 
         if "query" not in row or not query:
-            sorunlu[kod] = sorunlu.get(kod, "") + " Query sütunu boş veya eksik."
+            prefix = sorunlu.get(kod, "")
+            if prefix:
+                prefix = prefix.rstrip(". ") + ". "
+            sorunlu[kod] = prefix + "Query sütunu boş veya eksik."
 
     if logger:
         for kod, mesaj in sorunlu.items():
@@ -84,11 +88,12 @@ def validate(
 
     for idx, row in df_filtre.iterrows():
         kod_degeri = row.get("flag")
-        kod = f"satir_{idx}" if pd.isna(kod_degeri) else str(kod_degeri).strip()
+        kod_raw = "" if pd.isna(kod_degeri) else str(kod_degeri).strip()
+        kod = kod_raw or f"satir_{idx}"
         query_degeri = row.get("query", "")
         query = "" if pd.isna(query_degeri) else str(query_degeri).strip()
 
-        if not kod:
+        if not kod_raw:
             errors.append(
                 ValidationError(
                     hata_tipi="MISSING_FLAG",
@@ -99,7 +104,7 @@ def validate(
                     hint="Her filtre için bir kod girilmeli",
                 )
             )
-        elif not re.match(r"^[A-Z0-9_\-]+$", kod):
+        elif not re.match(r"^[A-Z0-9_\-]+$", kod_raw):
             errors.append(
                 ValidationError(
                     hata_tipi="INVALID_FLAG",

--- a/tests/test_filtre_dogrulama.py
+++ b/tests/test_filtre_dogrulama.py
@@ -4,7 +4,7 @@ import sys
 import pandas as pd
 import pytest
 
-from filtre_dogrulama import dogrula_filtre_dataframe
+from filtre_dogrulama import dogrula_filtre_dataframe, validate
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -41,3 +41,22 @@ def test_missing_columns_raises_keyerror():
     df = pd.DataFrame([{"FilterCode": "F1", "PythonQuery": "True"}])
     with pytest.raises(KeyError):
         dogrula_filtre_dataframe(df)
+
+
+def test_validate_reports_missing_flag():
+    df = pd.DataFrame([{"flag": pd.NA, "query": "True"}])
+    errors = validate(df)
+    assert len(errors) == 1
+    assert errors[0].hata_tipi == "MISSING_FLAG"
+
+
+def test_validate_reports_invalid_flag_characters():
+    df = pd.DataFrame([{"flag": "BAD#", "query": "True"}])
+    errors = validate(df)
+    assert any(e.hata_tipi == "INVALID_FLAG" for e in errors)
+
+
+def test_validate_reports_missing_query():
+    df = pd.DataFrame([{"flag": "VALID", "query": ""}])
+    errors = validate(df)
+    assert any(e.hata_tipi == "MISSING_QUERY" for e in errors)


### PR DESCRIPTION
## Summary
- handle blank flag codes in filtre_dogrulama
- return clear messages when query missing
- add unit tests for `validate`

## Testing
- `pre-commit run --files filtre_dogrulama.py tests/test_filtre_dogrulama.py`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fb6df63608325b19c12840865047b