### PR TITLE
Fix date parsing

### DIFF
--- a/tests/test_date_parse_iso.py
+++ b/tests/test_date_parse_iso.py
@@ -5,4 +5,5 @@ from utils.date_utils import parse_date
 
 def test_parse_date_iso():
     assert parse_date("2025-03-07") == pd.Timestamp("2025-03-07")
+    assert parse_date("2025/03/07") == pd.Timestamp("2025-03-07")
     assert parse_date("07.03.2025") == pd.Timestamp("2025-03-07")

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -13,8 +13,13 @@ def parse_date(date_str: str) -> datetime:
     if pd.isna(date_str) or str(date_str).strip() == "":
         return pd.NaT
 
-    # Try explicit ISO first
+    # Try explicit ISO first (YYYY-MM-DD)
     ts = pd.to_datetime(date_str, format="%Y-%m-%d", errors="coerce")
+    if ts is not pd.NaT:
+        return ts
+
+    # Handle ISO with slashes (YYYY/MM/DD)
+    ts = pd.to_datetime(date_str, format="%Y/%m/%d", errors="coerce")
     if ts is not pd.NaT:
         return ts
 


### PR DESCRIPTION
## Summary
- handle YYYY/MM/DD in parse_date
- test slashed date parsing

## Testing
- `pre-commit run --files utils/date_utils.py tests/test_date_parse_iso.py`
- `pytest -q`
- `pytest -q --cov=src --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_685fed1ea9d883258e1476c1969a24e1