### PR TITLE
fix: re-export rich logging helpers

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -1,6 +1,6 @@
 """Compatibility wrapper that re-exports logging helpers."""
 
-from finansal_analiz_sistemi.log_tools import get_logger
-from finansal_analiz_sistemi.log_tools import setup_logger as setup_logging
+# Re-export the rich-aware logging helpers from the package-level module.
+from finansal_analiz_sistemi.logging_config import get_logger, setup_logging
 
 __all__ = ["get_logger", "setup_logging"]


### PR DESCRIPTION
## Summary
- use package-level logging configuration from compatibility wrapper

## Testing
- `pre-commit run --files logging_config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fbee0e750832582d1d3d721c5a7a8