### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/tests/test_option_guard.py
+++ b/tests/test_option_guard.py
@@ -6,7 +6,7 @@ from utils.pandas_option_safe import ensure_option
 
 
 def test_ensure_option_no_error():
-    """ensure_option should not raise even if option is missing."""
+    """Ensure option setting does not raise even if the option is missing."""
     ensure_option("future.no_silent_downcasting", True)
     try:
         val = pd.get_option("future.no_silent_downcasting")

--- a/tests/test_swapaxes.py
+++ b/tests/test_swapaxes.py
@@ -7,7 +7,7 @@ from finansal_analiz_sistemi.utils import swapaxes
 
 
 def test_swapaxes_basic():
-    """swapaxes wrapper should behave like ``DataFrame.T`` by default."""
+    """Swapaxes wrapper should behave like ``DataFrame.T`` by default."""
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     out = swapaxes(df)
     expected = df.T
@@ -15,7 +15,7 @@ def test_swapaxes_basic():
 
 
 def test_swapaxes_axis_args():
-    """swapaxes accepts axis parameters identical to ``DataFrame.swapaxes``."""
+    """Swapaxes accepts axis parameters identical to ``DataFrame.swapaxes``."""
     df = pd.DataFrame({"x": [5, 6]})
     out = swapaxes(df, 0, 1)
     expected = df.T


### PR DESCRIPTION
## Summary
- standardize docstrings in tests so they start with a capital letter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686edbd596a083259daa59a8f5d06fb9