### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/finansal/utils/__init__.py
+++ b/finansal/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Helpers for the ``finansal`` package.
+"""Utility helpers for the ``finansal`` package.
 
 The module provides :func:`lazy_chunk` for streaming data in chunks and
 :func:`safe_set` for dtype-safe DataFrame assignment.

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,7 @@
 """Utility helpers shared across the project.
 
 This package exposes crossover detection routines, filter-column
-extraction helpers and log maintenance utilities used by the CLI and
+extraction helpers and log maintenance utilities for the CLI and
 reporting modules.
 """
 

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -1,6 +1,6 @@
-"""Helpers for robust date parsing.
+"""Utilities for robust date parsing.
 
-The :func:`parse_date` utility normalizes various date strings to
+The :func:`parse_date` helper converts diverse date strings to
 ``pd.Timestamp`` objects without raising ``ValueError``.
 """
 
@@ -15,12 +15,11 @@ from pandas._libs.tslibs.nattype import NaTType
 
 
 def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
-    """Parse ``date_str`` into a timestamp.
+    """Return ``date_str`` parsed into a timestamp.
 
-    The function first attempts the ISO form ``YYYY-MM-DD`` followed by the
-    Turkish/European style ``DD.MM.YYYY``. If both fail, a flexible day-first
-    parse via :mod:`dateutil` is used. Invalid inputs yield ``pd.NaT`` instead
-    of raising ``ValueError``.
+    The function tries ISO ``YYYY-MM-DD`` and ``DD.MM.YYYY`` formats first,
+    then falls back to a day-first parse via :mod:`dateutil`. Invalid inputs
+    yield ``pd.NaT`` instead of raising ``ValueError``.
 
     Args:
         date_str (Union[str, datetime]): Date string or datetime object to

--- a/utils/error_map.py
+++ b/utils/error_map.py
@@ -8,6 +8,7 @@ from typing import Dict, Tuple
 
 __all__ = ["get_reason_hint"]
 
+# Mapping from exception names to localized (reason, hint) tuples.
 REASON_MAP: Dict[str, Tuple[str, str]] = {
     "ZeroDivisionError": (
         "S\u0131f\u0131ra B\u00f6lme",

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -1,6 +1,6 @@
 """Track failed operations for later reporting.
 
-Collected failures are stored globally so they can be summarized after
+Collected failures are stored globally so they can be summarized once
 execution completes.
 """
 

--- a/utils/pandas_option_safe.py
+++ b/utils/pandas_option_safe.py
@@ -1,4 +1,4 @@
-"""Helpers to safely set pandas options across versions.
+"""Helper functions to safely set pandas options across versions.
 
 Unknown options are ignored instead of raising ``OptionError``.
 """

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -1,7 +1,7 @@
 """Delete aged log files from ``log_dir``.
 
-This helper is intended for maintenance scripts and supports a dry-run
-mode to preview deletions.
+Intended for maintenance scripts, this helper supports a dry-run mode to
+preview files slated for deletion.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- update docstring wording in several helper modules
- add clarifying comment for error mapping constant

## Testing
- `pre-commit run --files utils/error_map.py utils/date_utils.py utils/pandas_option_safe.py utils/purge_old_logs.py utils/__init__.py utils/failure_tracker.py finansal/utils/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_687415c6a60c8325a4611ddb9f4652f6