### PR TITLE
Fix IS_COLAB config inheritance

### DIFF
--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -1,7 +1,6 @@
 """Package level configuration wrapper."""
 
 import sys
-import sys as _sys
 from importlib import import_module
 
 _base = import_module("config")
@@ -12,6 +11,7 @@ TR_HOLIDAYS_REMOVE = getattr(_base, "TR_HOLIDAYS_REMOVE")
 OHLCV_MAP = getattr(_base, "OHLCV_MAP")
 INDIKATOR_AD_ESLESTIRME = getattr(_base, "INDIKATOR_AD_ESLESTIRME")
 SERIES_SERIES_CROSSOVERS = getattr(_base, "SERIES_SERIES_CROSSOVERS")
+IS_COLAB = getattr(_base, "IS_COLAB")
 
 sys.modules.setdefault("cfg", sys.modules[__name__])
 
@@ -29,12 +29,5 @@ SERIES_VALUE_CROSSOVERS = globals().get("SERIES_VALUE_CROSSOVERS", [])
 INDIKATOR_AD_ESLESTIRME = globals().get("INDIKATOR_AD_ESLESTIRME", {})
 INDIKATOR_AD_ESLESTIRME.setdefault("its_9", "ichimoku_conversionline")
 
-# Environment flag
-IS_COLAB = globals().get("IS_COLAB", False)
-
-# Ensure the attribute exists for downstream imports
-if "IS_COLAB" not in globals():
-    IS_COLAB = False
-
 # Legacy `cfg` alias
-cfg = _sys.modules.setdefault("cfg", _sys.modules[__name__])
+cfg = sys.modules.setdefault("cfg", sys.modules[__name__])


### PR DESCRIPTION
## Summary
- read `IS_COLAB` value from base `config` module
- simplify cfg alias logic

## Testing
- `pre-commit run --files finansal_analiz_sistemi/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb9e253a083258658552cdc1f0f70