### PR TITLE
🗑️ Geçici Dosya ve Klasör Temizliği

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,11 @@ dist/
 .mypy_cache/
 htmlcov/
 coverage.xml
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+ehthumbs.db
+
+# Benchmark outputs
+benchmark_output.txt


### PR DESCRIPTION
## Summary
- expand `.gitignore` to cover OS-specific files and benchmark output

No temporary files were present, but `.gitignore` now prevents accidental addition of system artifacts.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d377af6688325ac7d50b3e328558f