### PR TITLE
Add stub packages

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,9 @@ black==24.4.2
 flake8==7.0.0
 pre-commit
 pytest
+pandas-stubs
+types-openpyxl
+types-psutil
+types-PyYAML
+types-cachetools
+types-python-dateutil


### PR DESCRIPTION
## Summary
- add pandas/openpyxl/psutil/yaml/cachetools/python-dateutil stubs

## Testing
- `pip install -r requirements-dev.txt`
- `mypy src tests` *(fails: Item "Workbook" of "Workbook | Any" has no attribute "add_worksheet" etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860501136588325a033387346566836