### PR TITLE
fix: ignore strings in query column extraction

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -26,6 +26,7 @@ class MissingColumnError(Exception):
 
 
 def _extract_query_columns(query: str) -> set:
+    query = re.sub(r"(?:'[^']*'|\"[^\"]*\")", " ", query)
     tokens = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", query))
     reserved = set(keyword.kwlist) | {"and", "or", "not", "True", "False", "df"}
     return tokens - reserved

--- a/tests/test_query_columns.py
+++ b/tests/test_query_columns.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+import filter_engine
+
+
+def test_extract_ignore_string_literals():
+    cols = filter_engine._extract_query_columns('aciklama == "BETA" and close > 0')
+    assert cols == {"aciklama", "close"}
+
+
+def test_apply_single_filter_string_literal():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"],
+            "tarih": [pd.Timestamp("2025-03-01")],
+            "close": [1],
+            "aciklama": ["BETA"],
+        }
+    )
+    _, info = filter_engine._apply_single_filter(df, "T1", 'aciklama == "BETA"')
+    assert info["durum"] == "OK"


### PR DESCRIPTION
## Summary
- clean tokens inside quotes when extracting query columns
- test string literal handling for filter engine

## Testing
- `pre-commit run --files filter_engine.py tests/test_query_columns.py`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term`


------
https://chatgpt.com/codex/tasks/task_e_685fb6b0f1248325bded5dce60bb9a67