### PR TITLE
🔁 Çifte Merge Sonrası Kod Temizliği ve Tekrarların Kaldırılması

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,3 +31,9 @@ def sample_filtreler():
 def sample_indikator_df():
     """Tiny indicator DataFrame used by health-check tests."""
     return pd.DataFrame({"ichimoku_conversionline": [1.23]})
+
+
+@pytest.fixture
+def summary_df():
+    """Minimal summary DataFrame for report tests."""
+    return pd.DataFrame({"filtre_kodu": ["AAA"], "hisse_kodu": ["AAA"]})

--- a/tests/test_key_columns.py
+++ b/tests/test_key_columns.py
@@ -1,16 +1,6 @@
 """Unit tests for key_columns."""
-
 import pandas as pd
-import pytest
-
 from report_stats import _normalize_pct
-
-
-@pytest.fixture
-def summary_df():
-    """Test summary_df."""
-    return pd.DataFrame({"filtre_kodu": ["X"], "hisse_kodu": ["AAA"]})
-
 
 def test_required_columns_present(summary_df):
     """Summary DataFrame must include key columns used in merges."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,15 +1,5 @@
 """Unit tests for report."""
-
 import pandas as pd
-import pytest
-
-
-@pytest.fixture
-def summary_df():
-    """Test summary_df."""
-    return pd.DataFrame({"filtre_kodu": ["T2_Tn"], "hisse_kodu": ["AAA"]})
-
-
 def test_no_dummy_filter_codes(summary_df):
     """Test test_no_dummy_filter_codes."""
     assert not summary_df["filtre_kodu"].str.contains("FiltreIndex_").any()


### PR DESCRIPTION
## Summary
- share a single `summary_df` fixture via `conftest`
- remove duplicated fixture from `test_report` and `test_key_columns`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xlsxwriter')*

------
https://chatgpt.com/codex/tasks/task_e_686e63cd9f9c8325a4be3909e883af81