### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,11 +20,11 @@ _ = sitecustomize  # ensure side-effects
 
 
 def _sanitize_sys_modules() -> None:
-    """Hypothesis'in ``unhashable module`` hatasını önle.
+    """Ensure all ``sys.modules`` entries are hashable for Hypothesis.
 
-    ``sys.modules`` içinde gerçek :class:`ModuleType` olmayan girdileri tespit
-    eder; aynı isimle yeni bir :class:`ModuleType` üretip orijinal
-    öznitelikleri kopyalar. Böylece **hashable** hâle gelirler.
+    Detect items that are not real :class:`ModuleType` instances, create a
+    new ``ModuleType`` with the same name and copy their attributes so that
+    ``sys.modules`` only contains hashable objects.
     """
 
     fixed: dict[str, ModuleType] = {}
@@ -68,6 +68,7 @@ if not hasattr(SimpleNamespace, "__hash__"):
 
 @pytest.fixture
 def big_df() -> pd.DataFrame:
+    """Return a large DataFrame for performance-oriented tests."""
     rows = 10_000
     return pd.DataFrame(
         {

--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -17,13 +17,12 @@ SEBEP_KODLARI = {
 def dogrula_filtre_dataframe(
     df_filtre: pd.DataFrame, zorunlu_kolonlar=None, logger=None
 ) -> dict:
-    """
-    Filtre DataFrame'inde flag/query eksikliği veya bozukluğu kontrol eder.
-    Uygunsuz filtreleri ``{'filter_code': 'açıklama'}`` şeklinde döndürür.
+    """Validate a filter DataFrame and return problematic rows.
 
-    Varsayılan ``zorunlu_kolonlar`` değeri ``["flag", "query"]`` olup,
-    bunlar CSV'de sırasıyla ``FilterCode`` ve ``PythonQuery`` sütunlarına
-    karşılık gelir.
+    Checks for missing or malformed ``flag`` and ``query`` columns and
+    returns a mapping ``{'filter_code': 'reason'}`` for invalid rows.
+    The default ``zorunlu_kolonlar`` value is ``["flag", "query"]``,
+    corresponding to ``FilterCode`` and ``PythonQuery`` in the CSV file.
     """
     sorunlu = {}
     zorunlu_kolonlar = zorunlu_kolonlar or ["flag", "query"]

--- a/finansal/cli.py
+++ b/finansal/cli.py
@@ -72,7 +72,7 @@ def main(
         + [f"sma_{n}" for n in (50, 100, 200)]
     )
     active = config.CORE_INDICATORS if ind_set == "core" else full_inds
-    calculate_chunked(df, active, chunk_size=chunk_size)  # yazim: indicator_calculator
+    calculate_chunked(df, active, chunk_size=chunk_size)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/finansal_analiz_sistemi/config.py
+++ b/finansal_analiz_sistemi/config.py
@@ -188,6 +188,7 @@ if not hasattr(sys.modules[__name__], "TA_STRATEGY"):
 if not hasattr(sys.modules[__name__], "get"):
 
     def get(key, default=None):
+        """Return configuration variable ``key`` or ``default`` if missing."""
         return globals().get(key, default)
 
 

--- a/finansal_analiz_sistemi/utils/normalize.py
+++ b/finansal_analiz_sistemi/utils/normalize.py
@@ -4,11 +4,12 @@ import pandas as pd
 
 
 def normalize_filtre_kodu(df: pd.DataFrame) -> pd.DataFrame:
-    """'filtre_kodu' sütununu standartlaştır.
+    """Normalize the ``filtre_kodu`` column name.
 
-    ``FilterCode`` veya ``filtercode`` gibi olası isimleri, baştaki ve sondaki
-    boşluklara aldırmadan ``filtre_kodu`` adına dönüştürür. Birden fazla eşleşen
-    sütun varsa sadece ilki tutulur. Sütun yoksa ``KeyError`` yükseltilir.
+    Possible variants like ``FilterCode`` or ``filtercode`` are converted to
+    ``filtre_kodu`` after stripping surrounding whitespace. When multiple
+    columns match, only the first is kept. Raises ``KeyError`` if no matching
+    column exists.
     """
 
     # Harici müdahalelerden etkilenmemek için kopya üzerinde çalış


### PR DESCRIPTION
## Summary
- remove stray comment in CLI module
- document `config.get`
- translate filter validation docstring to English
- clean and translate test helpers
- clarify normalize helper docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0bd2f2f48325955b5be235267db6