### PR TITLE
Fix log directory handling

### DIFF
--- a/finansal_analiz_sistemi/log_tools.py
+++ b/finansal_analiz_sistemi/log_tools.py
@@ -96,7 +96,9 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
                     log_file, maxBytes=2_000_000, backupCount=20, encoding="utf-8"
                 )
             fh.setFormatter(
-                logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
+                logging.Formatter(
+                    "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+                )
             )
             fh.addFilter(DuplicateFilter())
             root.addHandler(fh)

--- a/finansal_analiz_sistemi/log_tools.py
+++ b/finansal_analiz_sistemi/log_tools.py
@@ -76,11 +76,34 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
     """Configure root logger for console and file output."""
 
     root = logging.getLogger()
-    if root.handlers:
-        return _counter_filter
-
     log_dir = Path("loglar")
     log_dir.mkdir(exist_ok=True)
+
+    if root.handlers:
+        root.setLevel(level)
+        if not any(
+            isinstance(h, (RotatingFileHandler, logging.FileHandler))
+            and Path(getattr(h, "baseFilename", "")).parent == log_dir
+            for h in root.handlers
+        ):
+            if config.IS_COLAB:
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                log_file = log_dir / f"colab_run_{timestamp}.log"
+                fh = logging.FileHandler(log_file, encoding="utf-8")
+            else:
+                log_file = log_dir / "rapor.log"
+                fh = RotatingFileHandler(
+                    log_file, maxBytes=2_000_000, backupCount=20, encoding="utf-8"
+                )
+            fh.setFormatter(
+                logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
+            )
+            fh.addFilter(DuplicateFilter())
+            root.addHandler(fh)
+        if _counter_filter not in root.filters:
+            root.addFilter(_counter_filter)
+        root.propagate = False
+        return _counter_filter
     if config.IS_COLAB:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         log_file = log_dir / f"colab_run_{timestamp}.log"


### PR DESCRIPTION
## Summary
- ensure log directory and handler are added when logging is preconfigured

## Testing
- `pytest -q`
- `python - <<'PY'
import os, logging
from finansal_analiz_sistemi.log_tools import setup_logger
import finansal_analiz_sistemi
print('loglar exists before:', os.path.exists('loglar'))
setup_logger()
print('loglar exists after:', os.path.exists('loglar'))
print('handlers', logging.getLogger().handlers)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686998e075e8832599443d15f3af3979