### PR TITLE
Ensure core indicators are computed

### DIFF
--- a/config_local.py
+++ b/config_local.py
@@ -131,7 +131,11 @@ if not hasattr(sys.modules[__name__], "TA_STRATEGY"):
                 "signal": 9,
                 "col_names": ["macd_line", "macd_signal", "macd_hist"],
             },
-            {"kind": "stochrsi", "length": 14, "col_names": ["stochrsi_k", "stochrsi_d"]},
+            {
+                "kind": "stochrsi",
+                "length": 14,
+                "col_names": ["stochrsi_k", "stochrsi_d"],
+            },
             {
                 "kind": "ichimoku",
                 "tenkan": 9,

--- a/config_local.py
+++ b/config_local.py
@@ -94,7 +94,13 @@ if "OHLCV_MAP" not in globals():
     }
 
 if "INDIKATOR_AD_ESLESTIRME" not in globals():
-    INDIKATOR_AD_ESLESTIRME: dict = {}
+    INDIKATOR_AD_ESLESTIRME: dict = {
+        "ITS_9": "ichimoku_conversionline",
+        "its_9": "ichimoku_conversionline",
+        "IKS_26": "ichimoku_baseline",
+        "ISA_9": "ichimoku_leadingspana",
+        "ISB_26": "ichimoku_leadingspanb",
+    }
 
 if "SERIES_SERIES_CROSSOVERS" not in globals():
     SERIES_SERIES_CROSSOVERS: list = []
@@ -114,7 +120,33 @@ if not hasattr(sys.modules[__name__], "cfg"):
 if not hasattr(sys.modules[__name__], "KOMISYON_ORANI"):
     KOMISYON_ORANI = 0.001
 if not hasattr(sys.modules[__name__], "TA_STRATEGY"):
-    TA_STRATEGY: dict = {}
+    TA_STRATEGY: dict = {
+        "name": "core",
+        "ta": [
+            {"kind": "rsi", "length": 14, "col_names": ["rsi_14"]},
+            {
+                "kind": "macd",
+                "fast": 12,
+                "slow": 26,
+                "signal": 9,
+                "col_names": ["macd_line", "macd_signal", "macd_hist"],
+            },
+            {"kind": "stochrsi", "length": 14, "col_names": ["stochrsi_k", "stochrsi_d"]},
+            {
+                "kind": "ichimoku",
+                "tenkan": 9,
+                "kijun": 26,
+                "senkou": 52,
+                "col_names": [
+                    "ichimoku_leadingspana",
+                    "ichimoku_leadingspanb",
+                    "ITS_9",
+                    "IKS_26",
+                    "ICS_26",
+                ],
+            },
+        ],
+    }
 if not hasattr(sys.modules[__name__], "get"):
 
     def get(key, default=None):

--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -113,10 +113,16 @@ if "INDIKATOR_AD_ESLESTIRME" not in globals():
     INDIKATOR_AD_ESLESTIRME: dict = {
         "ITS_9": "ichimoku_conversionline",
         "its_9": "ichimoku_conversionline",
+        "IKS_26": "ichimoku_baseline",
+        "ISA_9": "ichimoku_leadingspana",
+        "ISB_26": "ichimoku_leadingspanb",
     }
 else:
     INDIKATOR_AD_ESLESTIRME.setdefault("ITS_9", "ichimoku_conversionline")
     INDIKATOR_AD_ESLESTIRME.setdefault("its_9", "ichimoku_conversionline")
+    INDIKATOR_AD_ESLESTIRME.setdefault("IKS_26", "ichimoku_baseline")
+    INDIKATOR_AD_ESLESTIRME.setdefault("ISA_9", "ichimoku_leadingspana")
+    INDIKATOR_AD_ESLESTIRME.setdefault("ISB_26", "ichimoku_leadingspanb")
 
 if "SERIES_SERIES_CROSSOVERS" not in globals():
     SERIES_SERIES_CROSSOVERS: list = [
@@ -142,7 +148,41 @@ if not hasattr(sys.modules[__name__], "cfg"):
 if not hasattr(sys.modules[__name__], "KOMISYON_ORANI"):
     KOMISYON_ORANI = 0.001
 if not hasattr(sys.modules[__name__], "TA_STRATEGY"):
-    TA_STRATEGY: dict = {}
+    TA_STRATEGY: dict = {
+        "name": "core",
+        "ta": [
+            {
+                "kind": "rsi",
+                "length": 14,
+                "col_names": ["rsi_14"],
+            },
+            {
+                "kind": "macd",
+                "fast": 12,
+                "slow": 26,
+                "signal": 9,
+                "col_names": ["macd_line", "macd_signal", "macd_hist"],
+            },
+            {
+                "kind": "stochrsi",
+                "length": 14,
+                "col_names": ["stochrsi_k", "stochrsi_d"],
+            },
+            {
+                "kind": "ichimoku",
+                "tenkan": 9,
+                "kijun": 26,
+                "senkou": 52,
+                "col_names": [
+                    "ichimoku_leadingspana",
+                    "ichimoku_leadingspanb",
+                    "ITS_9",
+                    "IKS_26",
+                    "ICS_26",
+                ],
+            },
+        ],
+    }
 if not hasattr(sys.modules[__name__], "get"):
 
     def get(key, default=None):

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -995,7 +995,10 @@ def _calculate_group_indicators_and_crossovers(
                 df_final_group["close"],
             )
             if ich_df is not None and "ITS_9" in ich_df:
-                manual_cols["ITS_9"] = ich_df["ITS_9"]
+                target = config.INDIKATOR_AD_ESLESTIRME.get(
+                    "ITS_9", "ichimoku_conversionline"
+                )
+                manual_cols[target] = ich_df["ITS_9"]
                 local_logger.debug(
                     f"{hisse_kodu}: 'ITS_9' sütunu manuel olarak hesaplandı."
                 )
@@ -1024,6 +1027,37 @@ def _calculate_group_indicators_and_crossovers(
         local_logger.debug(
             f"{hisse_kodu}: 'momentum_10' sütunu manuel olarak hesaplandı."
         )
+
+    if "rsi_14" not in df_final_group.columns and "close" in df_final_group.columns:
+        try:
+            manual_cols["rsi_14"] = ta.rsi(df_final_group["close"], length=14)
+            local_logger.debug(f"{hisse_kodu}: 'rsi_14' sütunu manuel olarak hesaplandı.")
+        except Exception as e_rsi:
+            local_logger.error(f"{hisse_kodu}: rsi_14 hesaplanırken hata: {e_rsi}", exc_info=False)
+
+    if ({"macd_line", "macd_signal"} - set(df_final_group.columns)) and "close" in df_final_group.columns:
+        try:
+            macd_df = ta.macd(df_final_group["close"], fast=12, slow=26, signal=9)
+            if isinstance(macd_df, pd.DataFrame):
+                if "macd_line" not in df_final_group.columns:
+                    manual_cols["macd_line"] = macd_df.iloc[:, 0]
+                if "macd_signal" not in df_final_group.columns:
+                    manual_cols["macd_signal"] = macd_df.iloc[:, 1]
+            local_logger.debug(f"{hisse_kodu}: 'macd_line' ve 'macd_signal' sütunları manuel olarak hesaplandı.")
+        except Exception as e_macd:
+            local_logger.error(f"{hisse_kodu}: macd hesaplanırken hata: {e_macd}", exc_info=False)
+
+    if ({"stochrsi_k", "stochrsi_d"} - set(df_final_group.columns)) and "close" in df_final_group.columns:
+        try:
+            stoch_df = ta.stochrsi(df_final_group["close"], length=14)
+            if isinstance(stoch_df, pd.DataFrame):
+                if "stochrsi_k" not in df_final_group.columns:
+                    manual_cols["stochrsi_k"] = stoch_df.iloc[:, 0]
+                if "stochrsi_d" not in df_final_group.columns:
+                    manual_cols["stochrsi_d"] = stoch_df.iloc[:, 1]
+            local_logger.debug(f"{hisse_kodu}: 'stochrsi_k/d' sütunları manuel olarak hesaplandı.")
+        except Exception as e_stoch:
+            local_logger.error(f"{hisse_kodu}: stochrsi hesaplanırken hata: {e_stoch}", exc_info=False)
 
     if manual_cols:
         for alias, vals in manual_cols.items():

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -1031,11 +1031,17 @@ def _calculate_group_indicators_and_crossovers(
     if "rsi_14" not in df_final_group.columns and "close" in df_final_group.columns:
         try:
             manual_cols["rsi_14"] = ta.rsi(df_final_group["close"], length=14)
-            local_logger.debug(f"{hisse_kodu}: 'rsi_14' sütunu manuel olarak hesaplandı.")
+            local_logger.debug(
+                f"{hisse_kodu}: 'rsi_14' sütunu manuel olarak hesaplandı."
+            )
         except Exception as e_rsi:
-            local_logger.error(f"{hisse_kodu}: rsi_14 hesaplanırken hata: {e_rsi}", exc_info=False)
+            local_logger.error(
+                f"{hisse_kodu}: rsi_14 hesaplanırken hata: {e_rsi}", exc_info=False
+            )
 
-    if ({"macd_line", "macd_signal"} - set(df_final_group.columns)) and "close" in df_final_group.columns:
+    if (
+        {"macd_line", "macd_signal"} - set(df_final_group.columns)
+    ) and "close" in df_final_group.columns:
         try:
             macd_df = ta.macd(df_final_group["close"], fast=12, slow=26, signal=9)
             if isinstance(macd_df, pd.DataFrame):
@@ -1043,11 +1049,17 @@ def _calculate_group_indicators_and_crossovers(
                     manual_cols["macd_line"] = macd_df.iloc[:, 0]
                 if "macd_signal" not in df_final_group.columns:
                     manual_cols["macd_signal"] = macd_df.iloc[:, 1]
-            local_logger.debug(f"{hisse_kodu}: 'macd_line' ve 'macd_signal' sütunları manuel olarak hesaplandı.")
+            local_logger.debug(
+                f"{hisse_kodu}: 'macd_line' ve 'macd_signal' sütunları manuel olarak hesaplandı."
+            )
         except Exception as e_macd:
-            local_logger.error(f"{hisse_kodu}: macd hesaplanırken hata: {e_macd}", exc_info=False)
+            local_logger.error(
+                f"{hisse_kodu}: macd hesaplanırken hata: {e_macd}", exc_info=False
+            )
 
-    if ({"stochrsi_k", "stochrsi_d"} - set(df_final_group.columns)) and "close" in df_final_group.columns:
+    if (
+        {"stochrsi_k", "stochrsi_d"} - set(df_final_group.columns)
+    ) and "close" in df_final_group.columns:
         try:
             stoch_df = ta.stochrsi(df_final_group["close"], length=14)
             if isinstance(stoch_df, pd.DataFrame):
@@ -1055,9 +1067,13 @@ def _calculate_group_indicators_and_crossovers(
                     manual_cols["stochrsi_k"] = stoch_df.iloc[:, 0]
                 if "stochrsi_d" not in df_final_group.columns:
                     manual_cols["stochrsi_d"] = stoch_df.iloc[:, 1]
-            local_logger.debug(f"{hisse_kodu}: 'stochrsi_k/d' sütunları manuel olarak hesaplandı.")
+            local_logger.debug(
+                f"{hisse_kodu}: 'stochrsi_k/d' sütunları manuel olarak hesaplandı."
+            )
         except Exception as e_stoch:
-            local_logger.error(f"{hisse_kodu}: stochrsi hesaplanırken hata: {e_stoch}", exc_info=False)
+            local_logger.error(
+                f"{hisse_kodu}: stochrsi hesaplanırken hata: {e_stoch}", exc_info=False
+            )
 
     if manual_cols:
         for alias, vals in manual_cols.items():

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -111,3 +111,26 @@ def test_psar_no_error():
     )
     result = ic._calculate_combined_psar(df)
     assert len(result) == len(df)
+
+
+def test_core_strategy_indicators_exist():
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"] * 60,
+            "tarih": pd.date_range("2024-01-01", periods=60, freq="D"),
+            "open": np.linspace(1, 60, 60),
+            "high": np.linspace(1, 60, 60) + 1,
+            "low": np.linspace(1, 60, 60) - 1,
+            "close": np.linspace(1, 60, 60),
+            "volume": np.arange(60),
+        }
+    )
+    result = ic.hesapla_teknik_indikatorler_ve_kesisimler(df)
+    for col in [
+        "rsi_14",
+        "macd_line",
+        "macd_signal",
+        "ichimoku_conversionline",
+    ]:
+        assert col in result.columns
+        assert result[col].notna().any()


### PR DESCRIPTION
## Summary
- map more Ichimoku column names
- define a default pandas_ta strategy in config
- mirror the same defaults in config_local
- compute missing indicators manually when pandas_ta fails
- test for new indicator columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686984ae66c483259cb8ba420a0f082d