### PR TITLE
Add central error counter filter

### DIFF
--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -4,10 +4,21 @@ from __future__ import annotations
 
 import importlib
 import types
+from logging.config import dictConfig
+from pathlib import Path
+
+import yaml
 
 from . import config, logging_config
+from .logging_utils import ErrorCountingFilter
 
 __all__ = ["config", "logging_config", "cache_builder", "data_loader"]
+
+# Load logging configuration at import time if available
+_yaml_path = Path(__file__).resolve().parent.parent / "logging_config.yaml"
+if _yaml_path.exists():
+    with _yaml_path.open(encoding="utf-8") as fh:
+        dictConfig(yaml.safe_load(fh))
 
 
 def __getattr__(name: str) -> types.ModuleType:

--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import atexit
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -10,6 +11,9 @@ if __package__ is None:  # pragma: no cover - safe guard for manual execution
 import pandas as pd
 
 from finansal_analiz_sistemi.report_writer import ReportWriter
+from finansal_analiz_sistemi.logging_utils import ERROR_COUNTER
+
+logger = logging.getLogger(__name__)
 
 
 def run_analysis(csv_path: Path) -> Path:
@@ -68,3 +72,14 @@ if __name__ == "__main__":
     else:
         out = run_analysis(args.dosya)
         print(f"Rapor oluşturuldu -> {out}")
+
+
+@atexit.register
+def _summary() -> None:
+    logger.info(
+        "[SUMMARY] run finished — errors=%d warnings=%d",
+        ERROR_COUNTER["errors"],
+        ERROR_COUNTER["warnings"],
+    )
+    if ERROR_COUNTER["errors"]:
+        sys.exit(1)

--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -1,6 +1,6 @@
+import atexit
 import logging
 import sys
-import atexit
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -10,8 +10,8 @@ if __package__ is None:  # pragma: no cover - safe guard for manual execution
 
 import pandas as pd
 
-from finansal_analiz_sistemi.report_writer import ReportWriter
 from finansal_analiz_sistemi.logging_utils import ERROR_COUNTER
+from finansal_analiz_sistemi.report_writer import ReportWriter
 
 logger = logging.getLogger(__name__)
 

--- a/finansal_analiz_sistemi/logging_utils.py
+++ b/finansal_analiz_sistemi/logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+
+ERROR_COUNTER: dict[str, int] = {"errors": 0, "warnings": 0}
+
+
+class ErrorCountingFilter(logging.Filter):
+    """ERROR/WARNING satırlarını sayaçlar."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.ERROR:
+            ERROR_COUNTER["errors"] += 1
+        elif record.levelno == logging.WARNING:
+            ERROR_COUNTER["warnings"] += 1
+        return True

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -1,0 +1,30 @@
+version: 1
+formatters:
+  standard:
+    format: '%(asctime)s | %(levelname)s | %(name)s | %(message)s'
+filters:
+  error_counter:
+    "()": finansal_analiz_sistemi.logging_utils.ErrorCountingFilter
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: standard
+    filters: [error_counter]
+    stream: ext://sys.stdout
+  file:
+    class: logging.handlers.TimedRotatingFileHandler
+    filename: logs/fas_%Y-%m-%d.log
+    level: DEBUG
+    formatter: standard
+    when: midnight
+    backupCount: 14
+    filters: [error_counter]
+loggers:
+  finansal_analiz_sistemi:
+    level: DEBUG
+    handlers: [console, file]
+    propagate: False
+root:
+  level: INFO
+  handlers: [console, file]

--- a/tests/test_error_counter.py
+++ b/tests/test_error_counter.py
@@ -1,0 +1,21 @@
+import logging
+
+from finansal_analiz_sistemi.logging_utils import (
+    ERROR_COUNTER,
+    ErrorCountingFilter,
+)
+
+
+def test_counter_increments():
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+    logger = logging.getLogger("dummy")
+    logger.addFilter(ErrorCountingFilter())
+    ERROR_COUNTER["errors"] = 0
+    ERROR_COUNTER["warnings"] = 0
+    logger.error("boom")
+    logger.warning("careful")
+    assert ERROR_COUNTER["errors"] == 1
+    assert ERROR_COUNTER["warnings"] == 1


### PR DESCRIPTION
## Summary
- implement `logging_utils.ErrorCountingFilter`
- load `logging_config.yaml` in package `__init__`
- append error counter summary hook in CLI
- provide YAML logging config using the new filter
- test filter increments correctly

## Testing
- `black finansal_analiz_sistemi/logging_utils.py finansal_analiz_sistemi/cli.py finansal_analiz_sistemi/__init__.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `flake8 finansal_analiz_sistemi/logging_utils.py finansal_analiz_sistemi/cli.py finansal_analiz_sistemi/__init__.py >/tmp/flake8.log && tail -n 20 /tmp/flake8.log`
- `mypy finansal_analiz_sistemi/logging_utils.py finansal_analiz_sistemi/cli.py finansal_analiz_sistemi/__init__.py >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest tests/test_error_counter.py -q >/tmp/pytest.log && cat /tmp/pytest.log`
- `pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6868f939a9388325ad3b72dd572789ef