### PR TITLE
fix: ensure run import works when installed

### DIFF
--- a/finansal_analiz_sistemi/main.py
+++ b/finansal_analiz_sistemi/main.py
@@ -6,12 +6,6 @@ import runpy
 import sys
 from pathlib import Path
 
-# Re-export frequently used helpers from ``run.py`` so tests and users can simply
-# ``import finansal_analiz_sistemi.main``.
-from run import calistir_tum_sistemi, run_pipeline
-
-__all__ = ["calistir_tum_sistemi", "run_pipeline"]
-
 
 def _ensure_project_root() -> None:
     """Add the project root directory to ``sys.path`` if missing."""
@@ -21,6 +15,14 @@ def _ensure_project_root() -> None:
         sys.path.insert(0, str(project_root))
 
 
+_ensure_project_root()
+
+# Re-export frequently used helpers from ``run.py`` so tests and users can simply
+# ``import finansal_analiz_sistemi.main``.
+from run import calistir_tum_sistemi, run_pipeline  # noqa: E402
+
+__all__ = ["calistir_tum_sistemi", "run_pipeline"]
+
+
 if __name__ == "__main__":  # pragma: no cover - manual entry point
-    _ensure_project_root()
     runpy.run_module("run", run_name="__main__")


### PR DESCRIPTION
## Summary
- call `_ensure_project_root()` before importing `run`
- ignore flake8 E402 for `run` import

## Testing
- `pre-commit run --files finansal_analiz_sistemi/main.py`
- `pytest -q`
- `coverage run -m pytest -q`
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_e_685ff115ad788325b428bbe101423bda