### PR TITLE
fix: handle missing returns gracefully

### DIFF
--- a/portfolio_builder.py
+++ b/portfolio_builder.py
@@ -2,9 +2,20 @@ import pandas as pd
 
 
 def calculate_total_return(code: str, pos_df: pd.DataFrame) -> float:
-    """Return weighted total return for a filter."""
+    """Return weighted total return for a filter.
+
+    Missing or non-numeric values are treated as ``0`` and a missing
+    ``raw_return`` column results in ``0.0``.
+    """
+
     from config import cfg
 
-    w = cfg.get("filter_weights", {}).get(code, 1.0)
-    total_return = (pos_df["raw_return"] * w).sum()
-    return total_return
+    weight = float(cfg.get("filter_weights", {}).get(code, 1.0))
+
+    raw_col = pos_df.get("raw_return")
+    if raw_col is None:
+        return 0.0
+
+    raw = pd.to_numeric(raw_col, errors="coerce")
+    total_return = (raw.fillna(0) * weight).sum()
+    return float(total_return)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py test_extra_coverage.py test_lazy_chunk.py test_normalize.py
+    test_portfolio_builder.py
 markers =
     slow: uzun süren test
 filterwarnings =

--- a/tests/test_portfolio_builder.py
+++ b/tests/test_portfolio_builder.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+import config
+import portfolio_builder
+
+
+def test_calculate_total_return_weight(monkeypatch):
+    df = pd.DataFrame({"raw_return": [0.1, 0.2]})
+    monkeypatch.setattr(config, "filter_weights", {"F1": 0.5})
+    result = portfolio_builder.calculate_total_return("F1", df)
+    assert result == 0.15000000000000002
+
+
+def test_calculate_total_return_missing(monkeypatch):
+    df = pd.DataFrame({"other": [1, 2]})
+    monkeypatch.setattr(config, "filter_weights", {})
+    assert portfolio_builder.calculate_total_return("X", df) == 0.0


### PR DESCRIPTION
## Summary
- handle missing columns in `calculate_total_return`
- cover `portfolio_builder` logic with unit tests
- register the new test in `pytest.ini`

## Testing
- `pre-commit run --files portfolio_builder.py tests/test_portfolio_builder.py pytest.ini`
- `pytest -q --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685fbf0c4bb48325bf0387b048a356ce