### PR TITLE
Resolve unused import warning

### DIFF
--- a/finansal_analiz_sistemi/__init__.py
+++ b/finansal_analiz_sistemi/__init__.py
@@ -12,6 +12,9 @@ import yaml
 # Import solely for side-effects (YAML filter resolution).
 from .logging_utils import ErrorCountingFilter  # noqa: F401
 
+# Referans için erişilmez; yan etki importunu pyflakes'tan gizlemek amacıyla
+ErrorCountingFilter
+
 # Configure logging from YAML at package import time
 base = Path(__file__).resolve().parent.parent
 (base / "loglar").mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- reference `ErrorCountingFilter` so `pyflakes` doesn't flag unused import

## Testing
- `flake8`
- `pyflakes finansal_analiz_sistemi`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef90c209883259e4827c22c732794