### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/tests/test_aciklama_filled.py
+++ b/tests/test_aciklama_filled.py
@@ -13,7 +13,7 @@ if ROOT_DIR not in sys.path:
 
 
 def test_aciklama_filled(tmp_path):
-    """Test test_aciklama_filled."""
+    """Summary rows should be populated with explanation text."""
     # 1 satır OK, 1 satır QUERY_ERROR
     df_sum = pd.DataFrame(
         [
@@ -53,7 +53,7 @@ def test_aciklama_filled(tmp_path):
 
 
 def test_aciklama_dedup(tmp_path):
-    """Test test_aciklama_dedup."""
+    """Error descriptions should not duplicate within the summary sheet."""
     df_sum = pd.DataFrame(
         [
             ["T1", 1, 1.0, 1, 0, 1, "OK", "", "", ""],

--- a/tests/test_filter_sebep_kodu.py
+++ b/tests/test_filter_sebep_kodu.py
@@ -32,19 +32,19 @@ def _apply(query: str) -> str:
 
 
 def test_ok_code():
-    """Test test_ok_code."""
+    """Return ``OK`` when the query executes without issues."""
     code = _apply("close > 5")
     assert code == "OK"
     assert code in SEBEP_KODLARI
 
 
 def test_missing_column_returns_missing_col():
-    """Test test_missing_column_returns_missing_col."""
+    """Missing columns should trigger the ``QUERY_ERROR`` code."""
     code = _apply("missing > 0")
     assert code == "QUERY_ERROR"
 
 
 def test_syntax_error_returns_query_error():
-    """Test test_syntax_error_returns_query_error."""
+    """Syntax errors are reported as ``QUERY_ERROR``."""
     code = _apply("close >")
     assert code == "QUERY_ERROR"

--- a/tests/test_no_data_loss.py
+++ b/tests/test_no_data_loss.py
@@ -6,7 +6,7 @@ from report_generator import generate_full_report
 
 
 def test_no_data_loss(tmp_path):
-    """Test test_no_data_loss."""
+    """Report generation should preserve rows even when values are NaN."""
     # NaN'li ama silinmemesi gereken satır
     df_sum = pd.DataFrame(
         [

--- a/tests/test_no_future_warning.py
+++ b/tests/test_no_future_warning.py
@@ -8,7 +8,7 @@ from utils.compat import safe_concat, safe_to_excel
 
 
 def test_no_future_warning(tmp_path):
-    """Test test_no_future_warning."""
+    """Operations should not emit ``FutureWarning`` under strict settings."""
     df = pd.DataFrame({"a": [1]})
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("error", FutureWarning)

--- a/tests/test_no_pkg_conflict.py
+++ b/tests/test_no_pkg_conflict.py
@@ -8,7 +8,7 @@ import pytest
 
 @pytest.mark.slow
 def test_no_pkg_conflict():
-    """Test test_no_pkg_conflict."""
+    """Ensure package dependencies are consistent and tests still run."""
     pip_check = subprocess.run(
         [sys.executable, "-m", "pip", "check"], capture_output=True, text=True
     )

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -11,7 +11,7 @@ pytest.importorskip("pyarrow")
 
 
 def test_refresh_and_load(tmp_path: Path) -> None:
-    """Test test_refresh_and_load."""
+    """Refresh cache from CSV and ensure subsequent loads match."""
     csv_path = tmp_path / "sample.csv"
     cache_path = tmp_path / "cache.parquet"
 
@@ -28,7 +28,7 @@ def test_refresh_and_load(tmp_path: Path) -> None:
 
 
 def test_load_missing(tmp_path: Path) -> None:  # noqa: D401
-    """Test test_load_missing."""
+    """Loading a missing Parquet file should raise ``FileNotFoundError``."""
     mngr = ParquetCacheManager(tmp_path / "missing.parquet")
     with pytest.raises(FileNotFoundError):
         _ = mngr.load()

--- a/tests/test_percentage_scaling.py
+++ b/tests/test_percentage_scaling.py
@@ -21,6 +21,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
     ],
 )
 def test_normalize_pct(raw, expected):
-    """Test test_normalize_pct."""
+    """Values with various representations normalize to the same percent."""
     result = normalize_pct(pd.Series([raw]))[0]
     assert result == pytest.approx(expected)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 
 def test_temizle_sayisal_deger_thousand_comma():
-    """Test test_temizle_sayisal_deger_thousand_comma."""
+    """Parse numbers with Turkish thousands separators correctly."""
     cases = {
         "1.234,56": 1234.56,
         "12.345,67": 12345.67,
@@ -25,7 +25,7 @@ def test_temizle_sayisal_deger_thousand_comma():
 
 
 def test_on_isle_hisse_verileri_invalid_dates_dropped_and_numeric():
-    """Test test_on_isle_hisse_verileri_invalid_dates_dropped_and_numeric."""
+    """Invalid dates are dropped and numeric columns cast to float."""
     data = {
         "hisse_kodu": ["AAA", "AAA", "AAA"],
         "tarih": ["01.03.2025", "31.02.2025", "02.03.2025"],

--- a/tests/test_purge_old_logs.py
+++ b/tests/test_purge_old_logs.py
@@ -4,7 +4,7 @@ from utils.purge_old_logs import purge_old_logs
 
 
 def test_purge_dry_run(tmp_path):
-    """Test test_purge_dry_run."""
+    """Dry-run should count deletable files without removing them."""
     old = tmp_path / "old.log"
     lock_old = tmp_path / "old.lock"
     old.write_text("")

--- a/tests/test_query_columns.py
+++ b/tests/test_query_columns.py
@@ -6,13 +6,13 @@ import filter_engine
 
 
 def test_extract_ignore_string_literals():
-    """Test test_extract_ignore_string_literals."""
+    """String literals should be ignored when extracting column names."""
     cols = filter_engine._extract_query_columns('aciklama == "BETA" and close > 0')
     assert cols == {"aciklama", "close"}
 
 
 def test_apply_single_filter_string_literal():
-    """Test test_apply_single_filter_string_literal."""
+    """Applying a filter with a string literal should succeed."""
     df = pd.DataFrame(
         {
             "hisse_kodu": ["AAA"],

--- a/tests/test_read_prices.py
+++ b/tests/test_read_prices.py
@@ -6,7 +6,7 @@ from finansal_analiz_sistemi import data_loader
 
 
 def test_read_prices_detects_delimiter(tmp_path):
-    """Test test_read_prices_detects_delimiter."""
+    """``read_prices`` should infer delimiters for different CSV inputs."""
     csv = tmp_path / "p.csv"
     df = pd.DataFrame({"code": ["AAA"], "date": ["2025-01-01"], "open": [1]})
     df.to_csv(csv, sep=";", index=False)

--- a/tests/test_report_format.py
+++ b/tests/test_report_format.py
@@ -18,7 +18,7 @@ if ROOT_DIR not in sys.path:
 
 
 def test_legacy_columns_preserved(tmp_path):
-    """Test test_legacy_columns_preserved."""
+    """Generated report should keep the legacy column layout."""
     path = tmp_path / "rapor.xlsx"
     summary = pd.DataFrame(
         {
@@ -65,7 +65,7 @@ def test_legacy_columns_preserved(tmp_path):
 
 
 def test_error_sheet_not_empty(tmp_path):
-    """Test test_error_sheet_not_empty."""
+    """Error sheet must contain rows when a list is provided."""
     # sahte QUERY_ERROR satırı ekle
     errs = [
         {

--- a/tests/test_report_memory.py
+++ b/tests/test_report_memory.py
@@ -11,7 +11,7 @@ import report_generator
 
 @pytest.mark.slow
 def test_generate_full_report_memory(tmp_path, big_df):
-    """Test test_generate_full_report_memory."""
+    """Generating a full report should stay within reasonable memory usage."""
     base = psutil.Process().memory_info().rss
     out = tmp_path / "rep.xlsx"
     t0 = time.time()

--- a/tests/test_report_write.py
+++ b/tests/test_report_write.py
@@ -6,7 +6,7 @@ import report_generator
 
 
 def test_report_file_created(tmp_path):
-    """Test test_report_file_created."""
+    """Report generation should create a non-empty Excel file."""
     out = tmp_path / "t.xlsx"
     summary_df = pd.DataFrame(columns=report_generator.LEGACY_SUMMARY_COLS)
     detail_df = pd.DataFrame(columns=report_generator.LEGACY_DETAIL_COLS)

--- a/tests/test_rich_logging.py
+++ b/tests/test_rich_logging.py
@@ -37,7 +37,7 @@ def _capture(msg: str) -> str:
 
 
 def test_rich_enabled(monkeypatch):
-    """Test test_rich_enabled."""
+    """Rich logging should activate when environment allows."""
     monkeypatch.delenv("LOG_SIMPLE", raising=False)
     monkeypatch.setattr("finansal_analiz_sistemi.config.IS_COLAB", True)
     importlib.reload(logging_config)  # reload to apply monkeypatch
@@ -46,7 +46,7 @@ def test_rich_enabled(monkeypatch):
 
 
 def test_rich_disabled(monkeypatch):
-    """Test test_rich_disabled."""
+    """Rich logging is disabled when ``LOG_SIMPLE`` is set."""
     monkeypatch.setenv("LOG_SIMPLE", "1")
     importlib.reload(logging_config)
     out = _capture("warn")
@@ -54,7 +54,7 @@ def test_rich_disabled(monkeypatch):
 
 
 def test_rich_handler_added(monkeypatch):
-    """Test test_rich_handler_added."""
+    """A ``RichHandler`` is attached to loggers in supported setups."""
     monkeypatch.delenv("LOG_SIMPLE", raising=False)
     monkeypatch.setattr("finansal_analiz_sistemi.config.IS_COLAB", True)
     logging.getLogger().handlers.clear()

--- a/tests/test_rotate_logging.py
+++ b/tests/test_rotate_logging.py
@@ -7,7 +7,7 @@ from finansal_analiz_sistemi import log_tools as logging_setup
 
 
 def test_log_rotation(tmp_path, monkeypatch):
-    """Test test_log_rotation."""
+    """Log files should rotate when they exceed the size limit."""
     root = logging.getLogger()
     old_handlers = root.handlers[:]
     old_filters = root.filters[:]

--- a/tests/test_settings_fallback.py
+++ b/tests/test_settings_fallback.py
@@ -6,7 +6,7 @@ import settings
 
 
 def test_invalid_depth_fallback(tmp_path, monkeypatch):
-    """Test test_invalid_depth_fallback."""
+    """Invalid integer values fall back to the default depth."""
     cfg = tmp_path / "settings.yaml"
     cfg.write_text("max_filter_depth: bad\n")
     monkeypatch.setenv("FAS_SETTINGS_FILE", str(cfg))
@@ -18,7 +18,7 @@ def test_invalid_depth_fallback(tmp_path, monkeypatch):
 
 
 def test_invalid_yaml_fallback(tmp_path, monkeypatch):
-    """Test test_invalid_yaml_fallback."""
+    """Malformed YAML should not override configuration defaults."""
     cfg = tmp_path / "settings.yaml"
     cfg.write_text("invalid: [\n")
     monkeypatch.setenv("FAS_SETTINGS_FILE", str(cfg))

--- a/tests/test_settings_path.py
+++ b/tests/test_settings_path.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def test_env_override(monkeypatch):
-    """Test test_env_override."""
+    """Environment variable should override the default settings path."""
     monkeypatch.setenv("FAS_SETTINGS_FILE", "/tmp/custom.yaml")
     from finansal_analiz_sistemi.config import get_settings_path
 
@@ -13,7 +13,7 @@ def test_env_override(monkeypatch):
 
 
 def test_colab_path(monkeypatch):
-    """Test test_colab_path."""
+    """Colab runtime must point to the drive-mounted settings file."""
     monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
     monkeypatch.setitem(sys.modules, "google.colab", object())
     from finansal_analiz_sistemi.config import get_settings_path
@@ -23,7 +23,7 @@ def test_colab_path(monkeypatch):
 
 
 def test_local_path(monkeypatch):
-    """Test test_local_path."""
+    """Local environment falls back to repository ``settings.yaml``."""
     monkeypatch.delenv("FAS_SETTINGS_FILE", raising=False)
     sys.modules.pop("google.colab", None)
     from finansal_analiz_sistemi.config import get_settings_path

--- a/tests/test_solution_filled.py
+++ b/tests/test_solution_filled.py
@@ -17,7 +17,7 @@ if ROOT_DIR not in sys.path:
 
 
 def test_solution_not_empty(tmp_path):
-    """Test test_solution_not_empty."""
+    """Generated error sheet should include solution hints."""
     errs = [
         {
             "filtre_kodu": "T500",

--- a/tests/test_summary_columns.py
+++ b/tests/test_summary_columns.py
@@ -29,6 +29,6 @@ EXPECTED_COLUMNS = [
 
 
 def test_summary_columns_complete():
-    """Test test_summary_columns_complete."""
+    """Summary DataFrame should include all expected columns."""
     df = generate_summary(dummy_results())
     assert list(df.columns)[:13] == EXPECTED_COLUMNS

--- a/tests/test_swapaxes.py
+++ b/tests/test_swapaxes.py
@@ -7,7 +7,7 @@ from finansal_analiz_sistemi.utils import swapaxes
 
 
 def test_swapaxes_basic():
-    """Test test_swapaxes_basic."""
+    """swapaxes wrapper should behave like ``DataFrame.T`` by default."""
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     out = swapaxes(df)
     expected = df.T
@@ -15,7 +15,7 @@ def test_swapaxes_basic():
 
 
 def test_swapaxes_axis_args():
-    """Test test_swapaxes_axis_args."""
+    """swapaxes accepts axis parameters identical to ``DataFrame.swapaxes``."""
     df = pd.DataFrame({"x": [5, 6]})
     out = swapaxes(df, 0, 1)
     expected = df.T
@@ -23,7 +23,7 @@ def test_swapaxes_axis_args():
 
 
 def test_swapaxes_invalid_axis():
-    """Test test_swapaxes_invalid_axis."""
+    """Invalid axis values raise ``ValueError``."""
     df = pd.DataFrame({"x": [5, 6]})
     with pytest.raises(ValueError):
         swapaxes(df, 2, 0)

--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -4,7 +4,7 @@ from utilities.naming import unique_name
 
 
 def test_unique_name_helper():
-    """Test test_unique_name_helper."""
+    """``unique_name`` should append a counter when names clash."""
     seen = {"ema_10", "ema_10_1"}
     assert unique_name("ema_10", seen) == "ema_10_2"
     assert "ema_10_2" in seen

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 
 def test_crosses_above_simple_numeric():
-    """Test test_crosses_above_simple_numeric."""
+    """Detect when the first series crosses above the second."""
     s1 = pd.Series([1, 2, 3, 4])
     s2 = pd.Series([4, 3, 2, 1])
     result = crosses_above(s1, s2)
@@ -23,7 +23,7 @@ def test_crosses_above_simple_numeric():
 
 
 def test_crosses_below_simple_numeric():
-    """Test test_crosses_below_simple_numeric."""
+    """Detect when the first series crosses below the second."""
     s1 = pd.Series([4, 3, 2, 1])
     s2 = pd.Series([1, 2, 3, 4])
     result = crosses_below(s1, s2)
@@ -32,7 +32,7 @@ def test_crosses_below_simple_numeric():
 
 
 def test_crosses_above_with_nan_returns_false():
-    """Test test_crosses_above_with_nan_returns_false."""
+    """NaN values should suppress cross-above signals."""
     s1 = pd.Series([1, 2, np.nan, 4])
     s2 = pd.Series([4, 3, 2, 1])
     result = crosses_above(s1, s2)
@@ -41,7 +41,7 @@ def test_crosses_above_with_nan_returns_false():
 
 
 def test_crosses_below_with_nan_returns_false():
-    """Test test_crosses_below_with_nan_returns_false."""
+    """NaN values should suppress cross-below signals."""
     s1 = pd.Series([4, 3, np.nan, 1])
     s2 = pd.Series([1, 2, 3, 4])
     result = crosses_below(s1, s2)
@@ -51,7 +51,7 @@ def test_crosses_below_with_nan_returns_false():
 
 @pytest.mark.parametrize("func", [crosses_above, crosses_below])
 def test_cross_functions_equal_series_return_false(func):
-    """Test test_cross_functions_equal_series_return_false."""
+    """Cross functions return all ``False`` when inputs are equal."""
     s = pd.Series([1, 1, 1, 1])
     result = func(s, s)
     expected = pd.Series([False, False, False, False], dtype=bool)
@@ -60,7 +60,7 @@ def test_cross_functions_equal_series_return_false(func):
 
 
 def test_crosses_above_misaligned_index_length_matches_intersection():
-    """Test test_crosses_above_misaligned_index_length_matches_intersection."""
+    """Length matches index intersection for misaligned series (cross above)."""
     s1 = pd.Series([1, 2, 3, 4], index=[0, 1, 2, 3])
     s2 = pd.Series([4, 3, 2, 1], index=[2, 3, 4, 5])
     result = crosses_above(s1, s2)
@@ -68,7 +68,7 @@ def test_crosses_above_misaligned_index_length_matches_intersection():
 
 
 def test_crosses_below_misaligned_index_length_matches_intersection():
-    """Test test_crosses_below_misaligned_index_length_matches_intersection."""
+    """Length matches index intersection for misaligned series (cross below)."""
     s1 = pd.Series([4, 3, 2, 1], index=[0, 1, 2, 3])
     s2 = pd.Series([1, 2, 3, 4], index=[2, 3, 4, 5])
     result = crosses_below(s1, s2)
@@ -77,7 +77,7 @@ def test_crosses_below_misaligned_index_length_matches_intersection():
 
 @pytest.mark.parametrize("func", [crosses_above, crosses_below])
 def test_cross_functions_with_none_returns_empty_false_series(func):
-    """Test test_cross_functions_with_none_returns_empty_false_series."""
+    """Passing ``None`` yields an empty ``False`` series."""
     s = pd.Series([1, 2, 3])
     result = func(None, s)
     expected = pd.Series(False, index=[])
@@ -85,7 +85,7 @@ def test_cross_functions_with_none_returns_empty_false_series(func):
 
 
 def test_cross_functions_all_nan_do_not_fail():
-    """Test test_cross_functions_all_nan_do_not_fail."""
+    """Cross functions handle all-NaN input without errors."""
     s_nan = pd.Series([np.nan, np.nan, np.nan])
     expected = pd.Series([False, False, False], index=s_nan.index, dtype=bool)
     result_above = crosses_above(s_nan, s_nan)


### PR DESCRIPTION
## Summary
- reword stale docstrings in multiple test modules
- standardize explanations for helper behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_686e645b8dfc83258789af6b0226fc1b