### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Finansal Parquet Cache Sistemi
 
 [![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
- 
+
 ```bash
 # otomatik kurulum
 bash scripts/install.sh
@@ -15,9 +15,9 @@ python -m finansal.cli --help
 python run.py --help
 python -m finansal_analiz_sistemi --help
 ```
- 
+
  Örnek kullanım:
- 
+
 ```bash
 python -m finansal.cli --csv veri/prices.csv --log-level DEBUG
 python -m finansal_analiz_sistemi.cli --dosya veri/prices.csv
@@ -42,7 +42,7 @@ Bu proje artık OpenBB ile uyumludur. Eski pandas-ta desteği kaldırıldı.
 En son calisma suresi: 0.5397 saniye
 
 ## Benchmark Çalıştırma
-`benchmarks/benchmark.py` betiği bir milyon rasgele sayı toplayarak süreyi ölçer. 
+`benchmarks/benchmark.py` betiği bir milyon rasgele sayı toplayarak süreyi ölçer.
 Yerelde çalıştırmak için:
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,18 @@
 ## 🗓️ Temmuz 2025 Gelişmeleri
 
 ### ✅ Tamamlananlar
-☑️ OpenBB migration tamamlandı  
-☑️ pandas-ta bağımlılığı tamamen kaldırıldı  
-☑️ Codex uyumlu filter engine oluşturuldu  
+☑️ OpenBB migration tamamlandı
+☑️ pandas-ta bağımlılığı tamamen kaldırıldı
+☑️ Codex uyumlu filter engine oluşturuldu
 ☑️ pre-commit, CI ve pytest tümleşik hale getirildi
 ☑️ Benchmark testleri ve GitHub Actions iş akışı eklendi
 ☑️ Dependabot güncellemeleri entegre edildi (requests, ruff, pygments, typing-extensions)
 
 ### 🔄 Devam Edenler
-🔄 Parquet cache builder fonksiyonlarının yeniden test edilmesi  
-🔄 Filter cycle detection kontrol algoritması optimize edilecek  
+🔄 Parquet cache builder fonksiyonlarının yeniden test edilmesi
+🔄 Filter cycle detection kontrol algoritması optimize edilecek
 
 ### 🟦 Planlananlar
-🟦 trade_engine.py sadeleştirme ve belgelendirme  
-🟦 Gelişmiş performans raporu tablosu (benchmark/README.md içine)  
-🟦 OpenBB gösterge sonuçları ile pandas-ta karşılaştırma raporu  
+🟦 trade_engine.py sadeleştirme ve belgelendirme
+🟦 Gelişmiş performans raporu tablosu (benchmark/README.md içine)
+🟦 OpenBB gösterge sonuçları ile pandas-ta karşılaştırma raporu

--- a/report_stats.py
+++ b/report_stats.py
@@ -1,8 +1,7 @@
-"""Utilities to compute summary statistics and Plotly charts.
+"""Helpers to compute summary statistics and Plotly charts.
 
-The functions in this module convert raw backtest results into
-summary/detail tables and optionally generate interactive figures
-when :mod:`plotly` is available.
+Functions convert raw backtest results into summary/detail tables and
+optionally create interactive figures when :mod:`plotly` is available.
 """
 
 from __future__ import annotations

--- a/run.py
+++ b/run.py
@@ -1,7 +1,7 @@
-"""Command-line entry for the backtest workflow.
+"""Entry point for the backtest command-line workflow.
 
-Handles argument parsing, data loading, indicator computation and report
-generation.
+The module handles argument parsing, data loading, indicator computation
+and report generation.
 """
 
 from __future__ import annotations

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,6 +1,6 @@
-"""Utilities for generating unique column names.
+"""Helpers for generating unique column names.
 
-The :func:`unique_name` helper appends an incrementing suffix to ``base`` when
+The :func:`unique_name` function appends an incrementing suffix to ``base`` when
 the desired name already exists in ``seen`` and records the result so repeated
 calls remain collision free.
 """


### PR DESCRIPTION
## Summary
- standardize module docstrings in `run.py`, `report_stats.py`, and `utilities/naming.py`
- strip trailing spaces in `README.md` and `ROADMAP.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: XlsxWriter is required)*

------
https://chatgpt.com/codex/tasks/task_e_6873d47566d48325b9cb68338bc0c288