### PR TITLE
Add missing pyarrow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ loguru==0.7.3
 platformdirs==4.3.8
 plotly==6.2.0
 portalocker==3.2.0
+pyarrow==20.0.0
 psutil==7.0.0
 python-dateutil==2.9.0.post0
 pytz==2025.2
@@ -28,4 +29,3 @@ tzdata==2025.2
 urllib3==2.5.0
 xlsxwriter==3.2.5
 zipp==3.23.0
-pandas-ta==0.3.14b0


### PR DESCRIPTION
## Summary
- add `pyarrow` to main requirements
- remove duplicate `pandas-ta` entry in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698e6bf6b883258514abbd903a7e1d