### PR TITLE
🗑️ Geçici Dosya ve Klasör Temizliği

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ crossover_test_log.txt
 *.swp
 nohup.out
 logs/
+log/
 tmp/
 output/
 **/output/
@@ -48,6 +49,7 @@ cache/
 **/temp/
 **/tmp/
 **/logs/
+**/log/
 **/output/
 
 # Editor and IDE directories


### PR DESCRIPTION
## Summary
- extend `.gitignore` to cover `log/` directories

No temp or log files were present, so no files were removed.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xlsxwriter')*

------
https://chatgpt.com/codex/tasks/task_e_686d5b14855483258d64754b6a186f08