### PR TITLE
🔁 Çifte Merge Sonrası Kod Temizliği ve Tekrarların Kaldırılması

### DIFF
--- a/finansal_analiz_sistemi/log_tools.py
+++ b/finansal_analiz_sistemi/log_tools.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from finansal_analiz_sistemi import config
-from finansal_analiz_sistemi.logging_config import get_logger as _cfg_get_logger
 from finansal_analiz_sistemi.logging_config import setup_logging as _cfg_setup_logging
 from finansal_analiz_sistemi.logging_utils import ErrorCountingFilter
 
@@ -41,11 +40,6 @@ class DuplicateFilter(logging.Filter):
             if now - ts > self.window:
                 del self._seen[k]
         return last is None or (now - last) > self.window
-
-
-def get_logger(name: str) -> logging.Logger:
-    """Return a module-level logger via :mod:`logging_config`."""
-    return _cfg_get_logger(name)
 
 
 def setup_logger(level: int = logging.INFO) -> ErrorCountingFilter:


### PR DESCRIPTION
## Summary
- remove unused `get_logger` wrapper from `log_tools`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_686ef4a71cf08325b3dc7712aa748553