### PR TITLE
Fix Colab dependency conflicts

### DIFF
--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -1,7 +1,7 @@
 # Stabil Colab kurulumu icin gereken paketler
 # Colab'in on yüklu kutuphaneleriyle uyumlu surumler
 attrs==25.3.0
-cachetools==6.1.0
+cachetools==5.5.2
 certifi==2025.6.15
 charset-normalizer==3.4.2
 choreographer==1.0.9
@@ -9,7 +9,7 @@ click==8.2.1
 et_xmlfile==2.0.0
 logistro==1.1.0
 narwhals==1.45.0
-numpy==2.3.1
+numpy==2.0.2
 openpyxl==3.1.5
 orjson==3.10.18
 pandas==2.2.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ nodeenv==1.9.1
 packaging>=23,<25
 pathspec==0.12.1
 pluggy==1.6.0
-pydantic==1.10.15
+pydantic==2.7.4
 Pygments==2.19.1
 pyright==1.1.402
 pytest==8.4.0
@@ -21,4 +21,4 @@ responses==0.25.7
 ruff==0.11.13
 sniffio==1.3.1
 typing_extensions==4.14.0
-pyarrow==20.0.0
+pyarrow==19.0.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -46,7 +46,7 @@ portalocker==3.2.0
     # via -r requirements.txt
 psutil==7.0.0
     # via -r requirements.txt
-pyarrow==20.0.0
+pyarrow==19.0.1
     # via -r requirements.txt
 python-dateutil==2.9.0.post0
     # via pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==25.3.0
-cachetools==6.1.0
+cachetools==5.5.2
 certifi==2025.6.15
 charset-normalizer==3.4.2
 choreographer==1.0.9
@@ -7,10 +7,10 @@ click==8.2.1
 et_xmlfile==2.0.0
 logistro==1.1.0
 narwhals==1.45.0
-numpy==2.3.1
+numpy==2.0.2
 openpyxl==3.1.5
 orjson==3.10.18
-pandas==2.3.0
+pandas==2.2.2
 pandas_ta==0.3.14b0
 platformdirs==4.3.8
 plotly==6.2.0
@@ -19,7 +19,7 @@ psutil==7.0.0
 python-dateutil==2.9.0.post0
 pytz==2025.2
 PyYAML==6.0.2
-requests==2.32.4
+requests==2.32.3
 simplejson==3.20.1
 six==1.17.0
 sortedcontainers==2.4.0


### PR DESCRIPTION
## Summary
- update numpy and cachetools pin versions
- use Pydantic 2 and an older PyArrow for dev
- sync requirements with Colab-friendly versions

## Testing
- `pip install -r requirements-colab.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c921ef408325b1130a811d93e82c