### PR TITLE
Silence flake8 F401 for ErrorCountingFilter import

### DIFF
--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -3,9 +3,22 @@
 from __future__ import annotations
 
 import importlib
+import logging.config
+from pathlib import Path
 import types
 
-from . import config, logging_config
+import yaml
+
+# Import solely for side-effects (YAML filter resolution).  # noqa: F401
+from .logging_utils import ErrorCountingFilter  # noqa: F401
+
+# Configure logging from YAML at package import time
+base = Path(__file__).resolve().parent.parent
+(base / "logs").mkdir(exist_ok=True)
+with open(base / "logging_config.yaml", "r", encoding="utf-8") as fh:
+    logging.config.dictConfig(yaml.safe_load(fh))
+
+from . import config, logging_config  # noqa: E402
 
 __all__ = ["config", "logging_config", "cache_builder", "data_loader"]
 

--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import importlib
 import logging.config
-from pathlib import Path
 import types
+from pathlib import Path
 
 import yaml
 

--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import atexit
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -10,6 +11,20 @@ if __package__ is None:  # pragma: no cover - safe guard for manual execution
 import pandas as pd
 
 from finansal_analiz_sistemi.report_writer import ReportWriter
+from finansal_analiz_sistemi.logging_utils import ERROR_COUNTER
+
+logger = logging.getLogger(__name__)
+
+
+@atexit.register
+def _summary() -> None:
+    logger.info(
+        "[SUMMARY] run finished — errors=%d warnings=%d",
+        ERROR_COUNTER["errors"],
+        ERROR_COUNTER["warnings"],
+    )
+    if ERROR_COUNTER["errors"]:
+        sys.exit(1)
 
 
 def run_analysis(csv_path: Path) -> Path:

--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -1,6 +1,6 @@
+import atexit
 import logging
 import sys
-import atexit
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -10,8 +10,8 @@ if __package__ is None:  # pragma: no cover - safe guard for manual execution
 
 import pandas as pd
 
-from finansal_analiz_sistemi.report_writer import ReportWriter
 from finansal_analiz_sistemi.logging_utils import ERROR_COUNTER
+from finansal_analiz_sistemi.report_writer import ReportWriter
 
 logger = logging.getLogger(__name__)
 

--- a/finansal_analiz_sistemi/logging_utils.py
+++ b/finansal_analiz_sistemi/logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+
+ERROR_COUNTER: dict[str, int] = {"errors": 0, "warnings": 0}
+
+
+class ErrorCountingFilter(logging.Filter):
+    """Count ERROR and WARNING logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        if record.levelno >= logging.ERROR:
+            ERROR_COUNTER["errors"] += 1
+        elif record.levelno == logging.WARNING:
+            ERROR_COUNTER["warnings"] += 1
+        return True

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -1,0 +1,24 @@
+version: 1
+formatters:
+  standard:
+    format: "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+filters:
+  error_counter:
+    "()": finansal_analiz_sistemi.logging_utils.ErrorCountingFilter
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: standard
+    filters: [error_counter]
+  file:
+    class: logging.handlers.TimedRotatingFileHandler
+    filename: logs/fas_%Y-%m-%d.log
+    level: DEBUG
+    formatter: standard
+    when: midnight
+    backupCount: 14
+    filters: [error_counter]
+root:
+  level: INFO
+  handlers: [console, file]

--- a/tests/test_error_counter.py
+++ b/tests/test_error_counter.py
@@ -1,0 +1,14 @@
+import logging
+from finansal_analiz_sistemi.logging_utils import ERROR_COUNTER, ErrorCountingFilter
+
+
+def test_counter_increments():
+    ERROR_COUNTER["errors"] = 0
+    ERROR_COUNTER["warnings"] = 0
+    logger = logging.getLogger("dummy_test")
+    logger.propagate = False
+    logger.addFilter(ErrorCountingFilter())
+    logger.error("boom")
+    logger.warning("careful")
+    assert ERROR_COUNTER["errors"] == 1
+    assert ERROR_COUNTER["warnings"] == 1

--- a/tests/test_error_counter.py
+++ b/tests/test_error_counter.py
@@ -1,4 +1,5 @@
 import logging
+
 from finansal_analiz_sistemi.logging_utils import ERROR_COUNTER, ErrorCountingFilter
 
 


### PR DESCRIPTION
## Summary
- add global `ErrorCountingFilter` and YAML logging config
- load YAML config at package import and ensure logs directory exists
- report error/warning totals at exit in CLI
- test that the counter increments

## Testing
- `black finansal_analiz_sistemi/logging_utils.py finansal_analiz_sistemi/cli.py finansal_analiz_sistemi/__init__.py tests/test_error_counter.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `flake8 finansal_analiz_sistemi/logging_utils.py finansal_analiz_sistemi/cli.py finansal_analiz_sistemi/__init__.py tests/test_error_counter.py >/tmp/flake8.log && cat /tmp/flake8.log`
- `mypy finansal_analiz_sistemi/logging_utils.py finansal_analiz_sistemi/cli.py finansal_analiz_sistemi/__init__.py tests/test_error_counter.py >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest tests/test_error_counter.py -q >/tmp/pytest.log && cat /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6868f939a9388325ad3b72dd572789ef