### PR TITLE
🧹 Kod Tabanı Temizliği ve Fonksiyonel Güncellemeler

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,7 +16,7 @@
 - New unit tests cover cycle and depth errors.
 - cycle_test_log.txt captures test run output.
 - Validation exits with status 2 when cycles are present.
-- Placeholder apply_filter_logic returns filter id for now.
+- apply_filter_logic helper removed; evaluate_filter now returns the filter id directly.
 - Two cycles detected in synthetic tests during development.
 - Consolidated configuration into paket `finansal_analiz_sistemi.config`.
 - Renamed old root config to `config_local.py` to prevent shadowing.

--- a/filter_engine.py
+++ b/filter_engine.py
@@ -79,10 +79,6 @@ class MaxDepthError(RuntimeError):
 FILTER_DEFS: dict[str, dict] = {}
 
 
-def apply_filter_logic(fid: str) -> Any:
-    """Placeholder logic for filter execution."""
-    return fid
-
 
 def _build_solution(err_type: str, msg: str) -> str:
     if err_type == "GENERIC":
@@ -135,7 +131,9 @@ def evaluate_filter(
     seen.add(key)
     for child in children:
         evaluate_filter(child, df=df, depth=depth + 1, seen=seen)
-    return apply_filter_logic(key)
+    # Previously returned apply_filter_logic(key) which merely echoed the id.
+    # Returning the filter identifier directly simplifies the API.
+    return key
 
 
 def safe_eval(expr, df, depth: int = 0, visited=None):


### PR DESCRIPTION
## Değişiklikler
- `filter_engine.evaluate_filter` artık `apply_filter_logic` fonksiyonunu
  kullanmıyor ve doğrudan filtre kodunu döndürüyor
- kullanılmayan `apply_filter_logic` yardımcı fonksiyonu kaldırıldı
- dökümantasyon güncellendi

## Testler
- `pytest -q`
- `python -m finansal_analiz_sistemi --help`
- `tail -f loglar/debug_log.txt` (dosya mevcut olmadığı için hata verdi)

------
https://chatgpt.com/codex/tasks/task_e_686c1c4c22088325b6a2b9b19668f4ca