### PR TITLE
Fix Hatalar sheet header alignment and add test

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,16 @@
+# Fix Report
+
+## Changes Made
+- Added `HATALAR_COLUMNS` constant and new helper function `save_hatalar_excel` in `report_generator.py` to standardize writing of the "Hatalar" Excel sheet.
+- Updated `_write_error_sheet` to explicitly reindex columns and write using the correct header order.
+- Exported `save_hatalar_excel` via `__all__` for public use.
+- Added `tests/test_hatalar_sheet_header.py` verifying header alignment of generated Excel files.
+
+## Root Cause
+The "Hatalar" sheet was written without enforcing column order and engine, causing headers to shift during later reads. This resulted in `analyse_missing.py` reporting zero filters due to mismatched column names.
+
+## Resolution
+All error-sheet writes now specify `index=False` and column order. A dedicated helper saves the sheet with OpenPyXL, ensuring consistent headers.
+
+## Future Work
+Include similar helpers for other Excel outputs and ensure column names remain consistent across the project.

--- a/finansal_analiz_sistemi/report_generator.py
+++ b/finansal_analiz_sistemi/report_generator.py
@@ -1,0 +1,9 @@
+"""Compatibility wrapper for top-level report_generator module."""
+from importlib import import_module
+
+_rg = import_module("report_generator")
+
+save_hatalar_excel = _rg.save_hatalar_excel
+
+__all__ = ["save_hatalar_excel"]
+

--- a/report_generator.py
+++ b/report_generator.py
@@ -24,6 +24,31 @@ import report_stats
 from logging_config import get_logger
 from utils.compat import safe_concat, safe_to_excel
 
+HATALAR_COLUMNS = [
+    "filtre_kod",
+    "hata_tipi",
+    "eksik_ad",
+    "detay",
+    "cozum_onerisi",
+    "reason",
+    "hint",
+]
+
+
+def save_hatalar_excel(df: pd.DataFrame, out_path: str | Path) -> None:
+    """Save errors DataFrame to an Excel file with normalized header."""
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df = df.reindex(columns=HATALAR_COLUMNS, fill_value="-")
+    with pd.ExcelWriter(out_path, engine="openpyxl") as writer:
+        df.to_excel(
+            writer,
+            sheet_name="Hatalar",
+            index=False,
+            columns=HATALAR_COLUMNS,
+        )
+
 logger = get_logger(__name__)
 
 PADDING_COMMENT = " ".join(uuid.uuid4().hex for _ in range(1200))
@@ -510,7 +535,15 @@ def _write_error_sheet(
     if df_err.empty:
         return  # liste boşsa sheet oluşturma
 
-    safe_to_excel(df_err, wr, sheet_name="Hatalar", index=False)
+    df_err = df_err.reindex(columns=HATALAR_COLUMNS, fill_value="-")
+    safe_to_excel(
+        df_err,
+        wr,
+        sheet_name="Hatalar",
+        index=False,
+        columns=HATALAR_COLUMNS,
+        engine="openpyxl",
+    )
 
 
 def generate_full_report(
@@ -716,6 +749,7 @@ def generate_full_report(
 
 __all__ = [
     "add_error_sheet",
+    "save_hatalar_excel",
     "olustur_ozet_rapor",
     "olustur_hisse_bazli_rapor",
     "olustur_hatali_filtre_raporu",

--- a/tests/test_hatalar_sheet_header.py
+++ b/tests/test_hatalar_sheet_header.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from pathlib import Path
+
+from finansal_analiz_sistemi.report_generator import save_hatalar_excel
+
+
+def test_hatalar_sheet_header(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "filtre_kod": ["TST1"],
+            "hata_tipi": ["QUERY_ERROR"],
+            "eksik_ad": ["dummy"],
+            "detay": ["detail"],
+            "cozum_onerisi": ["fix"],
+        }
+    )
+    out = tmp_path / "out.xlsx"
+    save_hatalar_excel(df, out)
+
+    read = pd.read_excel(out, sheet_name="Hatalar")
+    assert list(read.columns[:5]) == [
+        "filtre_kod",
+        "hata_tipi",
+        "eksik_ad",
+        "detay",
+        "cozum_onerisi",
+    ]
+


### PR DESCRIPTION
## Summary
- ensure Hatalar sheet columns are written in a stable order
- provide helper `save_hatalar_excel`
- expose the helper for package import
- add regression test for Hatalar sheet header
- document the fix in `FIX_REPORT.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676453f8fc8325a2e59b1215b7b62f