### PR TITLE
fix: quote filter clauses

### DIFF
--- a/tests/smoke_data/filters.yml
+++ b/tests/smoke_data/filters.yml
@@ -1,4 +1,4 @@
 - code: Tsmk1
-  clause: close > open
+  clause: "close > open"
 - code: Tsmk2
-  clause: volume > 8000
+  clause: "volume > 8000"


### PR DESCRIPTION
## Summary
- add quotes around smoke filter clauses for clarity

## Testing
- `pre-commit run --files tests/smoke_data/filters.yml`
- `pytest -q`
- `pytest --cov=./`


------
https://chatgpt.com/codex/tasks/task_e_685fd6c0be988325a6ecb6679c6b517d