### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,9 +1,10 @@
-"""
-Create a consolidated Parquet cache from raw CSV files.
+"""Build and refresh the Parquet cache used by the project.
 
-CSV files under :data:`RAW_DIR` are merged once and persisted as
-:data:`CACHE` so that subsequent runs can load the combined dataset
-without reading every CSV again.
+CSV files located under :data:`RAW_DIR` are merged into a single Parquet
+file stored at :data:`CACHE`. A :class:`filelock.FileLock` guards the write
+operation so parallel processes do not corrupt the cache. Subsequent runs
+load this consolidated dataset directly without re-reading the individual
+CSV sources.
 """
 
 from pathlib import Path

--- a/filter_engine.py
+++ b/filter_engine.py
@@ -317,10 +317,14 @@ def run_single_filter(kod: str, query: str) -> dict[str, Any]:
 
 
 def safe_eval(expr, df, depth: int = 0, visited=None):
-    """Evaluate filter expressions with depth and cycle guards.
+    """Evaluate a filter expression and return the resulting DataFrame.
 
-    Nested dictionaries are resolved recursively while tracking visited
-    filter codes to prevent circular references.
+    Expressions may be plain query strings or nested dictionaries containing
+    ``sub_expr`` nodes. Nested expressions are resolved recursively while the
+    ``visited`` set keeps track of processed filter codes to detect circular
+    references. The function raises :class:`QueryError` when a syntax error
+    occurs or the maximum recursion depth defined in :mod:`settings` is
+    exceeded.
     """
     if visited is None:
         visited = set()

--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -117,14 +117,10 @@ def _standardize_ohlcv_columns(
     rename_map = {}
     current_columns_set = set(df.columns)  # Anlık sütunları set olarak tut
 
-    # config.OHLCV_MAP içindeki her bir (ham_ad_cfg: standart_ad_cfg) çifti için
+    # Map raw column names defined in ``config.OHLCV_MAP`` to their standardized
+    # equivalents when the target name does not already exist in ``df``.
     for raw_name_from_config, standard_name_target in config.OHLCV_MAP.items():
-        # Eğer config'deki ham_ad DataFrame'in sütunları arasında varsa
         if raw_name_from_config in current_columns_set:
-            # Ve bu ham_ad, zaten hedeflenen standart ad değilse
-            # VE hedeflenen standart ad, DataFrame'de (rename_map ile oluşacaklar dahil) henüz yoksa
-            # VEYA hedeflenen standart ad zaten rename_map'te başka bir orijinal adla
-            # eşleşmişse AMA şu anki raw_name_from_config için değilse
             if (
                 raw_name_from_config != standard_name_target
                 and (
@@ -132,7 +128,7 @@ def _standardize_ohlcv_columns(
                     or standard_name_target not in df.columns
                 )
                 and standard_name_target not in rename_map.values()
-            ):  # Bu standart ada daha önce başka bir sütun atanmamışsa
+            ):
                 rename_map[raw_name_from_config] = standard_name_target
                 log.debug(
                     f"'{file_name_short}': Eşleştirme bulundu: '{raw_name_from_config}' "


### PR DESCRIPTION
## Summary
- expand cache builder module description
- clarify recursion details in `safe_eval`
- shorten comments in `_standardize_ohlcv_columns`

## Testing
- `pytest -q` *(fails: XlsxWriter missing and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68736576bed88325ae5041d2b03f7cea