### PR TITLE
chore: pin minimal numpy version

### DIFF
--- a/scripts/lock_requirements.sh
+++ b/scripts/lock_requirements.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 pip install --quiet pip-tools
-pip-compile --output-file=requirements.lock requirements.txt
+pip-compile --output-file=requirements.lock requirements.in
 echo "✅  Requirements locked."

--- a/settings.py
+++ b/settings.py
@@ -35,3 +35,5 @@ def _as_int(value: Any, default: int) -> int:
 
 
 MAX_FILTER_DEPTH: int = _as_int(_cfg.get("max_filter_depth"), DEFAULT_MAX_FILTER_DEPTH)
+
+__all__ = ["MAX_FILTER_DEPTH"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,16 +9,16 @@ python_requires = >=3.11
 install_requires =
     cachetools>=5.3,<6.0
     click>=8.1
+    kaleido>=0.2
+    numpy>=1.25
+    openpyxl>=3.1
     pandas>=2.2
+    pandas-ta>=0.3.14b0
     portalocker>=2.8
     psutil>=5.9
     pyarrow>=16
-    pandas-ta>=0.3.14b0
-    openpyxl>=3.1
-    kaleido>=0.2
-    xlsxwriter>=3.1
     pyyaml>=6
-    numpy
+    xlsxwriter>=3.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
## Summary
- specify a minimum numpy version in setup.cfg
- re-export MAX_FILTER_DEPTH from settings
- use requirements.in in lock script

## Testing
- `pre-commit run --files setup.cfg settings.py scripts/lock_requirements.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd50117f08325be1bb4a2f3496684