### PR TITLE
fix: load patches before tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,9 @@ import numpy as np  # mevcut test yardımcıları için gerekli
 import pandas as pd  # mevcut test yardımcıları için gerekli
 import pytest  # pytest fixture’ları için gerekli
 
+# Ensure runtime patches (e.g., numpy.NaN) are applied early
+import sitecustomize  # noqa: F401
+
 
 def _sanitize_sys_modules() -> None:
     """Hypothesis'in ``unhashable module`` hatasını önle.

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,5 +1,7 @@
 import types
 
+import numpy as np
+
 # Ensure ``SimpleNamespace`` instances can be used in sets.
 if types.SimpleNamespace.__hash__ is None:
 
@@ -10,3 +12,7 @@ if types.SimpleNamespace.__hash__ is None:
 
     # Swap out the standard ``SimpleNamespace`` for the hashable variant.
     types.SimpleNamespace = _SimpleNamespaceHashable
+
+# numpy>=2 removed the ``NaN`` alias. Some optional dependencies still import it.
+if not hasattr(np, "NaN"):
+    np.NaN = np.nan


### PR DESCRIPTION
## Summary
- import `sitecustomize` at test startup so runtime fixes apply
- add missing `np.NaN` alias in `sitecustomize`

## Testing
- `pre-commit run --files sitecustomize.py conftest.py run.py tests/test_cli_output.py tests/test_run_log.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fcd8e78308325871771e76d9026ac