### PR TITLE
Fix cycle detection in evaluate_filter

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -186,7 +186,7 @@ def evaluate_filter(
     ``FILTER_DEFS``. Raises ``CyclicFilterError`` for cycles and
     ``MaxDepthError`` when ``settings.MAX_FILTER_DEPTH`` is exceeded.
     """
-    seen = seen or set()
+    seen = set(seen or ())
 
     if isinstance(fid, dict):
         key = fid.get("code", repr(fid))
@@ -203,9 +203,8 @@ def evaluate_filter(
     if depth > settings.MAX_FILTER_DEPTH:
         raise MaxDepthError(f"Depth {depth} exceeded on {key}")
 
-    seen.add(key)
     for child in children:
-        evaluate_filter(child, df=df, depth=depth + 1, seen=seen)
+        evaluate_filter(child, df=df, depth=depth + 1, seen=seen | {key})
     return key
 
 


### PR DESCRIPTION
## Summary
- avoid false cycle errors when a child is reused in a filter tree
- update `evaluate_filter` to pass a new `seen` set per branch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ff194c0c88325b1f80cf7e579cc64