### PR TITLE
Fix CLI crash by defining CORE_INDICATORS

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,6 +48,14 @@ DTYPES_MAP: dict[str, str] = {
 # chunk size for indicator calculation
 CHUNK_SIZE: int = 1
 
+# minimal indicator subset used for smoke tests and CLI defaults
+CORE_INDICATORS: list[str] = [
+    "ema_10",
+    "ema_20",
+    "rsi_14",
+    "macd",
+]
+
 # ---------------------------------------------------------------------------
 # Optional defaults
 if "ALIM_ZAMANI" not in globals():


### PR DESCRIPTION
## Summary
- add `CORE_INDICATORS` list to `config.py`

## Testing
- `pytest -q`
- `python -m finansal.cli --csv /tmp/small.csv --refresh-cache --ind-set core --chunk-size 1`

------
https://chatgpt.com/codex/tasks/task_e_6860a523b9b8832592e811ece13d7ae0