### PR TITLE
Fix warnings filter for file handles

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,6 @@ import pytest
 # pytest sırasında açık dosya uyarısını bastır
 warnings.filterwarnings(
     "ignore",
-    message="Exception ignored in: <_io.FileIO",
+    message=r"Exception ignored in: <_io",
     category=pytest.PytestUnraisableExceptionWarning,
 )


### PR DESCRIPTION
## Summary
- relax warning message filter in tests

## Testing
- `pre-commit run --files tests/__init__.py`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd699f3c483258edc979b270cfaf9