### PR TITLE
Fix settings load error

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -15,8 +15,11 @@ def _load_cfg() -> dict[str, Any]:
         os.environ.get("FAS_SETTINGS_FILE", Path(__file__).with_suffix(".yaml"))
     )
     if cfg_file.is_file():
-        with cfg_file.open() as f:
-            return yaml.safe_load(f) or {}
+        try:
+            with cfg_file.open() as f:
+                return yaml.safe_load(f) or {}
+        except yaml.YAMLError:
+            return {}
     return {}
 
 

--- a/tests/test_settings_fallback.py
+++ b/tests/test_settings_fallback.py
@@ -11,3 +11,14 @@ def test_invalid_depth_fallback(tmp_path, monkeypatch):
     assert settings.MAX_FILTER_DEPTH == 7
     monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
     importlib.reload(settings)
+    assert settings.MAX_FILTER_DEPTH == 7
+
+
+def test_invalid_yaml_fallback(tmp_path, monkeypatch):
+    cfg = tmp_path / "settings.yaml"
+    cfg.write_text("invalid: [\n")
+    monkeypatch.setenv("FAS_SETTINGS_FILE", str(cfg))
+    importlib.reload(settings)
+    assert settings.MAX_FILTER_DEPTH == 7
+    monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
+    importlib.reload(settings)


### PR DESCRIPTION
## Summary
- skip invalid YAML when loading settings
- test fallback for corrupt settings file

## Testing
- `pre-commit run --files settings.py tests/test_settings_fallback.py`
- `pytest -q --cov=src --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_685fd0c6e084832596d1dfef2f467d28