### PR TITLE
Align dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ isort==6.0.1
 mypy==1.16.1
 mypy_extensions==1.1.0
 nodeenv==1.9.1
-packaging>=23,<26
+packaging>=25,<26
 pathspec==0.12.1
 pluggy==1.6.0
 pydantic==2.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ psutil==7.0.0
 python-dateutil==2.9.0.post0
 pytz==2025.2
 PyYAML==6.0.2
-requests==2.32.3
+requests==2.32.4
 simplejson==3.20.1
 six==1.17.0
 sortedcontainers==2.4.0


### PR DESCRIPTION
## Summary
- update `requests` to 2.32.4 across environments
- require packaging >=25

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686b0257df70832597901eced5c10865