### PR TITLE
Fix pytest discovery after packaging changes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,23 +1,6 @@
 [pytest]
-python_files =
-    test_parquet_cache.py
-    test_dtypes_ok.py
-    test_filter_none_skipped.py
-    test_join_handles_none.py
-    test_detay_not_empty.py
-    test_duplicate_filter.py
-    test_setup_logging.py
-    test_logging_setup.py
-    test_rotate_logging.py
-    test_extra_coverage.py
-    test_lazy_chunk.py
-    test_normalize.py
-    test_portfolio_builder.py
-    test_settings_fallback.py
-    test_data_gap.py
-    test_ambiguous_truth.py
-    test_date_parse_iso.py
-    test_date_parse.py
+# Otomatik keşif için tüm ``test_*.py`` dosyalarını çalıştır
+python_files = test_*.py
 
 markers =
     slow: mark slow tests


### PR DESCRIPTION
## Summary
- restore default pytest discovery to run all tests

## Testing
- `python -m pytest -q tests/test_join_handles_none.py`
- `python -m pytest -q` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_e_6862983a34d48325b0c779b386d467ea