### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -1,9 +1,7 @@
-"""
-Fallback wrappers for optional OpenBB indicators.
+"""Thin wrappers around optional OpenBB indicators.
 
-Functions call into :mod:`openbb` when it is installed. If the package is
-missing, the helpers raise a :class:`NotImplementedError` to signal the
-missing dependency.
+The helpers delegate to :mod:`openbb` when it is installed and raise
+:class:`NotImplementedError` otherwise.
 """
 
 from __future__ import annotations
@@ -49,8 +47,7 @@ def ichimoku(
     offset: int = 26,
     lookahead: bool = False,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """
-    Return Ichimoku indicator DataFrames generated via OpenBB.
+    """Return Ichimoku indicator frames produced via OpenBB.
 
     Args:
         high: High price series.
@@ -64,6 +61,9 @@ def ichimoku(
 
     Returns:
         Two DataFrames containing classic Ichimoku and span columns.
+
+    Raises:
+        NotImplementedError: If :mod:`openbb` is not available.
     """
     df = pd.DataFrame(
         {
@@ -94,8 +94,7 @@ def macd(
     slow: int = 26,
     signal: int = 9,
 ) -> pd.DataFrame:
-    """
-    Return MACD indicator columns generated via OpenBB.
+    """Return MACD indicator columns generated via OpenBB.
 
     Args:
         close: Close price series.
@@ -105,6 +104,9 @@ def macd(
 
     Returns:
         DataFrame with MACD, signal and histogram columns.
+
+    Raises:
+        NotImplementedError: If :mod:`openbb` is not available.
     """
     df = pd.DataFrame({"date": close.index, "close": close.values})
     obb_obj = _call_openbb(
@@ -126,8 +128,7 @@ def rsi(
     scalar: float = 100.0,
     drift: int = 1,
 ) -> pd.Series:
-    """
-    Return the RSI series generated via OpenBB.
+    """Return the RSI series generated via OpenBB.
 
     Args:
         close: Close price series.
@@ -137,6 +138,9 @@ def rsi(
 
     Returns:
         Relative strength index series.
+
+    Raises:
+        NotImplementedError: If :mod:`openbb` is not available.
     """
     df = pd.DataFrame({"date": close.index, "close": close.values})
     obb_obj = _call_openbb(

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,7 +1,7 @@
 """Generate unique column names for DataFrames.
 
 ``unique_name`` appends an incrementing suffix to ``base`` when the desired
-name already exists in ``seen``. The newly created name is inserted into
+name already exists in ``seen``. The generated name is inserted into
 ``seen`` before being returned so subsequent calls remain unique.
 """
 
@@ -12,7 +12,7 @@ def unique_name(base: str, seen: set[str]) -> str:
     """Return ``base`` or a numbered variant not present in ``seen``.
 
     The generated name is automatically added to ``seen`` so the function can
-    be called repeatedly with the same set.
+    be called repeatedly with the same set without collisions.
 
     Args:
         base (str): Desired column name.


### PR DESCRIPTION
## Summary
- clarify optional OpenBB wrappers in `openbb_missing` docs
- refine wording in naming helper docstrings

## Testing
- `python -m py_compile openbb_missing.py utilities/naming.py`
- `pytest -k nothing -q` *(fails: ModuleNotFoundError: No module named 'responses')*


------
https://chatgpt.com/codex/tasks/task_e_68739db116b883258beb55c4022eb63b