### PR TITLE
🔁 Çifte Merge Sonrası Kod Temizliği ve Tekrarların Kaldırılması

### DIFF
--- a/finansal_analiz_sistemi/log_tools.py
+++ b/finansal_analiz_sistemi/log_tools.py
@@ -11,39 +11,16 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from finansal_analiz_sistemi import config
-from finansal_analiz_sistemi.logging_config import get_logger as _cfg_get_logger
-from finansal_analiz_sistemi.logging_config import setup_logging as _cfg_setup_logging
+from finansal_analiz_sistemi.logging_config import (
+    get_logger as _cfg_get_logger,
+    setup_logging as _cfg_setup_logging,
+)
+from finansal_analiz_sistemi.logging_utils import ErrorCountingFilter
 
 PCT_STEP = 10
 
 
-class CounterFilter(logging.Filter):
-    """Count warnings and errors for summary reporting."""
-
-    def __init__(self) -> None:
-        """Prepare counters and error list."""
-        super().__init__("counter")
-        self.errors = 0
-        self.warnings = 0
-        self.error_list: list[tuple[str, str, str]] = []
-
-    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
-        """Update counters based on the log level."""
-        if record.levelno == logging.ERROR:
-            self.errors += 1
-            self.error_list.append(
-                (
-                    datetime.now().isoformat(timespec="seconds"),
-                    "ERROR",
-                    record.getMessage(),
-                )
-            )
-        elif record.levelno == logging.WARNING:
-            self.warnings += 1
-        return True
-
-
-_counter_filter = CounterFilter()
+_counter_filter = ErrorCountingFilter()
 
 
 class DuplicateFilter(logging.Filter):
@@ -73,7 +50,7 @@ def get_logger(name: str) -> logging.Logger:
     return _cfg_get_logger(name)
 
 
-def setup_logger(level: int = logging.INFO) -> CounterFilter:
+def setup_logger(level: int = logging.INFO) -> ErrorCountingFilter:
     """Configure root logger for console and file output."""
     root = logging.getLogger()
     log_dir = Path("loglar")

--- a/run.py
+++ b/run.py
@@ -18,7 +18,7 @@ import yaml
 
 import utils
 from finansal_analiz_sistemi import config
-from finansal_analiz_sistemi.log_tools import CounterFilter, setup_logger
+from finansal_analiz_sistemi.log_tools import ErrorCountingFilter, setup_logger
 from finansal_analiz_sistemi.logging_config import get_logger
 from utils.date_utils import parse_date
 
@@ -31,7 +31,7 @@ if not hasattr(config, "CORE_INDICATORS") or not config.CORE_INDICATORS:
 
 
 logger = get_logger(__name__)
-log_counter: CounterFilter | None = None
+log_counter: ErrorCountingFilter | None = None
 
 
 def veri_yukle(force_excel_reload: bool = False):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 from finansal_analiz_sistemi.log_tools import (
-    CounterFilter,
+    ErrorCountingFilter,
     DuplicateFilter,
     setup_logger,
 )
@@ -25,7 +25,7 @@ def test_utils_setup_logger_adds_duplicate_filter_and_disables_propagation():
 
     counter = setup_logger()
 
-    assert isinstance(counter, CounterFilter)
+    assert isinstance(counter, ErrorCountingFilter)
     assert root.propagate is False
     assert any(isinstance(f, DuplicateFilter) for h in root.handlers for f in h.filters)
 


### PR DESCRIPTION
## Summary
- deduplicate error counter logic by replacing `CounterFilter` with `ErrorCountingFilter`
- adjust CLI and tests to use the common filter implementation

## Testing
- `pytest -q` *(fails: XlsxWriter is required)*

------
https://chatgpt.com/codex/tasks/task_e_686ed67daa388325911cf021875d83d5