### PR TITLE
Fix CLI import path for direct execution

### DIFF
--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -1,5 +1,10 @@
+import sys
 from argparse import ArgumentParser
 from pathlib import Path
+
+# allow running this file directly
+if __package__ is None:  # pragma: no cover - safe guard for manual execution
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- ensure finansal_analiz_sistemi.cli works when invoked as a script

## Testing
- `pre-commit run --files finansal_analiz_sistemi/cli.py`
- `pytest -q`
- `pytest --cov=finansal_analiz_sistemi -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb994ea9c8325bd08df69d1dfca85