### PR TITLE
Fix SimpleNamespace hashing

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,11 +1,12 @@
 import types
 
-# Ensure SimpleNamespace is hashable for Hypothesis set-operations
-if getattr(types.SimpleNamespace, "__hash__", None) is None:
+# Ensure ``SimpleNamespace`` instances can be used in sets.
+if types.SimpleNamespace.__hash__ is None:
 
-    def _simple_namespace_hash(self) -> int:
-        """Hash SimpleNamespace by identity, satisfies flake8 E731."""
-        return id(self)
+    class _SimpleNamespaceHashable(types.SimpleNamespace):
+        """Variant of :class:`SimpleNamespace` that is hashable by identity."""
 
-    # Bind the function once so Hypothesis can safely hash the stubs
-    types.SimpleNamespace.__hash__ = _simple_namespace_hash
+        __hash__ = object.__hash__
+
+    # Swap out the standard ``SimpleNamespace`` for the hashable variant.
+    types.SimpleNamespace = _SimpleNamespaceHashable


### PR DESCRIPTION
## Summary
- ensure `SimpleNamespace` is hashable by replacing it with a subclass

## Testing
- `pre-commit run --files sitecustomize.py`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_685fce114db08325a47cf3126db573fd