### PR TITLE
Fix pip install conflicts

### DIFF
--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -29,3 +29,5 @@ tzdata==2025.2
 urllib3==2.5.0
 xlsxwriter==3.2.5
 zipp==3.23.0
+pydantic==2.9.2
+jedi>=0.16

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,8 @@ nodeenv==1.9.1
 packaging>=23,<25
 pathspec==0.12.1
 pluggy==1.6.0
-pydantic==2.7.4
+pydantic==2.9.2
+jedi>=0.16
 Pygments==2.19.1
 pyright==1.1.402
 pytest==8.4.0


### PR DESCRIPTION
## Summary
- ensure jedi is installed for ipython
- update pydantic requirement to meet albumentations' dependency

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q -r requirements-colab.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cf22cba4832582b76b7ee99ec532