### PR TITLE
Fix Colab install conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
  # Finansal Parquet Cache Sistemi
  
- ```bash
- pip install -r requirements.txt
-+# Colab kullanıyorsanız: `pip install -r requirements-colab.txt`
-+pip install -r requirements-dev.txt  # Parquet testleri için pyarrow içerir
- python -m finansal.cli --help
- python run.py --help
- ```
+```bash
+pip install -r requirements.txt                  # temel paketler
+# Colab kullanıyorsanız: pip install -r requirements-colab.txt
+pip install -r requirements-dev.txt             # test ve geliştirme araçları
+python -m finansal.cli --help
+python run.py --help
+```
  
  Örnek kullanım:
  

--- a/docs/COLAB_REHBERI.md
+++ b/docs/COLAB_REHBERI.md
@@ -30,8 +30,8 @@ drive.mount('/content/drive')
 ## 3. Kütüphaneleri Kur (Sürüm Sabitleme)
 ```bash
 !pip install --upgrade pip
-!pip install -q -r requirements-colab.txt
-!pip install -q -r requirements-dev.txt
+!pip install -q -r requirements-colab.txt   # Colab'a uyumlu temel paketler
+!pip install -q -r requirements-dev.txt    # test ve geliştirme bağımlılıkları
 !pip install -e .
 ```
 `requirements-dev.txt` dosyası, Parquet desteği için gerekli **pyarrow** gibi test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,6 @@
--r requirements.txt
 anyio==4.9.0
 black==25.1.0
 coverage==7.9.2
-fastapi==0.97.0
 h11==0.16.0
 hypothesis==6.135.24
 idna==3.10
@@ -11,7 +9,7 @@ isort==6.0.1
 mypy==1.16.1
 mypy_extensions==1.1.0
 nodeenv==1.9.1
-packaging==25.0
+packaging>=23,<25
 pathspec==0.12.1
 pluggy==1.6.0
 pydantic==1.10.15
@@ -22,7 +20,5 @@ pytest-timeout==2.4.0
 responses==0.25.7
 ruff==0.11.13
 sniffio==1.3.1
-starlette==0.27.0
 typing_extensions==4.14.0
-uvicorn==0.27.0.post1
 pyarrow==20.0.0


### PR DESCRIPTION
## Summary
- drop pinned base dependencies from `requirements-dev.txt`
- relax packaging version and keep pydantic 1.x
- clarify install steps in README
- update Colab guide with updated commands

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c015b924832583d659d57d95c425