### PR TITLE
fix: add numpy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ psutil>=5.9
 pyarrow >= 16
 pandas-ta==0.3.14b0
 openpyxl>=3.1
+numpy>=1.25
 plotly>=5
 kaleido>=0.2
 hypothesis>=6.102,<7


### PR DESCRIPTION
## Summary
- include numpy in runtime dependencies

## Testing
- `pre-commit run --files requirements.txt`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685fd686a4c88325be6f0894b8ce6b49