### PR TITLE
fix: settings fallback for invalid config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ python_files =
     test_lazy_chunk.py
     test_normalize.py
     test_portfolio_builder.py
+    test_settings_fallback.py
 markers =
     slow: uzun süren test
 filterwarnings =

--- a/settings.py
+++ b/settings.py
@@ -1,12 +1,36 @@
+from __future__ import annotations
+
 import os
+from pathlib import Path
+from typing import Any
 
 import yaml
 
-_cfg_path = os.path.join(os.path.dirname(__file__), "settings.yaml")
-if os.path.exists(_cfg_path):
-    with open(_cfg_path) as f:
-        _cfg = yaml.safe_load(f) or {}
-else:
-    _cfg = {}
+DEFAULT_MAX_FILTER_DEPTH = 7
 
-MAX_FILTER_DEPTH = _cfg.get("max_filter_depth", 7)
+
+def _load_cfg() -> dict[str, Any]:
+    """Load YAML configuration if available."""
+    cfg_file = Path(
+        os.environ.get("FAS_SETTINGS_FILE", Path(__file__).with_suffix(".yaml"))
+    )
+    if cfg_file.is_file():
+        with cfg_file.open() as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+_cfg = _load_cfg()
+
+
+def _as_int(value: Any, default: int) -> int:
+    """Return ``value`` cast to ``int`` or ``default`` on failure."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+MAX_FILTER_DEPTH: int = _as_int(_cfg.get("max_filter_depth"), DEFAULT_MAX_FILTER_DEPTH)
+
+__all__ = ["MAX_FILTER_DEPTH"]

--- a/tests/test_settings_fallback.py
+++ b/tests/test_settings_fallback.py
@@ -1,0 +1,13 @@
+import importlib
+
+import settings
+
+
+def test_invalid_depth_fallback(tmp_path, monkeypatch):
+    cfg = tmp_path / "settings.yaml"
+    cfg.write_text("max_filter_depth: bad\n")
+    monkeypatch.setenv("FAS_SETTINGS_FILE", str(cfg))
+    importlib.reload(settings)
+    assert settings.MAX_FILTER_DEPTH == 7
+    monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
+    importlib.reload(settings)


### PR DESCRIPTION
## Summary
- improve settings loader
- support fallback to default when config values are invalid
- test invalid `MAX_FILTER_DEPTH` handling

## Testing
- `pre-commit run --files settings.py tests/test_settings_fallback.py pytest.ini`
- `pytest -q`
- `coverage run -m pytest -q && coverage report`


------
https://chatgpt.com/codex/tasks/task_e_685fcdb3bfa083259209393aa8334c4c