### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -73,6 +73,7 @@ def test_logging_config_import(monkeypatch):
     import logging
 
     class DummyHandler(logging.Handler):
+        """Minimal handler used to capture log file configuration."""
         def __init__(self, filename, maxBytes=None, backupCount=None, encoding=None):
             """Test __init__."""
             super().__init__()

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -74,6 +74,7 @@ def test_logging_config_import(monkeypatch):
 
     class DummyHandler(logging.Handler):
         """Minimal handler used to capture log file configuration."""
+
         def __init__(self, filename, maxBytes=None, backupCount=None, encoding=None):
             """Test __init__."""
             super().__init__()

--- a/tests/test_rotate_logging.py
+++ b/tests/test_rotate_logging.py
@@ -17,6 +17,7 @@ def test_log_rotation(tmp_path, monkeypatch):
 
     class TinyHandler(RotatingFileHandler):
         """Rotate log files aggressively for testing."""
+
         def __init__(self, filename, *args, **kwargs):
             """Test __init__."""
             super().__init__(filename, maxBytes=200, backupCount=1, encoding="utf-8")

--- a/tests/test_rotate_logging.py
+++ b/tests/test_rotate_logging.py
@@ -1,3 +1,5 @@
+"""Tests for log rotation utilities."""
+
 import logging
 from logging.handlers import RotatingFileHandler
 
@@ -14,6 +16,7 @@ def test_log_rotation(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     class TinyHandler(RotatingFileHandler):
+        """Rotate log files aggressively for testing."""
         def __init__(self, filename, *args, **kwargs):
             """Test __init__."""
             super().__init__(filename, maxBytes=200, backupCount=1, encoding="utf-8")


### PR DESCRIPTION
## Summary
- add missing docstring for DummyHandler class
- add missing docstring for TinyHandler and module heading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses', 'openpyxl', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686d39b0a9a48325a910b55024e04c9b