### PR TITLE
Update pytest discovery

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,23 +1,7 @@
 [pytest]
-python_files =
-    test_parquet_cache.py
-    test_dtypes_ok.py
-    test_filter_none_skipped.py
-    test_join_handles_none.py
-    test_detay_not_empty.py
-    test_duplicate_filter.py
-    test_setup_logging.py
-    test_logging_setup.py
-    test_rotate_logging.py
-    test_extra_coverage.py
-    test_lazy_chunk.py
-    test_normalize.py
-    test_portfolio_builder.py
-    test_settings_fallback.py
-    test_data_gap.py
-    test_ambiguous_truth.py
-    test_date_parse_iso.py
-    test_date_parse.py
+# Use a glob pattern so that any file named ``test_*.py`` will be
+# automatically discovered and executed by pytest.
+python_files = test_*.py
 
 markers =
     slow: mark slow tests


### PR DESCRIPTION
## Summary
- simplify pytest test file discovery by using a wildcard pattern

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'data_loader')*

------
https://chatgpt.com/codex/tasks/task_e_6862fff9e66483258fc8ac9314e48169