### PR TITLE
🔁 Çifte Merge Sonrası Kod Temizliği ve Tekrarların Kaldırılması

### DIFF
--- a/finansal_analiz_sistemi/log_tools.py
+++ b/finansal_analiz_sistemi/log_tools.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from finansal_analiz_sistemi import config
+from finansal_analiz_sistemi.logging_config import get_logger as _cfg_get_logger
+from finansal_analiz_sistemi.logging_config import setup_logging as _cfg_setup_logging
 
 PCT_STEP = 10
 
@@ -67,10 +69,10 @@ _counter_filter = CounterFilter()
 
 
 def setup_logging(window: float = 2.0, pct_step: int = 10) -> logging.Logger:
-    """Attach :class:`DuplicateFilter` to root logger and disable propagation."""
+    """Initialize logging via :mod:`logging_config` and attach de-dup filter."""
     global PCT_STEP
     PCT_STEP = max(1, pct_step)
-    root = logging.getLogger()
+    root = _cfg_setup_logging()
     if not any(isinstance(f, DuplicateFilter) for f in root.filters):
         root.addFilter(DuplicateFilter(window))
     root.propagate = False
@@ -137,5 +139,5 @@ def setup_logger(level: int = logging.INFO) -> CounterFilter:
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Return a module-level logger."""
-    return logging.getLogger(name)
+    """Return a module-level logger via :mod:`logging_config`."""
+    return _cfg_get_logger(name)

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -5,7 +5,8 @@ import logging
 import time
 
 from finansal_analiz_sistemi import log_tools
-from finansal_analiz_sistemi.log_tools import DuplicateFilter, setup_logging
+from finansal_analiz_sistemi.log_tools import DuplicateFilter
+from finansal_analiz_sistemi.logging_config import setup_logging
 
 
 def test_setup_logging_deduplicates_and_sets_propagate():


### PR DESCRIPTION
## Summary
- centralize logging setup by calling new logging_config helpers
- adjust tests to import logging_config instead of deprecated log_tools wrappers

## Testing
- `isort finansal_analiz_sistemi/log_tools.py tests/test_setup_logging.py`
- `black finansal_analiz_sistemi/log_tools.py tests/test_setup_logging.py`
- `flake8 finansal_analiz_sistemi/log_tools.py tests/test_setup_logging.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e5645a4ec8325a0cd8ae913a6ea52