### PR TITLE
fix: ensure numeric MAX_FILTER_DEPTH

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -9,4 +9,7 @@ if os.path.exists(_cfg_path):
 else:
     _cfg = {}
 
-MAX_FILTER_DEPTH = _cfg.get("max_filter_depth", 7)
+try:
+    MAX_FILTER_DEPTH = int(_cfg.get("max_filter_depth", 7))
+except (TypeError, ValueError):
+    MAX_FILTER_DEPTH = 7

--- a/settings.py
+++ b/settings.py
@@ -32,4 +32,3 @@ def _as_int(value: Any, default: int) -> int:
 
 
 MAX_FILTER_DEPTH: int = _as_int(_cfg.get("max_filter_depth"), DEFAULT_MAX_FILTER_DEPTH)
-


### PR DESCRIPTION
## Summary
- cast `MAX_FILTER_DEPTH` to `int` in settings loader
- fall back to default when conversion fails

## Testing
- `pre-commit run --files settings.py`
- `pytest -q`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fcdcbc7908325b275fc379b3aeb70