### PR TITLE
Fix tests path handling

### DIFF
--- a/tests/test_backtest_sebep_kodu.py
+++ b/tests/test_backtest_sebep_kodu.py
@@ -3,15 +3,11 @@ import sys
 
 import pandas as pd
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)  # isort: off
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 import backtest_core  # noqa: E402
-
-backtest_core = (
-    backtest_core  # importlib ile reload yapmıyorsan bu şekilde bırakabilirsin
-)
 
 
 def _df():


### PR DESCRIPTION
## Summary
- standardize ROOT_DIR handling for backtest tests

## Testing
- `pre-commit run --files tests/test_backtest_sebep_kodu.py`
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff0e386a48325a0b26ba47fba895a