### PR TITLE
fix: respect chunk size option

### DIFF
--- a/finansal/cli.py
+++ b/finansal/cli.py
@@ -52,7 +52,7 @@ def main(
         + [f"sma_{n}" for n in (50, 100, 200)]
     )
     active = config.CORE_INDICATORS if ind_set == "core" else full_inds
-    calculate_chunked(df, active)  # yazim: indicator_calculator
+    calculate_chunked(df, active, chunk_size=chunk_size)  # yazim: indicator_calculator
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -464,10 +464,12 @@ def apply_indicators(df: pd.DataFrame, indicators: list[str]) -> pd.DataFrame:
     return calculate_indicators(df, indicators)
 
 
-def calculate_chunked(df: pd.DataFrame, active_inds: list[str]) -> None:
+def calculate_chunked(
+    df: pd.DataFrame, active_inds: list[str], chunk_size: int = CHUNK_SIZE
+) -> None:
     """Process DataFrame per ticker and append to Parquet."""
     pq_path = Path("veri/gosterge.parquet")
-    for kods in lazy_chunk(df.groupby("ticker", sort=False), CHUNK_SIZE):
+    for kods in lazy_chunk(df.groupby("ticker", sort=False), chunk_size):
         for kod, group in kods:
             mini = group.sort_values("date").copy()
             mini = apply_indicators(mini, active_inds)


### PR DESCRIPTION
## Summary
- wire `--chunk-size` option to indicator processing
- allow `calculate_chunked` to accept custom chunk size

## Testing
- `pre-commit run --files finansal/cli.py indicator_calculator.py`
- `pytest -q --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685fb72b42bc8325b3bff9b37222d549