### PR TITLE
Fix path insertion in tests

### DIFF
--- a/tests/test_backtest_sebep_kodu.py
+++ b/tests/test_backtest_sebep_kodu.py
@@ -1,11 +1,12 @@
+import importlib
 import os
 import sys
 
 import pandas as pd
 
-import backtest_core
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+backtest_core = importlib.import_module("backtest_core")
 
 
 def _df():


### PR DESCRIPTION
## Summary
- ensure sys.path is modified before importing backtest_core in test

## Testing
- `pre-commit run --files tests/test_backtest_sebep_kodu.py`
- `pytest -q`
- `pytest --maxfail=1 --disable-warnings -q --cov=./`

------
https://chatgpt.com/codex/tasks/task_e_685fe5e439e88325a7bed45b2ee9885d