### PR TITLE
Fix cache refresh by using nanosecond mtime

### DIFF
--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -48,7 +48,8 @@ class DataLoaderCache:
     def load_csv(self, filepath: str, **kwargs) -> pd.DataFrame:
         abs_path = os.path.abspath(filepath)
         key = (abs_path, "__csv__")
-        mtime = os.path.getmtime(abs_path)
+        # Use nanosecond precision to detect rapid file updates
+        mtime = os.stat(abs_path).st_mtime_ns
         cached = self.loaded_data.get(key)
         if cached:
             cached_mtime, df_cached = cached


### PR DESCRIPTION
## Summary
- detect CSV modifications with nanosecond precision so cache invalidates

## Testing
- `pre-commit run --files data_loader_cache.py`
- `pytest -q --cov=src --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_686045df946c8325b8b01387ad9a5c26