### PR TITLE
Add OpenBB stubs and fix pandas-ta import

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 import warnings
+# Ensure pandas_ta can locate its distribution info
+import importlib.metadata  # noqa: F401
 
 import numpy as np
 import pandas as pd

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -6,10 +6,10 @@
 
 from __future__ import annotations
 
-import re
-import warnings
 # Ensure pandas_ta can locate its distribution info
 import importlib.metadata  # noqa: F401
+import re
+import warnings
 
 import numpy as np
 import pandas as pd

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -1,0 +1,60 @@
+"""Stubs for missing OpenBB functionality.
+
+This module defines placeholder functions for pandas-ta features not yet
+supported by OpenBB. Each function simply raises ``NotImplementedError``
+to signal that an equivalent implementation is unavailable.
+"""
+
+from __future__ import annotations
+
+
+def tema(*_args, **_kwargs):
+    """Placeholder for :func:`pandas_ta.tema`."""
+    raise NotImplementedError("openbb equivalent for 'tema' is missing")
+
+
+def Strategy(*_args, **_kwargs):  # noqa: N802
+    """Placeholder for :class:`pandas_ta.Strategy`."""
+    raise NotImplementedError("openbb equivalent for 'Strategy' is missing")
+
+
+def strategy(*_args, **_kwargs):
+    """Placeholder for ``DataFrame.ta.strategy``."""
+    raise NotImplementedError("openbb equivalent for 'strategy' is missing")
+
+
+def psar(*_args, **_kwargs):
+    """Placeholder for ``DataFrame.ta.psar`` or :func:`pandas_ta.psar`."""
+    raise NotImplementedError("openbb equivalent for 'psar' is missing")
+
+
+def ichimoku(*_args, **_kwargs):
+    """Placeholder for :func:`pandas_ta.ichimoku`."""
+    raise NotImplementedError("openbb equivalent for 'ichimoku' is missing")
+
+
+def rsi(*_args, **_kwargs):
+    """Placeholder for :func:`pandas_ta.rsi`."""
+    raise NotImplementedError("openbb equivalent for 'rsi' is missing")
+
+
+def macd(*_args, **_kwargs):
+    """Placeholder for :func:`pandas_ta.macd`."""
+    raise NotImplementedError("openbb equivalent for 'macd' is missing")
+
+
+def stochrsi(*_args, **_kwargs):
+    """Placeholder for :func:`pandas_ta.stochrsi`."""
+    raise NotImplementedError("openbb equivalent for 'stochrsi' is missing")
+
+
+MISSING_FUNCTIONS = [
+    "tema",
+    "Strategy",
+    "strategy",
+    "psar",
+    "ichimoku",
+    "rsi",
+    "macd",
+    "stochrsi",
+]


### PR DESCRIPTION
## Summary
- fix pandas_ta import on Python 3.11 by preloading `importlib.metadata`
- add `openbb_missing.py` with dummy stubs for TA functions missing in OpenBB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_686ac5cd9ffc8325b66ff50bb8ca872d