### PR TITLE
Fix safe_set index alignment

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -8,8 +8,20 @@ import config
 
 
 def safe_set(df: pd.DataFrame, column: str, values) -> None:
-    """Assign series to DataFrame with dtype safety."""
-    series = pd.Series(values)
+    """Assign series to DataFrame with dtype safety.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Target DataFrame to modify.
+    column : str
+        Column name to assign.
+    values : iterable
+        Values to be set. ``values`` must be index-aligned with ``df``.
+    """
+
+    # Ensure the index matches the DataFrame to avoid misaligned assignment
+    series = pd.Series(values, index=df.index)
 
     target_dtype = config.DTYPES_MAP.get(column)
     if target_dtype is None and column in df.columns:

--- a/tests/test_dtypes_ok.py
+++ b/tests/test_dtypes_ok.py
@@ -9,3 +9,16 @@ def test_safe_set_casts_to_config_dtype():
     df = pd.DataFrame({"adx_14": pd.Series([1, 2], dtype="int64")})
     safe_set(df, "adx_14", np.array([1.5, 2.5]))
     assert df["adx_14"].dtype == config.DTYPES_MAP["adx_14"]
+
+
+def test_safe_set_keeps_index_alignment():
+    df = pd.DataFrame({"close": [10, 20]}, index=[5, 6])
+    safe_set(df, "ema_10", [1, 2])
+    assert list(df.index) == [5, 6]
+    assert df.loc[5, "ema_10"] == 1
+
+
+def test_safe_set_fallback_dtype():
+    df = pd.DataFrame({"volume": pd.Series([1, 2], dtype="int32")})
+    safe_set(df, "volume", [1, np.nan])
+    assert df["volume"].dtype == "float32"


### PR DESCRIPTION
## Summary
- preserve DataFrame index when assigning series in `safe_set`
- test index preservation and fallback dtype handling

## Testing
- `pre-commit run --files finansal/utils/dtypes.py tests/test_dtypes_ok.py`
- `pytest -q`
- `pytest -q --cov=finansal`

------
https://chatgpt.com/codex/tasks/task_e_685fb8c026608325a113d4c4a3c62467