### PR TITLE
fix: ensure run module can be executed

### DIFF
--- a/finansal_analiz_sistemi/main.py
+++ b/finansal_analiz_sistemi/main.py
@@ -1,6 +1,16 @@
+"""Entry point for running the project as a module or script."""
+
 import runpy
+import sys
+from pathlib import Path
 
 if __name__ == "__main__":
+    # When executed directly ``python finansal_analiz_sistemi/main.py`` the
+    # parent directory is not on ``sys.path``. Add it so that ``run`` can be
+    # located correctly.
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
     runpy.run_module("run", run_name="__main__")
 else:
     from run import (  # noqa: F401


### PR DESCRIPTION
## Summary
- fix running `main.py` directly by setting up `sys.path`

## Testing
- `pre-commit run --files finansal_analiz_sistemi/main.py`
- `pytest -q`
- `coverage run -m pytest -q && coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_685fba8e434c8325ad7db53925b9f6ae