### PR TITLE
fix: avoid deprecated pandas check

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -9,6 +9,7 @@ import re
 
 import numpy as np
 import pandas as pd
+from pandas import CategoricalDtype
 
 import config
 from logging_config import get_logger
@@ -153,7 +154,7 @@ def on_isle_hisse_verileri(
         if col in df.columns:
             # Eğer sütun object (string) tipindeyse veya kategorikse, sayısal yapmaya
             # çalış
-            if df[col].dtype == "object" or pd.api.types.is_categorical_dtype(df[col]):
+            if df[col].dtype == "object" or isinstance(df[col].dtype, CategoricalDtype):
                 nan_before = df[col].isnull().sum()
                 original_type = df[col].dtype
                 df[col] = (


### PR DESCRIPTION
## Summary
- silence DeprecationWarning by switching to CategoricalDtype check

## Testing
- `pre-commit run --files preprocessor.py tests/test_auto_columns.py`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685fe52672d4832584c31aa3fcc2f62a