### PR TITLE
fix: adjust sys.path order and add backtest coverage

### DIFF
--- a/tests/test_backtest_core.py
+++ b/tests/test_backtest_core.py
@@ -4,10 +4,11 @@ import types
 
 import pandas as pd
 
-import backtest_core
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # isort: off
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
+import backtest_core  # noqa: E402
 
 sys.modules.setdefault("pandas_ta", types.SimpleNamespace(Strategy=lambda **kw: None))
 

--- a/tests/test_backtest_core_extra.py
+++ b/tests/test_backtest_core_extra.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # isort: off
+
+import backtest_core  # noqa: E402
+
+sys.modules.setdefault("pandas_ta", types.SimpleNamespace(Strategy=lambda **kw: None))
+
+
+def test_get_fiyat_no_data_nearby():
+    df = pd.DataFrame({"hisse_kodu": [], "tarih": [], "close": []})
+    out = backtest_core._get_fiyat(
+        df, pd.to_datetime("01.03.2025", dayfirst=True), "close"
+    )
+    assert np.isnan(out)
+
+
+def test_get_fiyat_invalid_value():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"],
+            "tarih": [pd.to_datetime("07.03.2025", dayfirst=True)],
+            "close": ["abc"],
+        }
+    )
+    out = backtest_core._get_fiyat(
+        df, pd.to_datetime("07.03.2025", dayfirst=True), "close"
+    )
+    assert np.isnan(out)
+
+
+def test_backtest_empty_data():
+    rapor_df, detay_df = backtest_core.calistir_basit_backtest(
+        {"F1": {"hisseler": [], "sebep": "OK", "hisse_sayisi": 0}},
+        pd.DataFrame(),
+        "10.03.2025",
+        "07.03.2025",
+    )
+    assert rapor_df.empty and detay_df.empty
+
+
+def test_backtest_invalid_dates():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"],
+            "tarih": [pd.to_datetime("07.03.2025", dayfirst=True)],
+            "close": [12.5],
+        }
+    )
+    rapor_df, detay_df = backtest_core.calistir_basit_backtest(
+        {}, df, "2025/03/10", "2025/03/07"
+    )
+    assert rapor_df.empty and detay_df.empty

--- a/tests/test_backtest_sebep_kodu.py
+++ b/tests/test_backtest_sebep_kodu.py
@@ -3,9 +3,11 @@ import sys
 
 import pandas as pd
 
-import backtest_core
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # isort: off
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import backtest_core  # noqa: E402
 
 
 def _df():


### PR DESCRIPTION
## Summary
- fix import path ordering in `test_backtest_core` tests
- cover additional branches of `backtest_core` for >90% coverage

## Testing
- `pre-commit run --files tests/test_backtest_core.py tests/test_backtest_sebep_kodu.py tests/test_backtest_core_extra.py`
- `pytest -q`
- `pytest tests/test_backtest_core.py tests/test_backtest_sebep_kodu.py tests/test_backtest_core_param.py tests/test_backtest_core_extra.py --cov=backtest_core --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe53997c883258e536095847e5d55