### PR TITLE
fix: validate chunk size

### DIFF
--- a/finansal/utils/__init__.py
+++ b/finansal/utils/__init__.py
@@ -12,6 +12,9 @@ T = TypeVar("T")
 
 def lazy_chunk(seq: Iterable[T], size: int) -> Generator[Sequence[T], None, None]:
     """Yield sequence chunks lazily without loading all into memory."""
+    if size <= 0:
+        raise ValueError("size must be positive")
+
     chunk: list[T] = []
     for item in seq:
         chunk.append(item)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py test_extra_coverage.py
+python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py test_extra_coverage.py test_lazy_chunk.py
 markers =
     slow: uzun süren test
 filterwarnings =

--- a/tests/test_lazy_chunk.py
+++ b/tests/test_lazy_chunk.py
@@ -1,0 +1,14 @@
+import pytest
+
+from finansal.utils import lazy_chunk
+
+
+def test_lazy_chunk_yields_groups():
+    data = list(range(5))
+    chunks = list(lazy_chunk(data, 2))
+    assert chunks == [[0, 1], [2, 3], [4]]
+
+
+def test_lazy_chunk_invalid_size():
+    with pytest.raises(ValueError):
+        list(lazy_chunk([1, 2], 0))


### PR DESCRIPTION
## Summary
- validate chunk size in `finansal.utils.lazy_chunk`
- cover negative chunk size case with tests
- include new test file in `pytest.ini`

## Testing
- `pre-commit run --files finansal/utils/__init__.py tests/test_lazy_chunk.py pytest.ini`
- `pytest -q`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fb89a1dcc83258bb42412273c2cc0