### PR TITLE
🧹 Kullanılmayan Bağımlılık ve Import Temizliği

### DIFF
--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -10,7 +10,6 @@ loguru==0.7.3
 plotly==6.2.0
 portalocker==3.2.0
 filelock==3.13.1
-pyarrow==20.0.0
 psutil==7.0.0
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,5 @@ rich
 click
 psutil
 portalocker
-pyarrow
 cachetools
 loguru

--- a/requirements.lock
+++ b/requirements.lock
@@ -76,8 +76,6 @@ portalocker==3.2.0
     # via -r requirements.txt
 psutil==7.0.0
     # via -r requirements.txt
-pyarrow==20.0.0
-    # via -r requirements.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ loguru==0.7.3
 plotly==6.2.0
 portalocker==3.2.0
 filelock==3.13.1
-pyarrow==20.0.0
 psutil==7.0.0
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2


### PR DESCRIPTION
## Summary
- remove `pyarrow` from dependency lists because it's only used in optional tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d144e3114832586062dc8db3a8662