### PR TITLE
Fix filter CSV delimiter handling

### DIFF
--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -29,7 +29,7 @@ def _summary() -> None:
 
 def run_analysis(csv_path: Path) -> Path:
     """Read CSV and write Excel report next to it."""
-    df = pd.read_csv(csv_path)
+    df = pd.read_csv(csv_path, sep=";")
     out_path = csv_path.with_suffix(".xlsx")
     ReportWriter().write_report(df, out_path)
     return out_path

--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -13,7 +13,7 @@ from logging_config import get_logger
 from utils.compat import safe_concat
 
 # Sabitler
-COLS = ["tarih", "filtre_kodu", "python_query"]
+COLS = ["tarih", "filtre_kodu", "PythonQuery"]
 
 # data_loader.py
 # -*- coding: utf-8 -*-

--- a/tests/test_header_alignment.py
+++ b/tests/test_header_alignment.py
@@ -6,4 +6,4 @@ def test_header_alignment(tmp_path):
     tmp.write_text("dummy\n2025-01-01;MACD;close>vwap\n")
 
     df = load_filter_csv(tmp)
-    assert list(df.columns) == ["tarih", "filtre_kodu", "python_query"]
+    assert list(df.columns) == ["tarih", "filtre_kodu", "PythonQuery"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -107,7 +107,7 @@ def extract_columns_from_filters_cached(
     df_filters = None
     if df_filters_csv:
         try:
-            df_filters = pd.read_csv(StringIO(df_filters_csv))
+            df_filters = pd.read_csv(StringIO(df_filters_csv), sep=";")
         except Exception:
             df_filters = None
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -107,7 +107,9 @@ def extract_columns_from_filters_cached(
     df_filters = None
     if df_filters_csv:
         try:
-            df_filters = pd.read_csv(StringIO(df_filters_csv), sep=";")
+            first = df_filters_csv.splitlines()[0]
+            sep = ";" if first.count(";") >= first.count(",") else ","
+            df_filters = pd.read_csv(StringIO(df_filters_csv), sep=sep)
         except Exception:
             df_filters = None
 


### PR DESCRIPTION
## Summary
- standardize filter CSV columns to `PythonQuery`
- read analysis CSVs with semicolon delimiter
- handle filter CSV strings with semicolon separation
- update header alignment test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xlsxwriter')*

------
https://chatgpt.com/codex/tasks/task_e_686977fd0d708325b2290116453bc317