### PR TITLE
fix: improve date parsing test

### DIFF
--- a/tests/test_date_parse.py
+++ b/tests/test_date_parse.py
@@ -12,7 +12,7 @@ def test_parse_date_variants():
     }
     for raw, expected in cases.items():
         ts = parse_date(raw)
-        if expected is pd.NaT:
-            assert ts is pd.NaT
+        if pd.isna(expected):
+            assert pd.isna(ts)
         else:
             assert ts.strftime("%Y-%m-%d") == expected

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -1,13 +1,12 @@
-from datetime import datetime
+import pandas as pd
 
 
-def parse_date(date_str: str) -> datetime:
+def parse_date(date_str: str) -> pd.Timestamp:
     """Parse TR/EU or ISO date strings safely.
 
     Returns ``pd.NaT`` for invalid inputs instead of raising ``ValueError``.
     """
 
-    import pandas as pd
     from dateutil import parser
 
     if pd.isna(date_str) or str(date_str).strip() == "":
@@ -30,6 +29,6 @@ def parse_date(date_str: str) -> datetime:
 
     # Fallback to dateutil for other variants
     try:
-        return parser.parse(str(date_str), dayfirst=True)
+        return pd.to_datetime(parser.parse(str(date_str), dayfirst=True))
     except Exception:
         return pd.NaT


### PR DESCRIPTION
## Summary
- handle NaT comparison in date parse test using `pd.isna`
- convert fallback path in `parse_date` to always return `Timestamp`

## Testing
- `pre-commit run --files tests/test_date_parse.py utils/date_utils.py`
- `pytest -q --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_685fecb9940883259296f7cecc1586ca