### PR TITLE
Fix ReportWriter path handling

### DIFF
--- a/finansal_analiz_sistemi/report_writer.py
+++ b/finansal_analiz_sistemi/report_writer.py
@@ -6,8 +6,9 @@ import pandas as pd
 class ReportWriter:
     """Simple Excel writer utility."""
 
-    def write_report(self, df: pd.DataFrame, output_path: Path) -> None:
+    def write_report(self, df: pd.DataFrame, output_path: Path | str) -> None:
         """Write DataFrame to Excel creating parent directories if needed."""
+        output_path = Path(output_path)
         # Ebeveyn klasörleri otomatik oluştur
         output_path.parent.mkdir(parents=True, exist_ok=True)
         df.to_excel(output_path, index=False)

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 import src.kontrol_araci as kontrol_araci
+from finansal_analiz_sistemi.report_writer import ReportWriter
 from src.preprocessor import fill_missing_business_day
 from src.utils import excel_reader
 
@@ -68,3 +69,10 @@ def test_logging_config_import(monkeypatch):
     monkeypatch.setattr(lc.os, "makedirs", lambda *a, **k: None)
     importlib.reload(lc)
     assert calls["file"].endswith("run.log")
+
+
+def test_report_writer_accepts_str(tmp_path):
+    df = pd.DataFrame({"a": [1]})
+    nested = tmp_path / "nested" / "out.xlsx"
+    ReportWriter().write_report(df, str(nested))
+    assert nested.exists() and nested.stat().st_size > 0


### PR DESCRIPTION
## Summary
- make `ReportWriter.write_report` accept Path or str
- test that ReportWriter handles string paths

## Testing
- `pre-commit run --files finansal_analiz_sistemi/report_writer.py tests/test_extra_coverage.py`
- `pytest -q`
- `pytest --cov=finansal_analiz_sistemi -q`


------
https://chatgpt.com/codex/tasks/task_e_685fbac334908325a29896b547ed1672