### PR TITLE
Fix helper module typings

### DIFF
--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,3 +1,6 @@
+__all__ = ["unique_name"]
+
+
 def unique_name(base: str, seen: set[str]) -> str:
     """Return a unique column name by appending _1, _2, ..."""
     if base not in seen:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -13,6 +13,14 @@ import pandas as pd
 
 from logging_config import get_logger
 
+__all__ = [
+    "crosses_above",
+    "crosses_below",
+    "extract_columns_from_filters",
+    "extract_columns_from_filters_cached",
+    "purge_old_logs",
+]
+
 logger = get_logger(__name__)
 
 

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -1,14 +1,15 @@
 from datetime import datetime
+from typing import Union
+
+import pandas as pd
+from dateutil import parser
 
 
-def parse_date(date_str: str) -> datetime:
+def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | type(pd.NaT):
     """Parse TR/EU or ISO date strings safely.
 
     Returns ``pd.NaT`` for invalid inputs instead of raising ``ValueError``.
     """
-
-    import pandas as pd
-    from dateutil import parser
 
     if pd.isna(date_str) or str(date_str).strip() == "":
         return pd.NaT

--- a/utils/error_map.py
+++ b/utils/error_map.py
@@ -1,5 +1,7 @@
 from typing import Dict, Tuple
 
+__all__ = ["get_reason_hint"]
+
 REASON_MAP: Dict[str, Tuple[str, str]] = {
     "ZeroDivisionError": (
         "S\u0131f\u0131ra B\u00f6lme",
@@ -17,4 +19,5 @@ DEFAULT_REASON: Tuple[str, str] = ("Bilinmeyen Hata", "Detay i\u00e7in loglara b
 def get_reason_hint(exc: Exception, locale: str = "tr") -> Tuple[str, str]:
     """Return a user friendly reason/hint tuple for given exception."""
 
+    # ``locale`` is reserved for future localization support
     return REASON_MAP.get(type(exc).__name__, DEFAULT_REASON)

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -9,7 +9,8 @@ class FailedFilter:
     hint: str = ""
 
 
-failures = defaultdict(list)  # {'indicators': [...], 'filters': [...], ...}
+# {'indicators': [...], 'filters': [...], ...}
+failures: defaultdict[str, list[FailedFilter]] = defaultdict(list)
 
 
 def clear_failures() -> None:
@@ -23,6 +24,8 @@ def log_failure(category: str, item: str, reason: str, hint: str = "") -> None:
 
 
 def get_failures(as_dict: bool = False):
+    """Return collected failures."""
+
     if as_dict:
         return {c: [asdict(r) for r in rows] for c, rows in failures.items()}
     return failures


### PR DESCRIPTION
## Summary
- add explicit exports to naming utilities
- export helper functions from utils package
- improve parse_date typing
- expose get_reason_hint and clarify locale note
- type annotate failure tracker

## Testing
- `pre-commit run --files utilities/naming.py utils/__init__.py utils/compat/__init__.py utils/date_utils.py utils/error_map.py utils/failure_tracker.py`
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686083b0502083259f15d4e2a9299be7