### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/cache_builder.py
+++ b/cache_builder.py
@@ -14,7 +14,11 @@ LOCK_FILE = CACHE.with_suffix(".lock")
 
 
 def build() -> None:
-    """Combine all CSVs under RAW_DIR into a single Parquet cache."""
+    """Build the Parquet cache from raw CSV files when missing.
+
+    Combines all CSVs under ``RAW_DIR`` and writes the result to ``CACHE``.
+    The function does nothing when a populated cache already exists.
+    """
     with FileLock(str(LOCK_FILE)):
         if CACHE.exists() and CACHE.stat().st_size > 0:
             logger.info("Cache hit, skipping build")

--- a/finansal/parquet_cache.py
+++ b/finansal/parquet_cache.py
@@ -23,7 +23,7 @@ class ParquetCacheManager:
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
 
     def load(self) -> DataFrame:  # noqa: D401, D403
-        """Load the cached parquet. Raise FileNotFoundError if absent."""
+        """Load the cached Parquet file or raise ``FileNotFoundError``."""
         import pandas as pd
 
         if not self.cache_path.exists():
@@ -33,7 +33,7 @@ class ParquetCacheManager:
         return df
 
     def refresh(self, csv_path: Path) -> DataFrame:  # noqa: D401, D403
-        """Read CSV (header or comment-style) and update the cache."""
+        """Read a CSV file and update the cache in place."""
         import pandas as pd  # local import to speed CLI --help
 
         read_kwargs = {}

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -48,7 +48,7 @@ def extract_columns_from_filters(
     series_series: list | None,
     series_value: list | None,
 ) -> set:
-    """Filtre sorgularında ve crossover tanımlarında geçen kolon adlarını döndürür."""
+    """Return column names referenced in filters and crossover definitions."""
     try:
         from filter_engine import _extract_query_columns
     except Exception:
@@ -82,16 +82,11 @@ def extract_columns_from_filters_cached(
     series_series: list | None,
     series_value: list | None,
 ) -> set:
-    """Cacheable wrapper for ``extract_columns_from_filters``.
+    """Return referenced columns using a CSV string for caching.
 
-    Parameters
-    ----------
-    df_filters_csv : str
-        CSV representation of the filters DataFrame.
-    series_series : list | None
-        Definitions for series/series crossovers.
-    series_value : list | None
-        Definitions for series/value crossovers.
+    This is a cache-friendly wrapper around
+    :func:`extract_columns_from_filters` that accepts the filters DataFrame as a
+    CSV string.
     """
     df_filters = None
     if df_filters_csv:

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -23,12 +23,16 @@ def clear_failures() -> None:
 
 
 def log_failure(category: str, item: str, reason: str, hint: str = "") -> None:
-    """Log a failure under given category."""
+    """Record a failed item under ``category`` with an optional hint."""
     failures[category].append(FailedFilter(item, reason, hint))
 
 
 def get_failures(as_dict: bool = False):
-    """Return collected failures."""
+    """Return collected failures.
+
+    When ``as_dict`` is ``True`` the result is returned as a plain dictionary
+    suitable for serialization.
+    """
     if as_dict:
         return {c: [asdict(r) for r in rows] for c, rows in failures.items()}
     return failures


### PR DESCRIPTION
## Summary
- clarify Parquet cache build steps
- standardize docstrings for column extraction helpers
- expand failure tracker documentation
- refine Parquet cache manager descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d57f97b3c832584dc505b6f2239a4