### PR TITLE
fix: allow reverse axes in transpose

### DIFF
--- a/finansal_analiz_sistemi/utils/compat.py
+++ b/finansal_analiz_sistemi/utils/compat.py
@@ -14,6 +14,14 @@ def transpose(
     """
     if axis0 == axis1:
         return df.copy(deep=bool(copy))
-    if (axis0, axis1) not in ((0, 1), ("index", "columns")):
+
+    valid_pairs = {
+        (0, 1),
+        (1, 0),
+        ("index", "columns"),
+        ("columns", "index"),
+    }
+    if (axis0, axis1) not in valid_pairs:
         raise ValueError("only axes 0 and 1 are supported")
+
     return df.transpose(copy=False if copy is None else copy)

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from finansal_analiz_sistemi.utils.compat import transpose
+
+
+def test_transpose_reverse_axes():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    result = transpose(df, axis0=1, axis1=0)
+    expected = df.transpose()
+    assert result.equals(expected)
+
+
+def test_transpose_invalid_axis():
+    df = pd.DataFrame({"a": [1]})
+    with pytest.raises(ValueError):
+        transpose(df, axis0=0, axis1=2)
+
+
+def test_transpose_same_axis_returns_copy():
+    df = pd.DataFrame({"a": [1, 2]})
+    result = transpose(df, axis0=0, axis1=0)
+    assert result.equals(df)
+    assert result is not df


### PR DESCRIPTION
## Summary
- support (1,0) axis order in utils.compat.transpose
- add regression tests for transpose helper

## Testing
- `pre-commit run --files finansal_analiz_sistemi/utils/compat.py tests/test_transpose.py`
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff40768748325822a1a3bbf988223