### PR TITLE
fix: correct date parsing in _get_fiyat

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -38,7 +38,9 @@ def _get_fiyat(
         # Tarih sütununun datetime olduğundan emin ol (preprocessor bunu yapmalı)
         if not pd.api.types.is_datetime64_any_dtype(df_hisse_veri["tarih"]):
             df_hisse_veri["tarih"] = pd.to_datetime(
-                df_hisse_veri["tarih"], errors="coerce"
+                df_hisse_veri["tarih"],
+                dayfirst=True,
+                errors="coerce",
             )
 
         veri_satiri = df_hisse_veri[df_hisse_veri["tarih"] == tarih]

--- a/tests/test_backtest_core_param.py
+++ b/tests/test_backtest_core_param.py
@@ -49,3 +49,15 @@ def test_get_fiyat_non_numeric():
     df.loc[0, "close"] = np.nan  # avoids object→float warning
     out = bc._get_fiyat(df, df.loc[0, "tarih"], "close")
     assert np.isnan(out)
+
+
+def test_get_fiyat_string_dates():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA", "AAA"],
+            "tarih": ["09.03.2025", "11.03.2025"],
+            "close": [10.0, 11.0],
+        }
+    )
+    out = bc._get_fiyat(df, pd.to_datetime("10.03.2025", dayfirst=True), "close")
+    assert out == 11.0


### PR DESCRIPTION
## Summary
- handle dayfirst string dates in `_get_fiyat`
- test `_get_fiyat` with string date inputs

## Testing
- `pre-commit run --files tests/test_backtest_core_param.py backtest_core.py`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fe54b51188325a5942eb0bec585e3