### PR TITLE
fix: correct cli pipeline return type

### DIFF
--- a/run.py
+++ b/run.py
@@ -243,7 +243,9 @@ def calistir_tum_sistemi(
     return rapor_df, detay_df, atlanmis
 
 
-def run_pipeline(price_csv: str, filter_def: str, output: str | Path) -> str:
+def run_pipeline(
+    price_csv: str | Path, filter_def: str | Path, output: str | Path
+) -> Path:
     """Run a minimal pipeline using provided CSV/filters and save Excel report."""
     df = pd.read_csv(
         price_csv,

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -12,9 +12,11 @@ from run import run_pipeline  # noqa: E402
 def test_cli_creates_report(tmp_path):
     out = tmp_path / "cli_report.xlsx"
     root = Path(__file__).parent / "smoke_data"
-    run_pipeline(
+    result = run_pipeline(
         price_csv=root / "prices.csv",
         filter_def=root / "filters.yml",
         output=out,
     )
     assert out.exists() and out.stat().st_size > 10_000
+    assert result == out
+    assert isinstance(result, Path)


### PR DESCRIPTION
## Summary
- fix typing of `run_pipeline` and return `Path`
- test that CLI pipeline returns the output path

## Testing
- `pre-commit run --files tests/test_cli_output.py run.py`
- `pytest -q --cov=src --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_685fe5f784c48325aadcca2738e09f09