### PR TITLE
Fix Hypothesis failure on Colab

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -87,6 +87,13 @@ def _mock_http():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _fix_sys_modules():
+    """Ensure newly imported modules are hashable for Hypothesis."""
+    _sanitize_sys_modules()
+    yield
+
+
 def pytest_sessionstart(session: pytest.Session) -> None:  # noqa: D401
     """Test oturumu başlamadan önce ``sys.modules``'u temizle."""
 


### PR DESCRIPTION
## Summary
- ensure Hypothesis always sees hashable modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866e2148b4883258318857b30d18ccc