### PR TITLE
Fix data loader cache invalidation

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -35,11 +35,9 @@ def _read_excel_cached(path: str) -> pd.DataFrame:
     return _read_excel(path)
 
 
-@lru_cache(maxsize=None)
 def load_data(path: str) -> pd.DataFrame:
-    """Read a CSV file using an in-memory cache."""
-    df = pd.read_csv(path, dtype=config.DTYPES)
-    return df
+    """Read a CSV file using the shared cache."""
+    return _cache_loader.load_csv(path)
 
 
 def load_filter_csv(path: str) -> pd.DataFrame:

--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -24,6 +24,16 @@ def test_load_data_empty(tmp_path: Path):
         data_loader.load_data(str(p))
 
 
+def test_load_data_cache_refresh(tmp_path: Path):
+    p = tmp_path / "sample.csv"
+    p.write_text("col\n1\n2")
+    df1 = data_loader.load_data(str(p))
+    assert len(df1) == 2
+    p.write_text("col\n1")
+    df2 = data_loader.load_data(str(p))
+    assert len(df2) == 1
+
+
 @pytest.mark.parametrize("colname", ["Date", "Tarih", "tarih", "TARİH", "Unnamed: 0"])
 def test_standardize_date_column(colname):
     df = pd.DataFrame({colname: ["2025-03-07"]})


### PR DESCRIPTION
## Summary
- refresh cached CSV data when file contents change
- delegate `load_data` to cache loader
- add regression test for cache refresh

## Testing
- `pre-commit run --files tests/test_data_loader_param.py finansal_analiz_sistemi/data_loader.py data_loader_cache.py`
- `pytest -q`
- `pytest --cov=finansal_analiz_sistemi -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe62f2ec0832586a8d62499474ab9