### PR TITLE
Fix import errors and logging tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           python -m pip install -e .   # editable install, varsa setup.cfg
           pip install -q "hypothesis>=6.102,<7"
           pip install -q pre-commit mypy pytest-cov
+          pip install -q -r requirements-dev.txt  # <-- TEST BAĞIMLILIKLARI BURADA
       - uses: pre-commit/action@v3.0.1
       - name: Type-check (mypy – toleranslı)
         run: mypy src tests || true

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,28 @@
+"""Compatibility wrapper for ``finansal_analiz_sistemi.data_loader``.
+
+Explicit imports keep flake8 happy while exposing the same public API.
+"""
+
+from finansal_analiz_sistemi.data_loader import (
+    _standardize_date_column,
+    _standardize_ohlcv_columns,
+    check_and_create_dirs,
+    load_data,
+    load_excel_katalogu,
+    load_filter_csv,
+    read_prices,
+    yukle_filtre_dosyasi,
+    yukle_hisse_verileri,
+)
+
+__all__ = [
+    "load_data",
+    "read_prices",
+    "load_filter_csv",
+    "check_and_create_dirs",
+    "load_excel_katalogu",
+    "_standardize_date_column",
+    "_standardize_ohlcv_columns",
+    "yukle_filtre_dosyasi",
+    "yukle_hisse_verileri",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,23 +1,7 @@
 [pytest]
-python_files =
-    test_parquet_cache.py
-    test_dtypes_ok.py
-    test_filter_none_skipped.py
-    test_join_handles_none.py
-    test_detay_not_empty.py
-    test_duplicate_filter.py
-    test_setup_logging.py
-    test_logging_setup.py
-    test_rotate_logging.py
-    test_extra_coverage.py
-    test_lazy_chunk.py
-    test_normalize.py
-    test_portfolio_builder.py
-    test_settings_fallback.py
-    test_data_gap.py
-    test_ambiguous_truth.py
-    test_date_parse_iso.py
-    test_date_parse.py
+# Use a glob pattern so that any file named ``test_*.py`` will be
+# automatically discovered and executed by pytest.
+python_files = test_*.py
 
 markers =
     slow: mark slow tests

--- a/report_utils.py
+++ b/report_utils.py
@@ -1,4 +1,6 @@
 # report_utils.py
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pandas as pd

--- a/utils/log_cleaner.py
+++ b/utils/log_cleaner.py
@@ -28,11 +28,26 @@ def purge_old_logs(
 
     cutoff = datetime.now() - timedelta(days=days)
     deleted = 0
-    for pattern in ("*.log", "*.lock"):
-        for fp in Path(dir_path).glob(pattern):
-            if datetime.fromtimestamp(fp.stat().st_mtime) < cutoff:
-                _LOG.info("%s %s", "Would delete" if dry_run else "Deleted", fp)
+    for fp in Path(dir_path).glob("*.log"):
+        if datetime.fromtimestamp(fp.stat().st_mtime) < cutoff:
+            _LOG.info("%s %s", "Would delete" if dry_run else "Deleted", fp)
+            if not dry_run:
+                fp.unlink(missing_ok=True)
+                deleted += 1
+            # remove matching lock even if newer
+            lock = fp.with_suffix(".lock")
+            if lock.exists():
+                _LOG.info("%s %s", "Would delete" if dry_run else "Deleted", lock)
                 if not dry_run:
-                    fp.unlink(missing_ok=True)
+                    lock.unlink(missing_ok=True)
                     deleted += 1
+    for fp in Path(dir_path).glob("*.lock"):
+        if (
+            not fp.with_suffix(".log").exists()
+            and datetime.fromtimestamp(fp.stat().st_mtime) < cutoff
+        ):
+            _LOG.info("%s %s", "Would delete" if dry_run else "Deleted", fp)
+            if not dry_run:
+                fp.unlink(missing_ok=True)
+                deleted += 1
     return deleted


### PR DESCRIPTION
## Summary
- add a shim `data_loader` module for backward compatibility
- ensure annotations don't require runtime imports in `report_utils`
- delete log lock files when purging old logs
- update command-line log cleanup accordingly
- install dev requirements in CI
- simplify pytest discovery with a glob pattern

## Testing
- `pre-commit run --files .github/workflows/ci.yml data_loader.py pytest.ini report_utils.py utils/log_cleaner.py utils/purge_old_logs.py`
- `pytest tests/test_log_clean.py::test_purge_old_logs[False] -q`
- `pytest tests/test_report_chart.py tests/test_report_utils.py -q`
- `pytest tests/test_data_loader_param.py::test_load_data_param -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fff9e66483258fc8ac9314e48169