### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -3,7 +3,7 @@
 import atexit
 import logging
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 # allow running this file directly
@@ -38,8 +38,11 @@ def run_analysis(csv_path: Path) -> Path:
     return out_path
 
 
-def parse_args():
-    """Parse command-line arguments for the CLI."""
+def parse_args() -> Namespace:
+    """Return parsed arguments for this CLI.
+
+    Parses options controlling report generation and filter validation.
+    """
     p = ArgumentParser(description="Rapor üret veya filtreleri doğrula")
 
     p.add_argument(

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,4 +1,8 @@
-"""Helpers for generating unique column names."""
+"""Utilities for generating unique DataFrame column names.
+
+The :func:`unique_name` helper appends a numeric suffix when ``base`` is
+already present in the provided set.
+"""
 
 __all__ = ["unique_name"]
 


### PR DESCRIPTION
## Summary
- refine CLI argument parser docstring
- expand module documentation for `utilities.naming`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_686e74c143f083259ea42c8510e197bc