### PR TITLE
Fix missing constants and run sample backtest

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,14 @@ IS_COLAB: bool = False
 CACHE_PATH: Path = Path("veri/birlesik_hisse_verileri.parquet")
 DEFAULT_CSV_PATH: Path = Path("data/raw/all_prices.csv")
 
+# default data directory and filename patterns
+VERI_KLASORU: Path = Path("tests/smoke_data")
+HISSE_DOSYA_PATTERN: str = str(VERI_KLASORU / "*.csv")
+PARQUET_ANA_DOSYA_YOLU: Path = CACHE_PATH
+
+# default filter rules CSV path
+FILTRE_DOSYA_YOLU: Path = Path("veri/15.csv")
+
 # Load optional configuration overrides from 'config.yml'
 _CFG_FILE = Path(__file__).with_name("config.yml")
 if _CFG_FILE.exists():

--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -31,3 +31,16 @@ INDIKATOR_AD_ESLESTIRME.setdefault("its_9", "ichimoku_conversionline")
 
 # Legacy `cfg` alias
 cfg = sys.modules.setdefault("cfg", sys.modules[__name__])
+
+# default chunk size for indicator calculations
+CHUNK_SIZE: int = 1
+
+# -------------------------------------------------
+# Minimal gösterge listesi – AttributeError almamak için gereklidir
+# -------------------------------------------------
+CORE_INDICATORS = [
+    "ema_10",  # 10-periyot EMA
+    "ema_20",  # 20-periyot EMA
+    "rsi_14",  # 14-periyot RSI
+    "macd",  # MACD (12-26-9 varsayılan)
+]


### PR DESCRIPTION
## Summary
- define default data paths in `config.py`
- export `CHUNK_SIZE` and `CORE_INDICATORS` from package config

## Testing
- `python -u -m finansal_analiz_sistemi --tarama 07.03.2025 --satis 10.03.2025 --output rapor.xlsx`

------
https://chatgpt.com/codex/tasks/task_e_6860ac4a0938832581e823b623dc4e76