### PR TITLE
Fix Parquet cache pandas import

### DIFF
--- a/finansal/parquet_cache.py
+++ b/finansal/parquet_cache.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
-import pandas as pd
 import portalocker
-from pandas import DataFrame
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from pandas import DataFrame
 
 logger: Final[logging.Logger] = logging.getLogger(__name__)
 
@@ -20,6 +21,8 @@ class ParquetCacheManager:  # noqa: D101
 
     def load(self) -> DataFrame:  # noqa: D401, D403
         """Load the cached parquet. Raise FileNotFoundError if absent."""
+        import pandas as pd
+
         if not self.cache_path.exists():
             raise FileNotFoundError(self.cache_path)
         df = pd.read_parquet(self.cache_path)


### PR DESCRIPTION
## Summary
- avoid importing pandas at module import time in ParquetCacheManager

## Testing
- `pre-commit run --files finansal/parquet_cache.py`
- `pytest -q`
- `pytest -q --cov=finansal --cov=src --cov=finansal_analiz_sistemi --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_685fb804c4dc8325b51120ddb1be4a5b