### PR TITLE
fix: ensure ambiguous truth test runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ python_files =
     test_normalize.py
     test_portfolio_builder.py
     test_settings_fallback.py
+    test_ambiguous_truth.py
 markers =
     slow: uzun süren test
 filterwarnings =


### PR DESCRIPTION
## Summary
- ensure `test_ambiguous_truth.py` is collected by pytest

## Testing
- `pre-commit run --files pytest.ini tests/test_ambiguous_truth.py`
- `pytest --cov=src --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe516655883259c06b1785495543d