### PR TITLE
Implement Parquet cache builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           pip install -q pip-tools
           pip install -q -r requirements.txt
           python -m pip install -e .   # editable install, varsa setup.cfg
+          pip install -q filelock
           pip install -q "hypothesis>=6.102,<7"
           pip install -q pre-commit mypy pytest-cov
           pip install -q -r requirements-dev.txt  # <-- TEST BAĞIMLILIKLARI BURADA

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir filelock
 RUN pip install --no-cache-dir pandas-ta==0.3.14b0 --no-binary :all:
 CMD ["python", "-m", "finansal_analiz_sistemi"]

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,5 +1,10 @@
-- Added pandas-ta requirement with correct package name.
-- Indicator calculator now fails fast if pandas-ta missing.
-- Created simple dependency test ensuring pandas_ta import.
-- Colab guide includes new step to install pandas-ta.
-- Updated install and test logs after running tests.
+- Added cache_builder module to assemble CSV files into a single Parquet.
+- config exposes PARQUET_CACHE_PATH for unified cache location.
+- data_loader.load_dataset loads the Parquet and rebuilds when missing.
+- cli.py now accepts --rebuild-cache to trigger cache build before running.
+- FileLock prevents simultaneous writes.
+- Dockerfile and CI workflow install filelock package.
+- Small sample raw CSVs placed under veri/ham for tests.
+- cache_build_log.txt records first build and cache-hit runs.
+- New test ensures cache rebuild creates non-empty Parquet.
+- All unit tests run successfully after changes.

--- a/cache_build_log.txt
+++ b/cache_build_log.txt
@@ -1,0 +1,13 @@
+2025-07-04 23:49:57.955 | INFO     | cache_builder:build:19 - CSV ➜ Parquet önbellek olusturuluyor…
+2025-07-04 23:49:57.970 | SUCCESS  | cache_builder:build:32 - Parquet cache yazildi (%d satir)
+Veri satir sayisi: 4
+2025-07-04 23:49:57,980 [WARNING] indicator_calculator: Indicator not implemented: rsi_14
+2025-07-04 23:49:57,981 [WARNING] indicator_calculator: Indicator not implemented: macd
+2025-07-04 23:49:58,002 [WARNING] indicator_calculator: Indicator not implemented: rsi_14
+2025-07-04 23:49:58,003 [WARNING] indicator_calculator: Indicator not implemented: macd
+2025-07-04 23:49:58.567 | INFO     | cache_builder:build:17 - Cache hit, skipping build
+Veri satir sayisi: 4
+2025-07-04 23:49:58,586 [WARNING] indicator_calculator: Indicator not implemented: rsi_14
+2025-07-04 23:49:58,586 [WARNING] indicator_calculator: Indicator not implemented: macd
+2025-07-04 23:49:58,609 [WARNING] indicator_calculator: Indicator not implemented: rsi_14
+2025-07-04 23:49:58,610 [WARNING] indicator_calculator: Indicator not implemented: macd

--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import pandas as pd
+from loguru import logger
+from filelock import FileLock
+
+import config
+
+RAW_DIR = Path("veri/ham")
+CACHE = Path(config.PARQUET_CACHE_PATH)
+LOCK_FILE = CACHE.with_suffix(".lock")
+
+
+def build() -> None:
+    """Combine all CSVs under RAW_DIR into a single Parquet cache."""
+    with FileLock(str(LOCK_FILE)):
+        if CACHE.exists() and CACHE.stat().st_size > 0:
+            logger.info("Cache hit, skipping build")
+            return
+        logger.info("CSV \u279c Parquet \u00f6nbellek olusturuluyor…")
+        dfs = [pd.read_csv(p, parse_dates=["date"]) for p in RAW_DIR.glob("*.csv")]
+        if not dfs:
+            logger.warning("Ham CSV bulunamadi: %s", RAW_DIR)
+            df = pd.DataFrame()
+        else:
+            df = (
+                pd.concat(dfs, ignore_index=True)
+                .drop_duplicates(["ticker", "date"])
+                .sort_values(["ticker", "date"])
+            )
+        CACHE.parent.mkdir(parents=True, exist_ok=True)
+        df.to_parquet(CACHE, index=False)
+        logger.success("Parquet cache yazildi (%d satir)", len(df))

--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+
 import pandas as pd
-from loguru import logger
 from filelock import FileLock
+from loguru import logger
 
 import config
 

--- a/config.py
+++ b/config.py
@@ -11,7 +11,9 @@ IS_COLAB: bool = False
 # Project root path so config can resolve files from any CWD
 BASE_DIR: Path = Path(__file__).resolve().parent
 
-CACHE_PATH: Path = BASE_DIR / "veri" / "birlesik_hisse_verileri.parquet"
+# unified Parquet cache location relative to project root
+PARQUET_CACHE_PATH: str = "veri/birlesik_hisse_verileri.parquet"
+CACHE_PATH: Path = BASE_DIR / PARQUET_CACHE_PATH
 DEFAULT_CSV_PATH: Path = BASE_DIR / "data" / "raw" / "all_prices.csv"
 
 # default data directory and filename patterns

--- a/data_loader.py
+++ b/data_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pandas as pd
 
+import cache_builder
 import config
 from finansal_analiz_sistemi.data_loader import (
     _standardize_date_column,
@@ -19,7 +20,6 @@ from finansal_analiz_sistemi.data_loader import (
     yukle_filtre_dosyasi,
     yukle_hisse_verileri,
 )
-import cache_builder
 
 __all__ = [
     "load_data",

--- a/data_loader.py
+++ b/data_loader.py
@@ -3,6 +3,11 @@
 Explicit imports keep flake8 happy while exposing the same public API.
 """
 
+from pathlib import Path
+
+import pandas as pd
+
+import config
 from finansal_analiz_sistemi.data_loader import (
     _standardize_date_column,
     _standardize_ohlcv_columns,
@@ -14,6 +19,7 @@ from finansal_analiz_sistemi.data_loader import (
     yukle_filtre_dosyasi,
     yukle_hisse_verileri,
 )
+import cache_builder
 
 __all__ = [
     "load_data",
@@ -25,4 +31,18 @@ __all__ = [
     "_standardize_ohlcv_columns",
     "yukle_filtre_dosyasi",
     "yukle_hisse_verileri",
+    "load_dataset",
 ]
+
+
+def load_dataset(rebuild: bool = False) -> pd.DataFrame:
+    """Return cached stock dataset, rebuilding if requested or missing."""
+    parquet_path = Path(config.PARQUET_CACHE_PATH)
+    if rebuild or not parquet_path.exists():
+        cache_builder.build()
+    if not parquet_path.exists():
+        raise FileNotFoundError(parquet_path)
+    df = pd.read_parquet(parquet_path)
+    if df.empty:
+        raise ValueError("Parquet cache empty")
+    return df

--- a/finansal/cli.py
+++ b/finansal/cli.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import click
 
-import config  # noqa: WPS433  # local import pattern is intentional
-from finansal.parquet_cache import ParquetCacheManager
 import cache_builder
+import config  # noqa: WPS433  # local import pattern is intentional
 import data_loader
+from finansal.parquet_cache import ParquetCacheManager
 from indicator_calculator import calculate_chunked
 
 

--- a/finansal/cli.py
+++ b/finansal/cli.py
@@ -9,6 +9,8 @@ import click
 
 import config  # noqa: WPS433  # local import pattern is intentional
 from finansal.parquet_cache import ParquetCacheManager
+import cache_builder
+import data_loader
 from indicator_calculator import calculate_chunked
 
 
@@ -23,6 +25,12 @@ from indicator_calculator import calculate_chunked
     default=False,
     help="Cache’i CSV’den yeniden olustur",
 )
+@click.option(
+    "--rebuild-cache",
+    is_flag=True,
+    default=False,
+    help="veri/ham klasorunden Parquet cache'i yeniden olustur",
+)
 @click.option("--ind-set", type=click.Choice(["core", "full"]), default="core")
 @click.option("--chunk-size", type=int, default=config.CHUNK_SIZE)
 @click.option(
@@ -36,6 +44,7 @@ def main(
     csv_path: str,
     cache_path: str,
     refresh_cache: bool,
+    rebuild_cache: bool,
     ind_set: str,
     chunk_size: int,
     log_level: str,
@@ -46,7 +55,10 @@ def main(
     )
     manager = ParquetCacheManager(Path(cache_path))
 
-    if refresh_cache or not Path(cache_path).exists():
+    if rebuild_cache:
+        cache_builder.build()
+        df = data_loader.load_dataset()
+    elif refresh_cache or not Path(cache_path).exists():
         df = manager.refresh(Path(csv_path))
     else:
         df = manager.load()

--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -1,5 +1,18 @@
-"""Submodule shortcuts."""
+"""Package exports with lazy submodule loading."""
+
+from __future__ import annotations
+
+import importlib
+import types
 
 from . import config, logging_config
 
-__all__ = ["config", "logging_config"]
+__all__ = ["config", "logging_config", "cache_builder", "data_loader"]
+
+
+def __getattr__(name: str) -> types.ModuleType:
+    if name in {"cache_builder", "data_loader"}:
+        module = importlib.import_module(name)
+        globals()[name] = module
+        return module
+    raise AttributeError(name)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,3 +23,4 @@ ruff==0.11.13
 sniffio==1.3.1
 typing_extensions==4.14.0
 pyarrow==19.0.1
+loguru==0.7.3

--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,4 @@ psutil
 portalocker
 pyarrow
 cachetools
+loguru

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ openpyxl==3.1.5
 orjson==3.10.18
 pandas==2.2.2
 pandas_ta==0.3.14b0
+loguru==0.7.3
 platformdirs==4.3.8
 plotly==6.2.0
 portalocker==3.2.0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,24 +1,28 @@
 import pandas as pd
 
-from finansal_analiz_sistemi import cache_builder, data_loader
 import config
+from finansal_analiz_sistemi import cache_builder, data_loader
 
 
 def test_rebuild_creates_nonempty_parquet(tmp_path, monkeypatch):
     csv = tmp_path / "a.csv"
-    pd.DataFrame({
-        "date": ["2025-01-01"],
-        "ticker": ["AAA"],
-        "open": [1],
-        "high": [1],
-        "low": [1],
-        "close": [1],
-        "volume": [100],
-    }).to_csv(csv, index=False)
+    pd.DataFrame(
+        {
+            "date": ["2025-01-01"],
+            "ticker": ["AAA"],
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [100],
+        }
+    ).to_csv(csv, index=False)
 
     monkeypatch.setattr(cache_builder, "RAW_DIR", tmp_path)
     monkeypatch.setattr(cache_builder, "CACHE", tmp_path / "cache.parquet")
-    monkeypatch.setattr(cache_builder, "LOCK_FILE", cache_builder.CACHE.with_suffix(".lock"))
+    monkeypatch.setattr(
+        cache_builder, "LOCK_FILE", cache_builder.CACHE.with_suffix(".lock")
+    )
     monkeypatch.setattr(config, "PARQUET_CACHE_PATH", str(cache_builder.CACHE))
 
     cache_builder.CACHE.unlink(missing_ok=True)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+from finansal_analiz_sistemi import cache_builder, data_loader
+import config
+
+
+def test_rebuild_creates_nonempty_parquet(tmp_path, monkeypatch):
+    csv = tmp_path / "a.csv"
+    pd.DataFrame({
+        "date": ["2025-01-01"],
+        "ticker": ["AAA"],
+        "open": [1],
+        "high": [1],
+        "low": [1],
+        "close": [1],
+        "volume": [100],
+    }).to_csv(csv, index=False)
+
+    monkeypatch.setattr(cache_builder, "RAW_DIR", tmp_path)
+    monkeypatch.setattr(cache_builder, "CACHE", tmp_path / "cache.parquet")
+    monkeypatch.setattr(cache_builder, "LOCK_FILE", cache_builder.CACHE.with_suffix(".lock"))
+    monkeypatch.setattr(config, "PARQUET_CACHE_PATH", str(cache_builder.CACHE))
+
+    cache_builder.CACHE.unlink(missing_ok=True)
+    cache_builder.build()
+    df = data_loader.load_dataset()
+    assert len(df) > 0

--- a/veri/ham/AAA.csv
+++ b/veri/ham/AAA.csv
@@ -1,0 +1,3 @@
+date,ticker,open,high,low,close,volume
+2025-05-01,AAA,10,11,9,10.5,1000
+2025-05-02,AAA,10.5,11,10,10.8,900

--- a/veri/ham/BBB.csv
+++ b/veri/ham/BBB.csv
@@ -1,0 +1,3 @@
+date,ticker,open,high,low,close,volume
+2025-05-01,BBB,5,5.2,4.9,5.1,800
+2025-05-02,BBB,5.1,5.3,5,5.2,850


### PR DESCRIPTION
## Summary
- create cache_builder module with FileLock
- expose PARQUET_CACHE_PATH constant
- load_dataset helper builds/loads cache
- add --rebuild-cache flag to CLI
- install filelock in Docker & CI
- include small raw CSV samples and cache build log
- unit test for cache building
- remove unused Path import in tests to satisfy flake8
- add loguru to requirements
- resolve circular import by lazy-loading cache_builder and data_loader

## Testing
- `pytest tests/test_cache.py -q`
- `flake8 tests/test_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686866ce92388325bccbd3000c065f91