### PR TITLE
fix: align filter column name

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -13,7 +13,7 @@ from logging_config import get_logger
 from utils.compat import safe_concat
 
 # Sabitler
-COLS = ["tarih", "filter_kodu", "python_query"]
+COLS = ["tarih", "filtre_kodu", "python_query"]
 
 # data_loader.py
 # -*- coding: utf-8 -*-

--- a/tests/test_header_alignment.py
+++ b/tests/test_header_alignment.py
@@ -6,4 +6,4 @@ def test_header_alignment(tmp_path):
     tmp.write_text("dummy\n2025-01-01;MACD;close>vwap\n")
 
     df = load_filter_csv(tmp)
-    assert list(df.columns) == ["tarih", "filter_kodu", "python_query"]
+    assert list(df.columns) == ["tarih", "filtre_kodu", "python_query"]


### PR DESCRIPTION
## Summary
- fix inconsistent filter column naming in `load_filter_csv`
- adjust tests

## Testing
- `pre-commit run --files finansal_analiz_sistemi/data_loader.py tests/test_header_alignment.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fba11bab08325a6c31dc533a34b96