### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -29,12 +29,7 @@ except ImportError:
 
 
 def _temizle_sayisal_deger(deger):
-    """Return ``deger`` as ``float`` if it can be parsed.
-
-    Strings are stripped of non-numeric characters and Turkish style
-    thousand/decimal separators are normalized. ``np.nan`` is returned when
-    conversion fails.
-    """
+    """Return numeric ``float`` parsed from ``deger`` or ``np.nan``."""
     if pd.isna(deger):
         return np.nan
     if isinstance(

--- a/run.py
+++ b/run.py
@@ -35,7 +35,18 @@ log_counter: ErrorCountingFilter | None = None
 
 
 def _hazirla_rapor_alt_df(rapor_df: pd.DataFrame):
-    """Split report data into summary, detail and stats frames."""
+    """Return summary, detail and statistics DataFrames from ``rapor_df``.
+
+    Parameters
+    ----------
+    rapor_df : pd.DataFrame
+        Combined report table containing raw results.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
+        Separated summary, detail and statistics frames.
+    """
     if rapor_df is None or rapor_df.empty:
         return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
     ozet_df = rapor_df.copy()
@@ -45,7 +56,15 @@ def _hazirla_rapor_alt_df(rapor_df: pd.DataFrame):
 
 
 def _run_gui(ozet_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
-    """Display results in a lightweight Streamlit interface."""
+    """Display results using a minimal Streamlit interface.
+
+    Parameters
+    ----------
+    ozet_df : pd.DataFrame
+        Summary table to show on the "Özet" page.
+    detay_df : pd.DataFrame
+        Detail table displayed when "Detay" is selected.
+    """
     import streamlit as st
 
     st.sidebar.title("Menü")

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -15,11 +15,11 @@ from pandas._libs.tslibs.nattype import NaTType
 
 
 def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
-    """Return ``pd.Timestamp`` from various date formats.
+    """Return a parsed timestamp or ``pd.NaT`` on failure.
 
     The parser tries ``YYYY-MM-DD`` first, then ``DD.MM.YYYY`` and finally a
-    generic day-first parse before falling back to :mod:`dateutil`. Invalid
-    inputs yield ``pd.NaT`` instead of raising ``ValueError``.
+    generic day-first parse before falling back to :mod:`dateutil`. Any invalid
+    input yields ``pd.NaT`` instead of raising ``ValueError``.
     """
     if pd.isna(date_str) or str(date_str).strip() == "":
         return pd.NaT

--- a/utils/memory_profile.py
+++ b/utils/memory_profile.py
@@ -10,7 +10,7 @@ import psutil
 
 
 class mem_profile:
-    """Write peak memory usage to ``reports/memory_profile.csv``."""
+    """Record peak memory usage during the with-block."""
 
     def __enter__(self):
         """Start tracking process memory usage."""


### PR DESCRIPTION
## Summary
- standardize helper docstrings in `parse_date`, `_temizle_sayisal_deger`, `_hazirla_rapor_alt_df`, `_run_gui` and `mem_profile`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_686fe8bacf908325b5933f5fa74a2f29