### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,7 +1,7 @@
-"""Build the Parquet cache from raw CSV files.
+"""Utilities to create the unified Parquet cache from raw CSV files.
 
-Raw CSV datasets are combined into a single Parquet file that can be
-loaded efficiently by the rest of the project.
+Raw datasets located under :data:`RAW_DIR` are merged and written to
+``CACHE`` so the rest of the project can load data efficiently.
 """
 
 from pathlib import Path
@@ -18,11 +18,7 @@ LOCK_FILE = CACHE.with_suffix(".lock")
 
 
 def build() -> None:
-    """Build the Parquet cache when the file is missing or empty.
-
-    All CSV files under :data:`RAW_DIR` are concatenated and written to
-    :data:`CACHE` as a Parquet dataset.
-    """
+    """Create or refresh the Parquet cache from the raw CSV files."""
     with FileLock(str(LOCK_FILE)):
         if CACHE.exists() and CACHE.stat().st_size > 0:
             logger.info("Cache hit, skipping build")

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -87,7 +87,11 @@ def _calc_ema(df: pd.DataFrame, n: int) -> pd.Series:
 
 
 def _calculate_classicpivots_1h_p(group_df: pd.DataFrame) -> pd.Series:
-    """Return the 1H classic pivot point for ``group_df``."""
+    """Compute the 1H classic pivot point for a ticker group.
+
+    The pivot is the mean of ``high``, ``low`` and ``close`` for each row
+    and is rounded to two decimals.
+    """
     hisse_str = (
         group_df["hisse_kodu"].iloc[0]
         if not group_df.empty and "hisse_kodu" in group_df.columns

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 def _call_openbb(func_name: str, **kwargs):
-    """Return the result of ``obb.technical.func_name`` if available.
+    """Invoke ``obb.technical.func_name`` when OpenBB is installed.
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def _call_openbb(func_name: str, **kwargs):
     Returns
     -------
     Any
-        Value returned by the OpenBB function.
+        Value produced by the OpenBB function.
 
     Raises
     ------

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -29,7 +29,11 @@ except ImportError:
 
 
 def _temizle_sayisal_deger(deger):
-    """Return numeric ``float`` parsed from ``deger`` or ``np.nan``."""
+    """Parse ``deger`` and return a float or ``np.nan`` on failure.
+
+    String inputs are cleaned of thousand separators and decimal commas
+    before conversion. Unsupported types yield ``np.nan``.
+    """
     if pd.isna(deger):
         return np.nan
     if isinstance(

--- a/validators.py
+++ b/validators.py
@@ -1,7 +1,7 @@
-"""Validation utilities used across the project.
+"""Validation utilities for structured error reporting.
 
-This module exposes :class:`ValidationError` for structured error
-reporting.
+The module exposes :class:`ValidationError` so helpers can return
+consistent error objects instead of bare strings.
 """
 
 from dataclasses import dataclass
@@ -11,7 +11,23 @@ __all__ = ["ValidationError"]
 
 @dataclass
 class ValidationError:
-    """Structured error information returned by validators."""
+    """Structured information about a validation failure.
+
+    Attributes
+    ----------
+    hata_tipi : str
+        Short code identifying the error type.
+    eksik_ad : str
+        Name of the missing or invalid field.
+    detay : str
+        Detailed explanation of the issue.
+    cozum_onerisi : str
+        Suggested resolution for the user.
+    reason : str
+        Localized failure reason.
+    hint : str
+        Localized hint to assist recovery.
+    """
 
     hata_tipi: str
     eksik_ad: str


### PR DESCRIPTION
## Summary
- refine module and class docstrings for `validators`
- clarify cache builder documentation
- expand numeric cleaning notes in `preprocessor`
- detail classic pivot calculation in indicator code
- tweak OpenBB wrapper wording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687027fbf59c8325bc5d77c3e0f7ee61