### PR TITLE
Improve docs and typing for helper functions

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -95,7 +95,24 @@ def calistir_basit_backtest(
     tarama_tarihi_str: str,
     logger_param=None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Filtre sonuçlarını kullanarak basit backtest çalıştırır."""
+    """Run a simple backtest using the given filter results.
+
+    Parameters
+    ----------
+    filtre_sonuc_dict : dict
+        Mapping of filter codes to selected stocks.
+    df_tum_veri : pd.DataFrame
+        Full price dataset containing all tickers.
+    satis_tarihi_str : str
+        Sale date in ``dd.mm.yyyy`` format.
+    tarama_tarihi_str : str
+        Screening date in ``dd.mm.yyyy`` format.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        Tuple of summary and detail DataFrames.
+    """
     if logger_param is None:
         logger_param = logger
     fn_logger = logger_param

--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -77,11 +77,15 @@ class DataLoaderCache:
 
 
 def _read_parquet(ticker: str, start: str, end: str) -> pd.DataFrame:
+    """Simulate reading parquet data for a ticker between two dates."""
+
     dates = pd.date_range(start, end, freq="D")
     return pd.DataFrame({"hisse_kodu": ticker, "tarih": dates})
 
 
-def get_df(ticker: str, start, end):
+def get_df(ticker: str, start: str, end: str) -> pd.DataFrame:
+    """Return cached DataFrame for ``ticker`` between ``start`` and ``end``."""
+
     key = f"{ticker}_{start}_{end}"
     if key in CACHE:
         return CACHE[key]
@@ -91,4 +95,6 @@ def get_df(ticker: str, start, end):
 
 
 def clear_cache() -> None:
+    """Empty the global cache."""
+
     CACHE.clear()

--- a/log_to_health.py
+++ b/log_to_health.py
@@ -45,7 +45,18 @@ def _apply_return_colors(ws, column_index):
 
 
 def generate(log_path: str | os.PathLike, excel_paths: list[str | os.PathLike]) -> str:
-    """Create health report from log and excel files."""
+    """Generate an XLSX health report from a log file and excel results.
+
+    Args:
+        log_path: Path to the log file that produced the run.
+        excel_paths: List of Excel workbooks to aggregate. Only ``Özet`` and
+            ``Detay`` sheets are read when present.
+
+    Returns
+    -------
+    str
+        Path to the generated health report workbook.
+    """
     run_dir = Path(log_path).resolve().parent
     run_dir.mkdir(exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M")

--- a/report_generator.py
+++ b/report_generator.py
@@ -86,7 +86,9 @@ def generate_summary(results: list[dict]) -> pd.DataFrame:
     return summary_df
 
 
-def add_error_sheet(writer, error_list: Iterable[tuple]):
+def add_error_sheet(writer: pd.ExcelWriter, error_list: Iterable[tuple]) -> None:
+    """Write error list to a ``Hatalar`` sheet if any errors are present."""
+
     if error_list:
         safe_to_excel(
             pd.DataFrame(error_list, columns=["timestamp", "level", "message"]),
@@ -101,6 +103,8 @@ def olustur_ozet_rapor(
     cikti_klasoru: str,
     logger_param=None,
 ) -> str | None:
+    """Create CSV summary report from raw backtest results."""
+
     if logger_param is None:
         logger_param = logger
     os.makedirs(cikti_klasoru, exist_ok=True)
@@ -153,6 +157,8 @@ def olustur_hisse_bazli_rapor(
     cikti_klasoru: str,
     logger_param=None,
 ) -> str | None:
+    """Create per-stock CSV report from raw results."""
+
     if logger_param is None:
         logger_param = logger
     os.makedirs(cikti_klasoru, exist_ok=True)
@@ -199,6 +205,8 @@ def olustur_hisse_bazli_rapor(
 
 
 def olustur_hatali_filtre_raporu(writer, kontrol_df) -> None:
+    """Write problematic filters to ``Hatalar`` sheet if provided."""
+
     if isinstance(kontrol_df, dict):
         hatalar = kontrol_df.get("hatalar", [])
         if hatalar:
@@ -241,6 +249,8 @@ def olustur_excel_raporu(
     fname: str | Path,
     logger_param=None,
 ) -> Path | None:
+    """Create a three-sheet Excel report from provided records."""
+
     if logger_param is None:
         logger_param = logger
     if not kayitlar:
@@ -262,6 +272,8 @@ def kaydet_uc_sekmeli_excel(
     istatistik_df: pd.DataFrame,
     logger_param=None,
 ) -> Path:
+    """Save ``ozet``, ``detay`` and ``istatistik`` DataFrames into ``fname``."""
+
     if logger_param is None:
         logger_param = logger
     fname = Path(fname)
@@ -299,6 +311,8 @@ def kaydet_raporlar(
     filepath: Path,
     logger_param=None,
 ) -> Path:
+    """Append three report sheets to an existing workbook."""
+
     if logger_param is None:
         logger_param = logger
     filepath = Path(filepath)
@@ -509,6 +523,8 @@ def generate_full_report(
     quick: bool = True,
     logger_param=None,
 ) -> Path:
+    """Create full Excel report with optional charts and error sheets."""
+
     if logger_param is None:
         logger_param = logger
     if keep_legacy:

--- a/report_utils.py
+++ b/report_utils.py
@@ -44,6 +44,8 @@ def build_ozet_df(
     tarama_tarihi: str = "",
     satis_tarihi: str = "",
 ) -> pd.DataFrame:
+    """Return summary dataframe in canonical column order."""
+
     df = report_stats.build_ozet_df(
         summary_df,
         detail_df,
@@ -58,6 +60,8 @@ def build_detay_df(
     detail_df: pd.DataFrame,
     strateji: str | None = None,
 ) -> pd.DataFrame:
+    """Return detail dataframe in canonical column order."""
+
     df = report_stats.build_detay_df(
         summary_df,
         detail_df,
@@ -67,6 +71,8 @@ def build_detay_df(
 
 
 def build_stats_df(ozet_df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate summary statistics from the provided dataframe."""
+
     df = report_stats.build_stats_df(ozet_df)
     return df.reindex(columns=DEFAULT_STATS_COLS)
 
@@ -75,7 +81,9 @@ def plot_summary_stats(
     ozet_df: pd.DataFrame,
     detail_df: pd.DataFrame,
     std_threshold: float = 5.0,
-):
+) -> "Figure":
+    """Create plotly ``Figure`` summarizing best and worst filters."""
+
     return report_stats.plot_summary_stats(
         ozet_df,
         detail_df,

--- a/report_utils.py
+++ b/report_utils.py
@@ -1,7 +1,12 @@
 # report_utils.py
+from typing import TYPE_CHECKING
+
 import pandas as pd
 from openpyxl.chart import BarChart, Reference
 from openpyxl.utils import get_column_letter
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints
+    from plotly.graph_objects import Figure
 
 import report_stats
 
@@ -81,7 +86,7 @@ def plot_summary_stats(
     ozet_df: pd.DataFrame,
     detail_df: pd.DataFrame,
     std_threshold: float = 5.0,
-) -> "Figure":
+) -> Figure:
     """Create plotly ``Figure`` summarizing best and worst filters."""
 
     return report_stats.plot_summary_stats(

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -24,12 +24,16 @@ __all__ = [
 logger = get_logger(__name__)
 
 
-def _align(a: pd.Series, b: pd.Series):
+def _align(a: pd.Series, b: pd.Series) -> tuple[pd.Series, pd.Series]:
+    """Return the pair aligned to their intersection index."""
+
     x, y = a.align(b, join="inner")
     return x, y
 
 
 def crosses_above(a: pd.Series, b: pd.Series) -> pd.Series:
+    """Return ``True`` where ``a`` crosses above ``b``."""
+
     if a is None or b is None:
         return pd.Series(False, index=[])
     x, y = _align(a, b)
@@ -37,6 +41,8 @@ def crosses_above(a: pd.Series, b: pd.Series) -> pd.Series:
 
 
 def crosses_below(a: pd.Series, b: pd.Series) -> pd.Series:
+    """Return ``True`` where ``a`` crosses below ``b``."""
+
     if a is None or b is None:
         return pd.Series(False, index=[])
     x, y = _align(a, b)


### PR DESCRIPTION
## Summary
- document `crosses_above` and `crosses_below`
- add docstrings for data loader cache helpers
- expand health report generation docs
- document report generation helpers
- clarify backtest helper usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d70a37088325acb8faf18f4cbbda