### PR TITLE
fix: prevent row multiplication when merging errors

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -545,7 +545,11 @@ def generate_full_report(
             if col not in err_df.columns:
                 err_df[col] = "-"
         if not err_df.empty and "detay" in err_df.columns:
-            err_map = err_df[["filtre_kodu", "detay"]].dropna()
+            err_map = (
+                err_df[["filtre_kodu", "detay"]]
+                .dropna()
+                .drop_duplicates(subset=["filtre_kodu"])
+            )
             # Özet
             summary_df = summary_df.merge(
                 err_map.rename(columns={"detay": "sebep_aciklama_fill"}),


### PR DESCRIPTION
## Summary
- avoid duplicate rows when merging error list
- add regression test for multiple errors on same filter

## Testing
- `pre-commit run --files report_generator.py tests/test_aciklama_filled.py`
- `pytest -q`
- `pytest --cov=. -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe50764808325bdc4a3c9f9870bca