### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -25,10 +25,11 @@ except ImportError:
 
 
 def _temizle_sayisal_deger(deger):
-    """Convert ``deger`` to ``float`` if possible.
+    """Return ``deger`` as ``float`` if it can be parsed.
 
-    Handles thousand separators using ``.`` and decimal commas. Returns
-    ``np.nan`` when conversion fails.
+    Strings are stripped of non-numeric characters and Turkish style
+    thousand/decimal separators are normalized. ``np.nan`` is returned when
+    conversion fails.
     """
     if pd.isna(deger):
         return np.nan

--- a/report_generator.py
+++ b/report_generator.py
@@ -36,7 +36,11 @@ HATALAR_COLUMNS = [
 
 
 def save_hatalar_excel(df: pd.DataFrame, out_path: str | Path) -> None:
-    """Save errors DataFrame to an Excel file with normalized header."""
+    """Write error records to an Excel file.
+
+    The DataFrame columns are normalized to ``HATALAR_COLUMNS`` before writing
+    to ensure consistent output.
+    """
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     df = df.reindex(columns=HATALAR_COLUMNS, fill_value="-")
@@ -94,13 +98,7 @@ EXPECTED_COLUMNS = [
 
 
 def generate_summary(results: list[dict]) -> pd.DataFrame:
-    """Create summary dataframe from raw result records.
-
-    Parameters
-    ----------
-    results : list[dict]
-        Raw backtest results.
-    """
+    """Return a summary DataFrame derived from backtest results."""
     summary_df = pd.DataFrame(results)
     # Kolonları tam ve sabit sırada tut
     summary_df = summary_df.reindex(columns=EXPECTED_COLUMNS, fill_value=np.nan)
@@ -112,7 +110,7 @@ def generate_summary(results: list[dict]) -> pd.DataFrame:
 
 
 def add_error_sheet(writer: pd.ExcelWriter, error_list: Iterable[tuple]) -> None:
-    """Write error list to a ``Hatalar`` sheet if any errors are present."""
+    """Append ``error_list`` to a ``Hatalar`` sheet when not empty."""
     if error_list:
         safe_to_excel(
             pd.DataFrame(error_list, columns=["timestamp", "level", "message"]),


### PR DESCRIPTION
## Summary
- improve numeric cleaning docstring in `preprocessor.py`
- clarify error-saving docstring in `report_generator.py`
- simplify docstrings for summary generation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d21e2969c8325886262c5dde06543