### PR TITLE
Fix transpose helper compatibility

### DIFF
--- a/finansal_analiz_sistemi/utils/compat.py
+++ b/finansal_analiz_sistemi/utils/compat.py
@@ -1,8 +1,29 @@
 """Compatibility helpers for finansal_analiz_sistemi package."""
 
+from __future__ import annotations
+
+from typing import Hashable
+
 import pandas as pd
 
 
-def transpose(df: pd.DataFrame) -> pd.DataFrame:
-    """swapaxes(0, 1) geçerli kalması için geriye uyumlu çözüm."""
-    return df.T
+def transpose(
+    df: pd.DataFrame,
+    axis1: Hashable = 0,
+    axis2: Hashable = 1,
+    copy: bool | None = None,
+) -> pd.DataFrame:
+    """Backwards compatible helper for :meth:`DataFrame.swapaxes`.
+
+    Parameters mimic ``swapaxes`` but only ``axis1=0`` and ``axis2=1`` are
+    supported. ``copy=None`` matches the previous default behaviour of returning
+    a view when possible.
+    """
+
+    if axis1 == axis2:
+        return df.copy(deep=bool(copy))
+
+    if {axis1, axis2} not in ({0, 1}, {"index", "columns"}):
+        raise ValueError("only axes 0 and 1 are supported")
+
+    return df.transpose(copy=False if copy is None else copy)


### PR DESCRIPTION
## Summary
- expand `transpose` helper to mimic DataFrame.swapaxes behaviour

## Testing
- `pre-commit run --files finansal_analiz_sistemi/utils/compat.py`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fc4b23ddc83258441933eb5750760