### PR TITLE
Fix memory leak in log_to_health

### DIFF
--- a/log_to_health.py
+++ b/log_to_health.py
@@ -11,7 +11,7 @@ from openpyxl.styles import Font, PatternFill
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows as _to_rows
 
-from src.utils.excel_reader import open_excel_cached
+from src.utils.excel_reader import clear_cache, open_excel_cached
 from utils.compat import safe_concat
 
 GREEN_FILL = PatternFill(start_color="C6EFCE", end_color="C6EFCE", fill_type="solid")
@@ -165,6 +165,7 @@ def generate(log_path: str | os.PathLike, excel_paths: list[str | os.PathLike]) 
         cell.font = Font(bold=True)
         cell.fill = BLUE_FILL
     _auto_width(ws3)
+    clear_cache()
 
     wb.save(out_file)
     wb.close()


### PR DESCRIPTION
## Summary
- close cached Excel handles when generating health reports

## Testing
- `pre-commit run --files log_to_health.py tests/test_log_to_health.py`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fbeccd39483259d7a0e7e86e19adb