### PR TITLE
Fix tests with optional hypothesis & Excel writer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,10 @@ import logging
 import sys
 from types import ModuleType, SimpleNamespace
 
-import hypothesis
+try:
+    import hypothesis
+except Exception:  # pragma: no cover - optional dependency missing
+    hypothesis = None
 import numpy as np  # mevcut test yardımcıları için gerekli
 import pandas as pd  # mevcut test yardımcıları için gerekli
 import pytest  # pytest fixture’ları için gerekli
@@ -40,12 +43,13 @@ def _sanitize_sys_modules() -> None:
 # Hemen yama uygulayarak koleksiyon hatalarını önle.
 _sanitize_sys_modules()
 
-hypothesis.settings.register_profile(
-    "ci",
-    max_examples=10,
-    deadline=1000,
-)
-hypothesis.settings.load_profile("ci")
+if hypothesis is not None:
+    hypothesis.settings.register_profile(
+        "ci",
+        max_examples=10,
+        deadline=1000,
+    )
+    hypothesis.settings.load_profile("ci")
 
 # ``SimpleNamespace`` için basit bir ``__hash__`` ekleyerek Hypothesis'in
 # set oluşturma sırasında hata vermemesini sağla.

--- a/report_generator.py
+++ b/report_generator.py
@@ -269,7 +269,6 @@ def kaydet_uc_sekmeli_excel(
     with pd.ExcelWriter(
         fname,
         engine="xlsxwriter",
-        engine_kwargs={"options": {"constant_memory": True}},
         mode="w",
     ) as w:
         safe_to_excel(ozet_df, w, sheet_name="Özet", index=False)
@@ -581,7 +580,6 @@ def generate_full_report(
     with pd.ExcelWriter(
         out_path,
         engine="xlsxwriter",
-        engine_kwargs={"options": {"constant_memory": True}},
     ) as wr:
         ws_ozet = wr.book.add_worksheet("Özet")
         wr.sheets["Özet"] = ws_ozet

--- a/tests/test_error_sheet_presence.py
+++ b/tests/test_error_sheet_presence.py
@@ -52,16 +52,16 @@ def report_path(tmp_path):
 
 
 def test_error_sheet_presence(report_path):
-    xls = pd.ExcelFile(report_path)
-    assert "Hatalar" in xls.sheet_names
-    df = pd.read_excel(report_path, "Hatalar")
-    assert not df.empty
-    critical = [
-        "hata_tipi",
-        "eksik_ad",
-        "detay",
-        "cozum_onerisi",
-        "reason",
-        "hint",
-    ]
-    assert df[critical].notna().all(axis=None)
+    with pd.ExcelFile(report_path) as xls:
+        assert "Hatalar" in xls.sheet_names
+        df = pd.read_excel(report_path, "Hatalar")
+        assert not df.empty
+        critical = [
+            "hata_tipi",
+            "eksik_ad",
+            "detay",
+            "cozum_onerisi",
+            "reason",
+            "hint",
+        ]
+        assert df[critical].notna().all(axis=None)


### PR DESCRIPTION
## Summary
- guard optional hypothesis imports so missing dependency skips tests
- avoid constant_memory mode when writing Excel files
- close ExcelFile in error sheet test to avoid warnings

## Testing
- `pytest -q`
- `pre-commit run --files conftest.py report_generator.py tests/test_error_sheet_presence.py`

------
https://chatgpt.com/codex/tasks/task_e_686075f7ea3483259cfd092272f119e5