### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -1,4 +1,5 @@
-"""Simplified backtesting utilities.
+"""
+Simplified backtesting utilities.
 
 Functions implement a lightweight trading simulator for unit tests and
 command-line usage.
@@ -20,7 +21,8 @@ def calistir_basit_backtest(
     tarama_tarihi_str: str,
     logger_param=None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Run a simple backtest using the given filter results.
+    """
+    Run a simple backtest using the given filter results.
 
     Args:
         filtre_sonuc_dict (dict): Mapping of filter codes to selected stocks.
@@ -122,7 +124,8 @@ def _get_fiyat(
     zaman_sutun_adi: str,
     logger_param=None,
 ) -> float:
-    """Return the price for ``tarih`` using the given column.
+    """
+    Return the price for ``tarih`` using the given column.
 
     Falls back to the nearest available date when an exact match is missing.
 

--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,4 +1,5 @@
-"""Create a consolidated Parquet cache from raw CSV files.
+"""
+Create a consolidated Parquet cache from raw CSV files.
 
 CSV files under :data:`RAW_DIR` are merged once and persisted as
 :data:`CACHE` so that subsequent runs can load the combined dataset
@@ -19,7 +20,8 @@ LOCK_FILE = CACHE.with_suffix(".lock")
 
 
 def build() -> None:
-    """Build the Parquet cache from the raw CSV files.
+    """
+    Build the Parquet cache from the raw CSV files.
 
     Reads all CSV files under ``RAW_DIR`` and writes them as a single
     Parquet file to ``CACHE``. When an existing cache is found, the

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -1,4 +1,5 @@
-"""Fallback wrappers for optional OpenBB indicators.
+"""
+Fallback wrappers for optional OpenBB indicators.
 
 Functions call into :mod:`openbb` when it is installed. If the package is
 missing, the helpers raise a :class:`NotImplementedError` to signal the
@@ -16,7 +17,8 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 def _call_openbb(func_name: str, **kwargs):
-    """Return ``obb.technical.func_name`` result if available.
+    """
+    Return ``obb.technical.func_name`` result if available.
 
     Args:
         func_name: Name of the technical indicator function under ``obb``.
@@ -47,7 +49,8 @@ def ichimoku(
     offset: int = 26,
     lookahead: bool = False,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Return Ichimoku indicator DataFrames generated via OpenBB.
+    """
+    Return Ichimoku indicator DataFrames generated via OpenBB.
 
     Args:
         high: High price series.
@@ -91,7 +94,8 @@ def macd(
     slow: int = 26,
     signal: int = 9,
 ) -> pd.DataFrame:
-    """Return MACD indicator columns generated via OpenBB.
+    """
+    Return MACD indicator columns generated via OpenBB.
 
     Args:
         close: Close price series.
@@ -122,7 +126,8 @@ def rsi(
     scalar: float = 100.0,
     drift: int = 1,
 ) -> pd.Series:
-    """Return the RSI series generated via OpenBB.
+    """
+    Return the RSI series generated via OpenBB.
 
     Args:
         close: Close price series.

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -1,4 +1,5 @@
-"""Data preprocessing helpers for stock price datasets.
+"""
+Data preprocessing helpers for stock price datasets.
 
 Functions clean numeric values, align dates and drop invalid rows before
 indicator calculation.
@@ -31,7 +32,8 @@ except ImportError:
 def on_isle_hisse_verileri(
     df_ham: pd.DataFrame, logger_param=None
 ) -> pd.DataFrame | None:
-    """Return cleaned stock data ready for indicator calculation.
+    """
+    Return cleaned stock data ready for indicator calculation.
 
     The preprocessing pipeline fixes date formats, converts OHLCV columns
     to numeric types, manages ``NaN`` values, sorts the dataset and
@@ -272,7 +274,8 @@ def on_isle_hisse_verileri(
 
 
 def _temizle_sayisal_deger(deger):
-    """Parse ``deger`` and return a float or ``np.nan`` on failure.
+    """
+    Parse ``deger`` and return a float or ``np.nan`` on failure.
 
     String inputs are cleaned of thousand separators and decimal commas
     before conversion. Unsupported types yield ``np.nan``.


### PR DESCRIPTION
## Summary
- standardize top-level docstrings across several modules
- adjust function docstrings in preprocessing, backtesting and OpenBB helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68734e47bbf48325b4d6847dbf8deb67