### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -1,7 +1,7 @@
 """Simplified backtesting utilities used by the CLI.
 
-Functions here implement a lightweight trading simulator for unit tests
-and command line usage.
+Functions implement a lightweight trading simulator for unit tests and
+command-line usage.
 """
 
 import numpy as np

--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -10,7 +10,11 @@ from src.utils.excel_reader import open_excel_cached
 
 
 class DataLoaderCache:
-    """Simple in-memory cache for CSV and Excel readers."""
+    """In-memory caching wrapper for CSV and Excel loaders.
+
+    The cache tracks file modification time and size to avoid redundant
+    disk reads across repeated data-loading operations.
+    """
 
     def __init__(self, logger=None, *, ttl: int = 4 * 60 * 60, maxsize: int = 64):
         """Initialize the cache and configure expiration policy.

--- a/finansal_analiz_sistemi/logging_config.py
+++ b/finansal_analiz_sistemi/logging_config.py
@@ -1,4 +1,8 @@
-"""Logging configuration with optional rich handling."""
+"""Utilities to configure application logging.
+
+The module exposes helpers that attach rich handlers when available and
+fallback to standard stream logging otherwise.
+"""
 
 from __future__ import annotations
 

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,7 +1,7 @@
-"""Excel report generation helpers used by tests and CLI.
+"""Helpers for generating Excel reports used by tests and the CLI.
 
-These utilities assemble performance statistics into an XLSX workbook
-with optional charts and error sheets.
+Utilities here assemble performance statistics into an XLSX workbook with
+optional charts and error sheets.
 """
 
 from __future__ import annotations

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,7 @@
-"""Load optional YAML settings controlling recursion depth.
+"""Load optional YAML settings for the system.
 
-Configuration is read from ``settings.yaml`` or the path specified via
-the ``FAS_SETTINGS_FILE`` environment variable.
+Configuration is read from ``settings.yaml`` or from the path specified via the
+``FAS_SETTINGS_FILE`` environment variable.
 """
 
 from __future__ import annotations

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,7 +1,7 @@
-"""Utilities for generating unique DataFrame column names.
+"""Helpers for generating unique DataFrame column names.
 
-The :func:`unique_name` helper appends a numeric suffix when ``base`` is
-already present in the provided set.
+The :func:`unique_name` helper appends a numeric suffix to ``base`` when it
+already exists in the provided set.
 """
 
 __all__ = ["unique_name"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,7 @@
-"""Shared utility helpers for the analysis project.
+"""Utility helpers shared across the analysis project.
 
-This package bundles crossover detection, filter column extraction and
-log maintenance utilities used by CLI and report modules.
+This package bundles crossover detection, filter column extraction and log
+maintenance helpers used by the CLI and report modules.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- refine module-level docstrings for clarity and style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686fba694e4c8325bd6689c318839587