### PR TITLE
Fix import errors and logging tests

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,28 @@
+"""Compatibility wrapper for ``finansal_analiz_sistemi.data_loader``.
+
+Explicit imports keep flake8 happy while exposing the same public API.
+"""
+
+from finansal_analiz_sistemi.data_loader import (
+    _standardize_date_column,
+    _standardize_ohlcv_columns,
+    check_and_create_dirs,
+    load_data,
+    load_excel_katalogu,
+    load_filter_csv,
+    read_prices,
+    yukle_filtre_dosyasi,
+    yukle_hisse_verileri,
+)
+
+__all__ = [
+    "load_data",
+    "read_prices",
+    "load_filter_csv",
+    "check_and_create_dirs",
+    "load_excel_katalogu",
+    "_standardize_date_column",
+    "_standardize_ohlcv_columns",
+    "yukle_filtre_dosyasi",
+    "yukle_hisse_verileri",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,23 +1,7 @@
 [pytest]
-python_files =
-    test_parquet_cache.py
-    test_dtypes_ok.py
-    test_filter_none_skipped.py
-    test_join_handles_none.py
-    test_detay_not_empty.py
-    test_duplicate_filter.py
-    test_setup_logging.py
-    test_logging_setup.py
-    test_rotate_logging.py
-    test_extra_coverage.py
-    test_lazy_chunk.py
-    test_normalize.py
-    test_portfolio_builder.py
-    test_settings_fallback.py
-    test_data_gap.py
-    test_ambiguous_truth.py
-    test_date_parse_iso.py
-    test_date_parse.py
+# Use a glob pattern so that any file named ``test_*.py`` will be
+# automatically discovered and executed by pytest.
+python_files = test_*.py
 
 markers =
     slow: mark slow tests

--- a/report_utils.py
+++ b/report_utils.py
@@ -1,4 +1,6 @@
 # report_utils.py
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pandas as pd

--- a/run.py
+++ b/run.py
@@ -178,9 +178,8 @@ def raporla(rapor_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
 
 # Ana modülleri import et
 try:
-    import data_loader
-
     import backtest_core
+    import data_loader
     import filter_engine
     import indicator_calculator
     import preprocessor

--- a/utils/log_cleaner.py
+++ b/utils/log_cleaner.py
@@ -42,7 +42,10 @@ def purge_old_logs(
                     lock.unlink(missing_ok=True)
                     deleted += 1
     for fp in Path(dir_path).glob("*.lock"):
-        if not fp.with_suffix(".log").exists() and datetime.fromtimestamp(fp.stat().st_mtime) < cutoff:
+        if (
+            not fp.with_suffix(".log").exists()
+            and datetime.fromtimestamp(fp.stat().st_mtime) < cutoff
+        ):
             _LOG.info("%s %s", "Would delete" if dry_run else "Deleted", fp)
             if not dry_run:
                 fp.unlink(missing_ok=True)

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -29,7 +29,10 @@ def purge_old_logs(
                     lock.unlink()
                 count += 1
     for f in log_dir.glob("*.lock"):
-        if not f.with_suffix(".log").exists() and datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
+        if (
+            not f.with_suffix(".log").exists()
+            and datetime.fromtimestamp(f.stat().st_mtime) < cutoff
+        ):
             if dry_run:
                 print(f"[DRY-RUN] Would delete {f}")
             else:

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -14,14 +14,27 @@ def purge_old_logs(
     """
     cutoff = datetime.now() - timedelta(days=keep_days)
     count = 0
-    for pattern in ("*.log*", "*.lock"):
-        for f in log_dir.glob(pattern):
-            if datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
+    for f in log_dir.glob("*.log*"):
+        if datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
+            if dry_run:
+                print(f"[DRY-RUN] Would delete {f}")
+            else:
+                f.unlink()
+            count += 1
+            lock = f.with_suffix(".lock")
+            if lock.exists():
                 if dry_run:
-                    print(f"[DRY-RUN] Would delete {f}")
+                    print(f"[DRY-RUN] Would delete {lock}")
                 else:
-                    f.unlink()
+                    lock.unlink()
                 count += 1
+    for f in log_dir.glob("*.lock"):
+        if not f.with_suffix(".log").exists() and datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
+            if dry_run:
+                print(f"[DRY-RUN] Would delete {f}")
+            else:
+                f.unlink()
+            count += 1
     return count
 
 


### PR DESCRIPTION
## Summary
- add a shim `data_loader` module for backward compatibility
- ensure annotations don't require runtime imports in `report_utils`
- delete log lock files when purging old logs
- update command-line log cleanup accordingly
- replace star-imports in `data_loader.py` to satisfy flake8

## Testing
- `pytest tests/test_log_clean.py::test_purge_old_logs[False] -q`
- `pytest tests/test_report_chart.py tests/test_report_utils.py -q`
- `pytest tests/test_data_loader_param.py::test_load_data_param -q`


------
https://chatgpt.com/codex/tasks/task_e_6862fff9e66483258fc8ac9314e48169