### PR TITLE
Add flexible settings path detection

### DIFF
--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -1,9 +1,25 @@
 """Global yapılandırma sabitleri."""
 
-import sys  # isort: skip
+import os
 from pathlib import Path
 
 import yaml
+
+import sys  # isort: skip
+
+
+def get_settings_path(custom: str | None = None) -> Path:
+    """Return absolute path to ``settings.yaml`` considering the environment."""
+    if custom:
+        return Path(custom).expanduser().resolve()
+    env_path = os.getenv("FAS_SETTINGS_FILE")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+    is_colab = "google.colab" in sys.modules or bool(os.getenv("COLAB_GPU"))
+    if is_colab:
+        return Path("/content/drive/MyDrive/finansal-analiz-sistemi/settings.yaml")
+    return Path(__file__).resolve().parent.parent / "settings.yaml"
+
 
 # Flag to indicate the application is running in Google Colab
 IS_COLAB: bool = False

--- a/finansal_analiz_sistemi/settings_loader.py
+++ b/finansal_analiz_sistemi/settings_loader.py
@@ -1,0 +1,17 @@
+import logging
+from pathlib import Path
+
+import yaml
+
+from .config import get_settings_path
+
+logger = logging.getLogger(__name__)
+
+
+def load_settings(path: str | None = None) -> dict:
+    """Load YAML settings from detected path."""
+    settings_path = get_settings_path(path)
+    if not Path(settings_path).exists():
+        raise RuntimeError(f"settings.yaml not found at {settings_path}")
+    with open(settings_path) as fh:
+        return yaml.safe_load(fh) or {}

--- a/run.py
+++ b/run.py
@@ -351,6 +351,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Parquet yerine Excel/CSV dosyalarını yeniden yükle",
     )
     parser.add_argument(
+        "--settings-file",
+        dest="settings_file",
+        help="settings.yaml yolunu elle belirt",
+    )
+    parser.add_argument(
         "--output",
         required=True,
         help="Excel .xlsx son dosya yolu",
@@ -364,6 +369,15 @@ def main(argv: list[str] | None = None) -> None:
         help="Log seviyesi",
     )
     args = parser.parse_args(argv)
+
+    # Ensure settings file can be located early
+    try:
+        from finansal_analiz_sistemi import settings_loader
+
+        settings_loader.load_settings(args.settings_file)
+    except Exception as exc:  # pragma: no cover - CLI safeguard
+        print(exc)
+        sys.exit(1)
 
     global log_counter
     log_counter = setup_logger(level=getattr(logging, args.log_level))

--- a/tests/test_settings_path.py
+++ b/tests/test_settings_path.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("FAS_SETTINGS_FILE", "/tmp/custom.yaml")
+    from finansal_analiz_sistemi.config import get_settings_path
+
+    assert str(get_settings_path()) == str(Path("/tmp/custom.yaml").resolve())
+
+
+def test_colab_path(monkeypatch):
+    monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
+    monkeypatch.setitem(sys.modules, "google.colab", object())
+    from finansal_analiz_sistemi.config import get_settings_path
+
+    assert "/content/drive/MyDrive/finansal-analiz-sistemi" in str(get_settings_path())
+    sys.modules.pop("google.colab", None)
+
+
+def test_local_path(monkeypatch):
+    monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
+    sys.modules.pop("google.colab", None)
+    from finansal_analiz_sistemi.config import get_settings_path
+
+    expected = Path(__file__).resolve().parents[1] / "settings.yaml"
+    assert get_settings_path() == expected


### PR DESCRIPTION
## Summary
- resolve settings.yaml path via new `get_settings_path` helper
- add `settings_loader.load_settings` utility
- expose `--settings-file` option in CLI
- verify path logic with tests

## Testing
- `pre-commit run --files finansal_analiz_sistemi/config.py finansal_analiz_sistemi/settings_loader.py run.py tests/test_settings_path.py`
- `pytest -k settings_path -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f6de5de48325adf3906489475736