### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -21,22 +21,16 @@ SEBEP_KODLARI = {
 def dogrula_filtre_dataframe(
     df_filtre: pd.DataFrame, zorunlu_kolonlar=None, logger=None
 ) -> dict:
-    """Return a mapping of problematic rows to a description.
+    """Return problematic rows as a ``dict`` keyed by filter code.
 
-    Parameters
-    ----------
-    df_filtre : pd.DataFrame
-        Filter definitions to verify.
-    zorunlu_kolonlar : list[str] | None, optional
-        Required column names, defaults to ``["flag", "query"]``.
-    logger : logging.Logger | None, optional
-        Logger used for warning messages.
+    Args:
+        df_filtre (pd.DataFrame): Filter definitions to verify.
+        zorunlu_kolonlar (list[str] | None, optional): Required column names.
+            Defaults to ``["flag", "query"]``.
+        logger (logging.Logger | None, optional): Logger used for warnings.
 
-    Returns
-    -------
-    dict
-        Keys are filter codes and values describe why the row is invalid.
-
+    Returns:
+        dict: Mapping of filter codes to descriptions of the issue.
     """
     sorunlu = {}
     zorunlu_kolonlar = zorunlu_kolonlar or ["flag", "query"]
@@ -77,20 +71,16 @@ def validate(
 ) -> list[ValidationError]:
     """Return ``ValidationError`` objects describing invalid rows.
 
-    Parameters
-    ----------
-    df_filtre : pd.DataFrame
-        Filter definitions to validate.
-    zorunlu_kolonlar : list[str] | None, optional
-        Required column names, defaults to ``["flag", "query"]``.
-    logger : logging.Logger | None, optional
-        Logger emitting warnings for each problem.
+    Args:
+        df_filtre (pd.DataFrame): Filter definitions to validate.
+        zorunlu_kolonlar (list[str] | None, optional): Required column names.
+            Defaults to ``["flag", "query"]``.
+        logger (logging.Logger | None, optional): Logger emitting warnings for
+            each problem.
 
-    Returns
-    -------
-    list[ValidationError]
-        Structured error objects describing validation failures.
-
+    Returns:
+        list[ValidationError]: Structured error objects describing validation
+        failures.
     """
     zorunlu_kolonlar = zorunlu_kolonlar or ["flag", "query"]
     errors: list[ValidationError] = []

--- a/finansal_analiz_sistemi/utils/compat.py
+++ b/finansal_analiz_sistemi/utils/compat.py
@@ -8,11 +8,10 @@ import pandas as pd
 def transpose(
     df: pd.DataFrame, axis0: int = 0, axis1: int = 1, copy: bool | None = None
 ) -> pd.DataFrame:
-    """Return ``df`` transposed while preserving older behavior.
+    """Transpose ``df`` while mimicking ``DataFrame.swapaxes``.
 
-    Parameters mimic :meth:`DataFrame.swapaxes` but only ``axis0=0`` and
-    ``axis1=1`` are supported. ``copy=None`` preserves the original view when
-    possible.
+    Only ``axis0=0`` and ``axis1=1`` are supported. ``copy=None`` preserves the
+    original view when possible.
 
     Args:
         df (pd.DataFrame): Frame to transpose.
@@ -22,8 +21,7 @@ def transpose(
             replicates the legacy behavior of returning a view when possible.
 
     Returns:
-        pd.DataFrame: Transposed frame.
-
+        pd.DataFrame: Transposed DataFrame.
     """
     if axis0 == axis1:
         return df.copy(deep=bool(copy))


### PR DESCRIPTION
## Summary
- clean and standardize docstrings in `filtre_dogrulama.py`
- clarify transpose helper docstring in `utils/compat.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874097d4c3c8325a71fadc30d0b716a