### PR TITLE
🔁 Çifte Merge Sonrası Kod Temizliği ve Tekrarların Kaldırılması

### DIFF
--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -55,8 +55,6 @@ def test_standardize_date_column_no_match():
     assert out.columns.tolist() == ["x"]
 
 
-
-
 def test_check_and_create_dirs(tmp_path: Path):
     """Test test_check_and_create_dirs."""
     new_dir = tmp_path / "nested"

--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -55,19 +55,6 @@ def test_standardize_date_column_no_match():
     assert out.columns.tolist() == ["x"]
 
 
-def test_standardize_ohlcv_columns():
-    """Test test_standardize_ohlcv_columns."""
-    df = pd.DataFrame(
-        {
-            "Açılış": [1],
-            "Yüksek": [2],
-            "Düşük": [0],
-            "Kapanış": [1],
-            "Miktar": [10],
-        }
-    )
-    out = data_loader._standardize_ohlcv_columns(df, "dummy")
-    assert set(["open", "high", "low", "close", "volume"]).issubset(out.columns)
 
 
 def test_check_and_create_dirs(tmp_path: Path):

--- a/tests/test_key_columns.py
+++ b/tests/test_key_columns.py
@@ -1,17 +1,8 @@
 """Unit tests for key_columns."""
 
-import pandas as pd
-
-from report_stats import _normalize_pct
-
 
 def test_required_columns_present(summary_df):
     """Summary DataFrame must include key columns used in merges."""
     assert {"filtre_kodu", "hisse_kodu"} <= set(summary_df.columns)
 
 
-def test_normalize_pct():
-    """Whole-number percentages should be scaled to fractional form."""
-    ser = pd.Series([5.0, 0.07, -350])
-    out = _normalize_pct(ser)
-    assert out.tolist() == [0.05, 0.07, -3.5]

--- a/tests/test_key_columns.py
+++ b/tests/test_key_columns.py
@@ -4,5 +4,3 @@
 def test_required_columns_present(summary_df):
     """Summary DataFrame must include key columns used in merges."""
     assert {"filtre_kodu", "hisse_kodu"} <= set(summary_df.columns)
-
-


### PR DESCRIPTION
## Summary
- remove duplicate `test_normalize_pct` case
- drop redundant `test_standardize_ohlcv_columns`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6dd90ec48325ae0f254a5059000b