### PR TITLE
Fix test discovery for date parsing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,8 @@ python_files =
     test_settings_fallback.py
     test_data_gap.py
     test_ambiguous_truth.py
+    test_date_parse_iso.py
+    test_date_parse.py
 
 markers =
     slow: uzun süren test


### PR DESCRIPTION
## Summary
- include date_parse tests in pytest.ini

## Testing
- `pre-commit run -a`
- `pytest -q`
- `coverage run -m pytest -q && coverage report -m | head`

------
https://chatgpt.com/codex/tasks/task_e_68606fb3a9e483259f65cc9ac6b02acf