### PR TITLE
Enable streaming Excel writes & parallel coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+concurrency = multiprocessing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,16 @@ jobs:
       - uses: pre-commit/action@v3.0.1
       - name: Type-check (mypy – toleranslı)
         run: mypy src tests || true
-      - name: Run unit tests + coverage
-        run: pytest -q --cov=src --cov-report=xml
+      - name: Run tests (parallel coverage)
+        run: |
+          coverage run -m pytest -q --parallel
         timeout-minutes: 10
+      - name: Combine & export coverage
+        run: |
+          coverage combine
+          coverage xml
+        env:
+          COVERAGE_PROCESS_START: .coveragerc
       - name: Upload coverage artefact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: mypy src tests || true
       - name: Run tests (parallel coverage)
         run: |
-          coverage run -m pytest -q --parallel
+          coverage run -m pytest -q
         timeout-minutes: 10
       - name: Combine & export coverage
         run: |

--- a/report_generator.py
+++ b/report_generator.py
@@ -266,7 +266,12 @@ def kaydet_uc_sekmeli_excel(
         logger_param = logger
     fname = Path(fname)
     fname.parent.mkdir(parents=True, exist_ok=True)
-    with pd.ExcelWriter(fname, engine="xlsxwriter", mode="w") as w:
+    with pd.ExcelWriter(
+        fname,
+        engine="xlsxwriter",
+        engine_kwargs={"options": {"constant_memory": True}},
+        mode="w",
+    ) as w:
         safe_to_excel(ozet_df, w, sheet_name="Özet", index=False)
         safe_to_excel(detay_df, w, sheet_name="Detay", index=False)
         safe_to_excel(istatistik_df, w, sheet_name="İstatistik", index=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ hypothesis>=6.102,<7
 xlsxwriter>=3.1
 pyyaml>=6
 pytest-timeout>=2.2
+coverage>=7.0


### PR DESCRIPTION
## Summary
- lower memory usage when exporting Excel reports
- add coverage to requirements
- enable parallel safe coverage collection

## Testing
- `pytest -q`
- `coverage run -m pytest -q --parallel` *(fails: unrecognized arguments)*
- `coverage combine`
- `coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_68606bfc1c4c8325bef94218d1dba28d