### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "pandas-ta-openbb"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- configure Dependabot for pip packages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686af311d21c83258f1a5bef6548521d