### PR TITLE
Add regression test for config path variables

### DIFF
--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -25,3 +25,14 @@ def test_yaml_values_loaded():
     """YAML'deki değerler modüle yüklenmeli."""
     assert config.get("filter_weights", {}).get("T31") == 0.0
     assert "T31" in config.get("passive_filters", [])
+
+
+
+def test_config_exposes_paths():
+    for name in [
+        "VERI_KLASORU",
+        "HISSE_DOSYA_PATTERN",
+        "PARQUET_ANA_DOSYA_YOLU",
+        "FILTRE_DOSYA_YOLU",
+    ]:
+        assert hasattr(config, name)

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -27,7 +27,6 @@ def test_yaml_values_loaded():
     assert "T31" in config.get("passive_filters", [])
 
 
-
 def test_config_exposes_paths():
     for name in [
         "VERI_KLASORU",


### PR DESCRIPTION
## Summary
- ensure config exposes the expected path constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f40fa8508325b90f7c0f8f439037