### PR TITLE
fix: polish helper utilities

### DIFF
--- a/utils/memory_profile.py
+++ b/utils/memory_profile.py
@@ -8,6 +8,7 @@ class mem_profile:
     def __enter__(self):
         self.proc = psutil.Process(os.getpid())
         self.start = self.proc.memory_info().rss
+        return self
 
     def __exit__(self, *exc):
         peak = self.proc.memory_info().rss

--- a/utils/pandas_option_safe.py
+++ b/utils/pandas_option_safe.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from contextlib import contextmanager
 
 import pandas as pd
@@ -13,7 +14,7 @@ def ensure_option(name: str, value) -> None:
 
 
 @contextmanager
-def option_context(name: str, value):
+def option_context(name: str, value) -> Iterator[None]:
     """Like ``pd.option_context`` but ignores unknown-option errors."""
     try:
         with pd.option_context(name, value):

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -10,18 +10,18 @@ def purge_old_logs(
 ) -> int:
     """Purge ``*.log`` files older than ``keep_days`` days in ``log_dir``.
 
-    Returns the number of files considered for deletion.
+    Returns the number of matching files (even in dry-run mode).
     """
     cutoff = datetime.now() - timedelta(days=keep_days)
-    deleted = 0
+    count = 0
     for f in log_dir.glob("*.log*"):
         if datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
             if dry_run:
                 print(f"[DRY-RUN] Would delete {f}")
             else:
                 f.unlink()
-            deleted += 1
-    return deleted
+            count += 1
+    return count
 
 
 if __name__ == "__main__":

--- a/validators.py
+++ b/validators.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+__all__ = ["ValidationError"]
+
 
 @dataclass
 class ValidationError:


### PR DESCRIPTION
## Summary
- improve `mem_profile` as context manager
- add typing for pandas option helpers
- clarify log purging helper semantics
- expose `ValidationError` symbol

## Testing
- `pre-commit run --files utils/log_cleaner.py utils/memory_profile.py utils/pandas_option_safe.py utils/purge_old_logs.py validators.py`
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_686086096eec832586080465aa46b6b1