### PR TITLE
fix: refresh Excel cache when source file changes

### DIFF
--- a/src/utils/excel_reader.py
+++ b/src/utils/excel_reader.py
@@ -7,19 +7,33 @@ from typing import Any, Dict
 
 import pandas as pd
 
-# Global cache mapping absolute file paths to ``ExcelFile`` objects
-_excel_cache: Dict[str, pd.ExcelFile] = {}
+# Global cache mapping absolute file paths to their modification time and the
+# corresponding ``ExcelFile`` object. This ensures stale files are reloaded when
+# the underlying Excel workbook changes on disk.
+_excel_cache: Dict[str, tuple[float, pd.ExcelFile]] = {}
 
 
-def open_excel_cached(path: str, **kwargs: Any) -> pd.ExcelFile:
-    """Return a cached ``ExcelFile`` object for the given path."""
+def open_excel_cached(path: str | os.PathLike[str], **kwargs: Any) -> pd.ExcelFile:
+    """Return a cached ``ExcelFile`` object for the given path.
+
+    The cache automatically refreshes if the file's modification time changes.
+    """
     abs_path = os.path.abspath(os.fspath(path))
-    if abs_path not in _excel_cache:
-        _excel_cache[abs_path] = pd.ExcelFile(abs_path, **kwargs)
-    return _excel_cache[abs_path]
+    mtime = os.path.getmtime(abs_path)
+    cached = _excel_cache.get(abs_path)
+    if cached is None or cached[0] != mtime:
+        if cached is not None:
+            try:
+                cached[1].close()
+            except Exception:
+                pass
+        _excel_cache[abs_path] = (mtime, pd.ExcelFile(abs_path, **kwargs))
+    return _excel_cache[abs_path][1]
 
 
-def read_excel_cached(path: str, sheet_name: str, **kwargs: Any) -> pd.DataFrame:
+def read_excel_cached(
+    path: str | os.PathLike[str], sheet_name: str, **kwargs: Any
+) -> pd.DataFrame:
     """Parse ``sheet_name`` from a cached Excel workbook."""
     xls = open_excel_cached(path)
     return xls.parse(sheet_name=sheet_name, **kwargs)
@@ -27,7 +41,7 @@ def read_excel_cached(path: str, sheet_name: str, **kwargs: Any) -> pd.DataFrame
 
 def clear_cache() -> None:
     """Clear the internal ExcelFile cache and close workbooks."""
-    for xls in _excel_cache.values():
+    for _, xls in _excel_cache.values():
         try:
             xls.close()
         except Exception:

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -24,6 +24,21 @@ def test_excel_reader_cache(tmp_path):
     assert not excel_reader._excel_cache
 
 
+def test_excel_reader_cache_refresh(tmp_path):
+    path = tmp_path / "t.xlsx"
+    df1 = pd.DataFrame({"a": [1]})
+    df1.to_excel(path, index=False)
+    x1 = excel_reader.open_excel_cached(path)
+
+    df2 = pd.DataFrame({"a": [2]})
+    df2.to_excel(path, index=False)
+
+    x2 = excel_reader.open_excel_cached(path)
+    assert x1 is not x2
+    pd.testing.assert_frame_equal(excel_reader.read_excel_cached(path, "Sheet1"), df2)
+    excel_reader.clear_cache()
+
+
 def test_tarama_denetimi_summary(monkeypatch):
     df_filtreler = pd.DataFrame({"kod": ["F1"], "PythonQuery": ["close > open"]})
     df_ind = pd.DataFrame()


### PR DESCRIPTION
## Summary
- refresh cached Excel files when the workbook is modified
- test Excel cache refresh logic

## Testing
- `pre-commit run --files src/utils/excel_reader.py tests/test_extra_coverage.py`
- `coverage run --source src -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd67670408325ab9739da60b8626f