### PR TITLE
fix: expose excel_reader module

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,6 +4,12 @@ Exports wrappers around :mod:`openpyxl`'s ``ExcelFile`` handling
 implemented in :mod:`.excel_reader`.
 """
 
+from . import excel_reader
 from .excel_reader import clear_cache, open_excel_cached, read_excel_cached
 
-__all__ = ["open_excel_cached", "read_excel_cached", "clear_cache"]
+__all__ = [
+    "excel_reader",
+    "open_excel_cached",
+    "read_excel_cached",
+    "clear_cache",
+]


### PR DESCRIPTION
## Summary
- expose `excel_reader` submodule in `src.utils`

## Testing
- `pre-commit run --files src/utils/__init__.py tests/test_extra_coverage.py`
- `pytest -q`
- `coverage run -m pytest -q && coverage report`

------
https://chatgpt.com/codex/tasks/task_e_685fd663cb9083258cafaea911badde4