### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -227,9 +227,23 @@ def kaydet_hata(
     log_dict.setdefault("hatalar", []).append(entry)
 
 
-def run_filter(code, df, expr):
-    """Run a filter expression and return the resulting DataFrame."""
-    # Pasif filtreler listede mi?
+def run_filter(code: str, df: pd.DataFrame, expr: str) -> pd.DataFrame:
+    """Execute ``expr`` on ``df`` unless the filter is marked passive.
+
+    Parameters
+    ----------
+    code : str
+        Identifier of the filter to run.
+    df : pd.DataFrame
+        DataFrame containing indicator columns.
+    expr : str
+        Filter expression in ``pandas.query`` syntax.
+
+    Returns
+    -------
+    pd.DataFrame
+        Resulting DataFrame or an empty frame when skipped.
+    """
     from finansal_analiz_sistemi.config import cfg
 
     if code in cfg.get("passive_filters", []):

--- a/run.py
+++ b/run.py
@@ -364,14 +364,14 @@ def calistir_tum_sistemi(
 def run_pipeline(
     price_csv: str | Path, filter_def: str | Path, output: str | Path
 ) -> Path:
-    """Execute a lightweight pipeline and produce an Excel report.
+    """Run the pipeline on ``price_csv`` and ``filter_def``.
 
     Parameters
     ----------
     price_csv : str or Path
         CSV file containing historical price data.
     filter_def : str or Path
-        JSON/YAML file with filter definitions.
+        JSON or YAML file with filter definitions.
     output : str or Path
         Target Excel file path for the generated report.
 

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -1,7 +1,8 @@
-"""Delete aged log and lock files from the given directory.
+"""Delete aged log and lock files from ``log_dir``.
 
-The helper is used by maintenance scripts and can operate in dry-run
-mode to preview deletions.
+The helper is intended for maintenance scripts and supports a dry-run
+mode to preview deletions.  In addition to ``*.log`` files, orphaned
+``*.lock`` files are also removed.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- clean up filter execution comments
- clarify `run_filter` and `run_pipeline` docstrings
- expand log cleanup module description

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ecaf4b76483259d1adbc71d357ebf