### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -145,6 +145,7 @@ def _build_solution(err_type: str, msg: str) -> str:
     -------
     str
         Localized hint text suitable for displaying to the user.
+
     """
     if err_type == "GENERIC":
         m1 = _missing_re.search(msg)

--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -560,6 +560,7 @@ def _calculate_series_series_crossover(
     tuple[pd.Series, pd.Series] | None
         Pair of boolean Series for cross-above and cross-below or ``None`` when
         the columns are missing.
+
     """
     if logger_param is None:
         logger_param = logger
@@ -633,6 +634,7 @@ def _calculate_series_value_crossover(
     tuple[pd.Series, pd.Series] | None
         Series for cross-above and cross-below events or ``None`` when the
         source column is missing.
+
     """
     if logger_param is None:
         logger_param = logger

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -38,6 +38,7 @@ def _align(a: pd.Series, b: pd.Series) -> tuple[pd.Series, pd.Series]:
     -------
     tuple[pd.Series, pd.Series]
         ``(a, b)`` reindexed to the intersection of their indices.
+
     """
     x, y = a.align(b, join="inner")
     return x, y
@@ -57,6 +58,7 @@ def _crosses(a: pd.Series, b: pd.Series, above: bool) -> pd.Series:
     -------
     pd.Series
         Boolean mask indexed like the aligned input series.
+
     """
     if a is None or b is None:
         return pd.Series(False, index=[])
@@ -96,6 +98,7 @@ def extract_columns_from_filters(
     -------
     set
         Unique column names required for indicator computation.
+
     """
     try:
         from filter_engine import _extract_query_columns
@@ -145,6 +148,7 @@ def extract_columns_from_filters_cached(
     -------
     set
         Unique column names collected from the CSV content.
+
     """
     df_filters = None
     if df_filters_csv:


### PR DESCRIPTION
## Summary
- fix missing blank line after `Returns` section in `_build_solution`
- fix missing blank lines in indicator calculator crossover helpers
- add missing blank lines to utils helper docstrings

## Testing
- `pytest -q`
- `ruff check --select D1,D2,D3,D4 --ignore D401`

------
https://chatgpt.com/codex/tasks/task_e_6872340c26248325970b258d652ef3e9