### PR TITLE
fix: correct return type for full report

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -504,7 +504,7 @@ def generate_full_report(
     keep_legacy: bool = True,
     quick: bool = True,
     logger_param=None,
-) -> str:
+) -> Path:
     if logger_param is None:
         logger_param = logger
     if keep_legacy:


### PR DESCRIPTION
## Summary
- fix return type annotation of `generate_full_report`

## Testing
- `pre-commit run --files report_generator.py`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_685fc4e77fb88325add6c4f6260f278c