### PR TITLE
fix: prevent double log counting

### DIFF
--- a/finansal_analiz_sistemi/log_tools.py
+++ b/finansal_analiz_sistemi/log_tools.py
@@ -90,10 +90,11 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
     )
     console_handler = logging.StreamHandler(sys.stdout)
 
+    if _counter_filter not in root.filters:
+        root.addFilter(_counter_filter)
     for handler in (file_handler, console_handler):
         handler.setFormatter(formatter)
         handler.addFilter(DuplicateFilter())
-        handler.addFilter(_counter_filter)
 
     logging.basicConfig(level=level, handlers=[console_handler, file_handler])
     root.propagate = False


### PR DESCRIPTION
## Summary
- ensure CounterFilter only attaches once to root logger

## Testing
- `pre-commit run --files finansal_analiz_sistemi/log_tools.py tests/test_setup_logging.py`
- `pytest -q`
- `pytest --cov=finansal_analiz_sistemi --cov=finansal --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_685fba513dd88325b127665cfca595aa