### PR TITLE
fix: expose helper APIs via finansal package

### DIFF
--- a/finansal/__init__.py
+++ b/finansal/__init__.py
@@ -1,1 +1,9 @@
-"""Parquet cache management package."""
+"""Convenience exports for :mod:`finansal` package."""
+
+from importlib import import_module
+
+ParquetCacheManager = import_module("finansal.parquet_cache").ParquetCacheManager
+lazy_chunk = import_module("finansal.utils").lazy_chunk
+safe_set = import_module("finansal.utils").safe_set
+
+__all__ = ["ParquetCacheManager", "lazy_chunk", "safe_set"]


### PR DESCRIPTION
## Summary
- export ParquetCacheManager and utility helpers from `finansal`

## Testing
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing`
- `pre-commit run --files finansal/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685fb6f801188325825e7941870210a0