### PR TITLE
Add OpenBB TA wrappers

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -16,6 +16,9 @@ import pandas as pd
 import pandas.errors
 
 from finansal_analiz_sistemi.utils.normalize import normalize_filtre_kodu
+from openbb_missing import ichimoku as obb_ichimoku
+from openbb_missing import macd as obb_macd
+from openbb_missing import rsi as obb_rsi
 from utils.compat import safe_concat
 
 # Tarih: 19 Mayıs 2025 (Tüm özel fonksiyonlar eklendi, reset_index
@@ -995,7 +998,7 @@ def _calculate_group_indicators_and_crossovers(
         and {"high", "low", "close"}.issubset(df_final_group.columns)
     ):
         try:
-            ich_df, _ = ta.ichimoku(
+            ich_df, _ = obb_ichimoku(
                 df_final_group["high"],
                 df_final_group["low"],
                 df_final_group["close"],
@@ -1036,7 +1039,7 @@ def _calculate_group_indicators_and_crossovers(
 
     if "rsi_14" not in df_final_group.columns and "close" in df_final_group.columns:
         try:
-            manual_cols["rsi_14"] = ta.rsi(df_final_group["close"], length=14)
+            manual_cols["rsi_14"] = obb_rsi(df_final_group["close"], length=14)
             local_logger.debug(
                 f"{hisse_kodu}: 'rsi_14' sütunu manuel olarak hesaplandı."
             )
@@ -1049,7 +1052,7 @@ def _calculate_group_indicators_and_crossovers(
         {"macd_line", "macd_signal"} - set(df_final_group.columns)
     ) and "close" in df_final_group.columns:
         try:
-            macd_df = ta.macd(df_final_group["close"], fast=12, slow=26, signal=9)
+            macd_df = obb_macd(df_final_group["close"], fast=12, slow=26, signal=9)
             if isinstance(macd_df, pd.DataFrame):
                 if "macd_line" not in df_final_group.columns:
                     manual_cols["macd_line"] = macd_df.iloc[:, 0]

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -28,19 +28,98 @@ def psar(*_args, **_kwargs):
     raise NotImplementedError("openbb equivalent for 'psar' is missing")
 
 
-def ichimoku(*_args, **_kwargs):
-    """Placeholder for :func:`pandas_ta.ichimoku`."""
-    raise NotImplementedError("openbb equivalent for 'ichimoku' is missing")
+import pandas as pd
 
 
-def rsi(*_args, **_kwargs):
-    """Placeholder for :func:`pandas_ta.rsi`."""
-    raise NotImplementedError("openbb equivalent for 'rsi' is missing")
+def _call_openbb(func_name: str, **kwargs):
+    """Invoke an OpenBB technical analysis function if available."""
+    try:
+        from openbb import obb  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise NotImplementedError(
+            f"openbb equivalent for '{func_name}' is missing"
+        ) from exc
+    func = getattr(obb.technical, func_name, None)
+    if func is None:
+        raise NotImplementedError(f"openbb equivalent for '{func_name}' is missing")
+    return func(**kwargs)
 
 
-def macd(*_args, **_kwargs):
-    """Placeholder for :func:`pandas_ta.macd`."""
-    raise NotImplementedError("openbb equivalent for 'macd' is missing")
+def ichimoku(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    conversion: int = 9,
+    base: int = 26,
+    lagging: int = 52,
+    offset: int = 26,
+    lookahead: bool = False,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Wrapper for OpenBB ``ichimoku`` returning pandas objects."""
+    df = pd.DataFrame(
+        {
+            "date": close.index,
+            "high": high.values,
+            "low": low.values,
+            "close": close.values,
+        }
+    )
+    obb_obj = _call_openbb(
+        "ichimoku",
+        data=df.to_dict("records"),
+        conversion=conversion,
+        base=base,
+        lagging=lagging,
+        offset=offset,
+        lookahead=lookahead,
+    )
+    res_df = pd.DataFrame(obb_obj.results).set_index("date")
+    span_cols = [c for c in res_df.columns if c.startswith("span_")]
+    ich_cols = [c for c in res_df.columns if c not in span_cols]
+    return res_df[ich_cols], res_df[span_cols]
+
+
+def rsi(
+    close: pd.Series,
+    length: int = 14,
+    scalar: float = 100.0,
+    drift: int = 1,
+) -> pd.Series:
+    """Wrapper for OpenBB ``rsi`` returning a Series."""
+    df = pd.DataFrame({"date": close.index, "close": close.values})
+    obb_obj = _call_openbb(
+        "rsi",
+        data=df.to_dict("records"),
+        target="close",
+        length=length,
+        scalar=scalar,
+        drift=drift,
+    )
+    res_df = pd.DataFrame(obb_obj.results).set_index("date")
+    rsi_col = [c for c in res_df.columns if c.lower().startswith("close_rsi")]
+    col = rsi_col[0] if rsi_col else res_df.columns[-1]
+    return res_df[col].rename(close.name)
+
+
+def macd(
+    close: pd.Series,
+    fast: int = 12,
+    slow: int = 26,
+    signal: int = 9,
+) -> pd.DataFrame:
+    """Wrapper for OpenBB ``macd`` returning a DataFrame."""
+    df = pd.DataFrame({"date": close.index, "close": close.values})
+    obb_obj = _call_openbb(
+        "macd",
+        data=df.to_dict("records"),
+        target="close",
+        fast=fast,
+        slow=slow,
+        signal=signal,
+    )
+    res_df = pd.DataFrame(obb_obj.results).set_index("date")
+    macd_cols = [c for c in res_df.columns if c.lower().startswith("close_macd")]
+    return res_df[macd_cols]
 
 
 def stochrsi(*_args, **_kwargs):
@@ -53,8 +132,5 @@ MISSING_FUNCTIONS = [
     "Strategy",
     "strategy",
     "psar",
-    "ichimoku",
-    "rsi",
-    "macd",
     "stochrsi",
 ]

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -7,6 +7,12 @@ to signal that an equivalent implementation is unavailable.
 
 from __future__ import annotations
 
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    from openbb import obb  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    obb = None
 
 def tema(*_args, **_kwargs):
     """Placeholder for :func:`pandas_ta.tema`."""
@@ -28,17 +34,12 @@ def psar(*_args, **_kwargs):
     raise NotImplementedError("openbb equivalent for 'psar' is missing")
 
 
-import pandas as pd
-
-
 def _call_openbb(func_name: str, **kwargs):
     """Invoke an OpenBB technical analysis function if available."""
-    try:
-        from openbb import obb  # type: ignore
-    except Exception as exc:  # pragma: no cover - optional dependency
+    if obb is None:
         raise NotImplementedError(
             f"openbb equivalent for '{func_name}' is missing"
-        ) from exc
+        )
     func = getattr(obb.technical, func_name, None)
     if func is None:
         raise NotImplementedError(f"openbb equivalent for '{func_name}' is missing")

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -14,6 +14,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     obb = None
 
+
 def tema(*_args, **_kwargs):
     """Placeholder for :func:`pandas_ta.tema`."""
     raise NotImplementedError("openbb equivalent for 'tema' is missing")
@@ -37,9 +38,7 @@ def psar(*_args, **_kwargs):
 def _call_openbb(func_name: str, **kwargs):
     """Invoke an OpenBB technical analysis function if available."""
     if obb is None:
-        raise NotImplementedError(
-            f"openbb equivalent for '{func_name}' is missing"
-        )
+        raise NotImplementedError(f"openbb equivalent for '{func_name}' is missing")
     func = getattr(obb.technical, func_name, None)
     if func is None:
         raise NotImplementedError(f"openbb equivalent for '{func_name}' is missing")


### PR DESCRIPTION
## Summary
- add wrappers for OpenBB technical analysis functions in `openbb_missing.py`
- update `indicator_calculator` to use wrappers for Ichimoku, RSI and MACD

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ac8899de083259cc50fa8752572db