### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -97,6 +97,6 @@ def _fix_sys_modules():
     yield
 
 
-def pytest_sessionstart(session: pytest.Session) -> None:  # noqa: D401
-    """Clean ``sys.modules`` before the test session starts."""
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Clean up ``sys.modules`` before the test session starts."""
     _sanitize_sys_modules()

--- a/finansal/cli.py
+++ b/finansal/cli.py
@@ -48,8 +48,8 @@ def main(
     ind_set: str,
     chunk_size: int,
     log_level: str,
-) -> None:  # noqa: D401
-    """Manage the Parquet cache and compute indicators from the CLI."""
+) -> None:
+    """Run the CLI to manage the Parquet cache and compute indicators."""
     logging.basicConfig(
         level=getattr(logging, log_level.upper()),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -27,8 +27,8 @@ def test_refresh_and_load(tmp_path: Path) -> None:
     pd.testing.assert_frame_equal(df_cached, df_loaded)
 
 
-def test_load_missing(tmp_path: Path) -> None:  # noqa: D401
-    """Loading a missing Parquet file should raise ``FileNotFoundError``."""
+def test_load_missing(tmp_path: Path) -> None:
+    """Raise ``FileNotFoundError`` when the Parquet file is missing."""
     mngr = ParquetCacheManager(tmp_path / "missing.parquet")
     with pytest.raises(FileNotFoundError):
         _ = mngr.load()


### PR DESCRIPTION
## Summary
- clean up D401 suppressions by rewriting short docstrings
- ensure CLI entrypoint and tests follow a consistent style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e68c7f7fc83259be608542883e1d1