### PR TITLE
Fix logging cleanup in test helper

### DIFF
--- a/tests/test_rich_logging.py
+++ b/tests/test_rich_logging.py
@@ -22,7 +22,13 @@ def _capture(msg: str) -> str:
         console = Console(file=buf, force_terminal=True)
         handler = RichHandler(console=console, show_time=False, rich_tracebacks=True)
     logger = logging_config.setup_logging()
-    logger.handlers = [handler]
+    for h in list(logger.handlers):
+        logger.removeHandler(h)
+        try:
+            h.close()
+        except Exception:
+            pass
+    logger.addHandler(handler)
     logger.warning(msg)
     return buf.getvalue()
 


### PR DESCRIPTION
## Summary
- clean up old handlers in test log capture to avoid unclosed file warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d332e344832582120f1d4837824c