### PR TITLE
fix: handle 2-column filter csv

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -43,6 +43,13 @@ def load_data(path: str) -> pd.DataFrame:
 def load_filter_csv(path: str) -> pd.DataFrame:
     """CSV'yi okunur ve kolon hizasını garanti eder."""
 
+    # Önce başlıksız okuma dene (eski format: sadece 2 kolon)
+    raw = pd.read_csv(path, sep=";")
+    if list(raw.columns) == ["filtre_kodu", "PythonQuery"]:
+        raw.insert(0, "tarih", pd.NA)
+        raw.columns = COLS
+        return raw
+
     df = pd.read_csv(
         path,
         names=COLS,  # beklenen kolon listesi


### PR DESCRIPTION
## Summary
- fix misaligned columns when a filter CSV contains only two columns

## Testing
- `pre-commit run --files finansal_analiz_sistemi/data_loader.py`
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686087d53eec83258e6e037c367d64c5