### PR TITLE
Fix swapaxes compat test

### DIFF
--- a/finansal_analiz_sistemi/utils/compat.py
+++ b/finansal_analiz_sistemi/utils/compat.py
@@ -3,6 +3,16 @@
 import pandas as pd
 
 
-def transpose(df: pd.DataFrame) -> pd.DataFrame:
-    """swapaxes(0, 1) geçerli kalması için geriye uyumlu çözüm."""
+def transpose(df: pd.DataFrame, axis1: int = 0, axis2: int = 1) -> pd.DataFrame:
+    """Compat replacement for ``DataFrame.swapaxes``.
+
+    Pandas 3 removed :meth:`DataFrame.swapaxes`.  ``df.T`` mirrors
+    ``df.swapaxes(0, 1)`` so we only support that case.  ``axis1`` and
+    ``axis2`` parameters are accepted for API compatibility and must both be
+    ``0`` and ``1`` respectively.  Any other values raise ``NotImplementedError``
+    to signal unsupported use.
+    """
+
+    if axis1 != 0 or axis2 != 1:
+        raise NotImplementedError("only axes (0, 1) are supported")
     return df.T

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
-python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py test_extra_coverage.py test_lazy_chunk.py test_normalize.py
-    test_portfolio_builder.py
+python_files = test_parquet_cache.py test_dtypes_ok.py test_filter_none_skipped.py test_join_handles_none.py test_setup_logging.py test_logging_setup.py test_rotate_logging.py test_extra_coverage.py test_lazy_chunk.py test_normalize.py test_portfolio_builder.py test_swapaxes.py
 markers =
     slow: uzun süren test
 filterwarnings =

--- a/tests/test_swapaxes.py
+++ b/tests/test_swapaxes.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from finansal_analiz_sistemi.utils import swapaxes
+
+
+def test_swapaxes_basic():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    out = swapaxes(df)
+    expected = df.T
+    pd.testing.assert_frame_equal(out, expected)
+
+
+def test_swapaxes_axis_args():
+    df = pd.DataFrame({"x": [5, 6]})
+    out = swapaxes(df, 0, 1)
+    expected = df.T
+    pd.testing.assert_frame_equal(out, expected)
+
+
+def test_swapaxes_invalid_axis():
+    df = pd.DataFrame({"x": [5, 6]})
+    with pytest.raises(NotImplementedError):
+        swapaxes(df, 1, 0)


### PR DESCRIPTION
## Summary
- add pandas3-compatible swapaxes helper
- test swapaxes helper functionality
- run new test with pytest configuration

## Testing
- `pre-commit run --files finansal_analiz_sistemi/utils/compat.py tests/test_swapaxes.py pytest.ini`
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc4d2cac88325b38d79cd51254e7a