### PR TITLE
fix: expose helpers via package init

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,11 @@
+"""Public shortcuts for the ``src`` helpers."""
+
+from .kontrol_araci import tarama_denetimi
+from .preprocessor import fill_missing_business_day
+from .utils import excel_reader
+
+__all__ = [
+    "tarama_denetimi",
+    "fill_missing_business_day",
+    "excel_reader",
+]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,9 @@
-"""Utility helpers for the src package."""
+"""Utility helpers for the ``src`` package.
+
+Exports wrappers around :mod:`openpyxl`'s ``ExcelFile`` handling
+implemented in :mod:`.excel_reader`.
+"""
+
+from .excel_reader import clear_cache, open_excel_cached, read_excel_cached
+
+__all__ = ["open_excel_cached", "read_excel_cached", "clear_cache"]


### PR DESCRIPTION
## Summary
- expose Excel helper functions from `src.utils`
- export common helpers from `src` package

## Testing
- `pre-commit run --files src/utils/__init__.py src/__init__.py`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685fce28904883258de06b683f91db02