### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ import warnings
 
 import pytest
 
-# pytest sırasında açık dosya uyarısını bastır
+# suppress open file warnings during pytest runs
 warnings.filterwarnings(
     "ignore",
     message=r"Exception ignored in: <_io",

--- a/tests/test_aciklama_filled.py
+++ b/tests/test_aciklama_filled.py
@@ -14,7 +14,7 @@ if ROOT_DIR not in sys.path:
 
 def test_aciklama_filled(tmp_path):
     """Summary rows should be populated with explanation text."""
-    # 1 satır OK, 1 satır QUERY_ERROR
+    # one row OK, one QUERY_ERROR
     df_sum = pd.DataFrame(
         [
             ["T1", 1, 1.0, 1, 0, 1, "OK", "", "", ""],

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -37,6 +37,6 @@ def test_config_has_defaults():
 
 
 def test_yaml_values_loaded():
-    """YAML'deki değerler modüle yüklenmeli."""
+    """Values from YAML should be loaded into the module."""
     assert config.get("filter_weights", {}).get("T31") == 0.0
     assert "T31" in config.get("passive_filters", [])

--- a/tests/test_config_has_core_indicators.py
+++ b/tests/test_config_has_core_indicators.py
@@ -5,9 +5,9 @@ def test_config_has_core_indicators():
     """Check that ``CORE_INDICATORS`` exists and is not empty."""
     from finansal_analiz_sistemi import config as cfg
 
-    # Tanımlı mı?
+    # Does it exist?
     assert hasattr(cfg, "CORE_INDICATORS"), "config.py'de CORE_INDICATORS YOK!"
-    # Liste mi?
+    # Is it a list?
     assert isinstance(cfg.CORE_INDICATORS, list), "CORE_INDICATORS bir liste değil!"
-    # Boş mu?
+    # Is it non-empty?
     assert len(cfg.CORE_INDICATORS) > 0, "CORE_INDICATORS listesi boş!"

--- a/tests/test_filtre_dogrulama.py
+++ b/tests/test_filtre_dogrulama.py
@@ -16,7 +16,7 @@ def test_invalid_filter_code_characters():
     df = pd.DataFrame([{"flag": "BAD#", "query": "True"}])
     result = dogrula_filtre_dataframe(df)
     assert "BAD#" in result
-    assert "Geçersiz" in result["BAD#"]  # message contains "Geçersiz karakterler"
+    assert "Geçersiz" in result["BAD#"]  # message contains "Invalid characters"
 
 
 def test_empty_python_query():

--- a/tests/test_ichimoku_mapping.py
+++ b/tests/test_ichimoku_mapping.py
@@ -12,7 +12,7 @@ from finansal_analiz_sistemi import config as _cfg
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
-importlib.reload(_cfg)  # test ortamında doğru yolu garantile
+importlib.reload(_cfg)  # ensure correct path resolution in the test environment
 config = _cfg
 
 

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -57,8 +57,8 @@ def test_fallback_indicators_created_when_missing():
         result = ic.hesapla_teknik_indikatorler_ve_kesisimler(df)
         assert not rec
     assert not any("fragmented" in str(w.message) for w in rec)
-    # pandas_ta normalde sma_200/ema_200 üretmez.
-    # Fallback mekanizmasi kolonlarin NaN dahi olsa eklenmesini saglar.
+    # pandas_ta does not normally produce sma_200/ema_200 columns.
+    # The fallback mechanism ensures they exist even if filled with NaN.
     assert "sma_200" in result.columns
     assert "ema_200" in result.columns
     assert "momentum_10" in result.columns

--- a/tests/test_log_clean.py
+++ b/tests/test_log_clean.py
@@ -24,7 +24,7 @@ def test_purge_old_logs(tmp_path: Path, dry_run: bool):
     new.write_text("y")
     lock_old.write_text("")
 
-    # 10 gün geriye çek
+    # rewind timestamps by 10 days
     old_time = time.time() - 10 * 86400
     os.utime(old, (old_time, old_time))
 

--- a/tests/test_log_contains_error_tags.py
+++ b/tests/test_log_contains_error_tags.py
@@ -13,7 +13,7 @@ from filter_engine import run_single_filter
 def test_log_has_query_error(tmp_path, caplog):
     """Error logs should contain the ``QUERY_ERROR`` tag."""
     caplog.set_level(logging.WARNING)
-    # sahte filtre, parse hatası tetikle
+    # use a dummy filter to trigger a parse error
     run_single_filter("TERRIBLE_FILTER", "close > df['X']")
     log_text = "\n".join(rec.getMessage() for rec in caplog.records)
     assert re.search(r"QUERY_ERROR:", log_text), "Log QUERY_ERROR etiketi içermiyor"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -37,10 +37,10 @@ def test_cache_memory():
     base = proc.memory_info().rss
     for _ in range(200):
         get_df("AKBNK", "2023-01-01", "2023-12-29")
-    # Küçük dalgalanmaları elimine et
+    # eliminate minor fluctuations
     gc.collect()
     after = proc.memory_info().rss
 
-    # Toleransı 15 MB'a çek (CI container'larında hafıza tahsisi burst yapabiliyor)
+    # allow up to 15 MB increase (CI containers may burst allocate memory)
     assert after - base < 15 * 1024 * 1024  # <15 MB artış
     clear_cache()

--- a/tests/test_no_data_loss.py
+++ b/tests/test_no_data_loss.py
@@ -7,7 +7,7 @@ from report_generator import generate_full_report
 
 def test_no_data_loss(tmp_path):
     """Report generation should preserve rows even when values are NaN."""
-    # NaN'li ama silinmemesi gereken satır
+    # Row contains NaN but should not be dropped
     df_sum = pd.DataFrame(
         [
             {
@@ -28,5 +28,5 @@ def test_no_data_loss(tmp_path):
     path = tmp_path / "rapor.xlsx"
     generate_full_report(df_sum, df_det, [], path, keep_legacy=True)
     ozet = pd.read_excel(path, "Özet")
-    # Satır silinmemiş olmalı
+    # Row should remain intact
     assert len(ozet) == 1, "Satır gereksiz silindi!"

--- a/tests/test_purge_old_logs.py
+++ b/tests/test_purge_old_logs.py
@@ -19,6 +19,6 @@ def test_purge_dry_run(tmp_path):
     import os
     import time
 
-    os.utime(old, (time.time() - 864000,) * 2)  # 10 gün
+    os.utime(old, (time.time() - 864000,) * 2)  # 10 days ago
     deleted = purge_old_logs(log_dir=tmp_path, keep_days=7, dry_run=True)
     assert deleted == 2 and old.exists() and lock_old.exists() and new.exists()

--- a/tests/test_report_format.py
+++ b/tests/test_report_format.py
@@ -66,7 +66,7 @@ def test_legacy_columns_preserved(tmp_path):
 
 def test_error_sheet_not_empty(tmp_path):
     """Error sheet must contain rows when a list is provided."""
-    # sahte QUERY_ERROR satırı ekle
+    # add a dummy QUERY_ERROR row
     errs = [
         {
             "filtre_kodu": "T999",


### PR DESCRIPTION
## Summary
- translate a few remaining Turkish comments in `report_generator`
- standardize comments across tests
- run pre-commit and tests

## Testing
- `pre-commit run --files report_generator.py tests/__init__.py tests/test_aciklama_filled.py tests/test_config_defaults.py tests/test_config_has_core_indicators.py tests/test_filtre_dogrulama.py tests/test_ichimoku_mapping.py tests/test_indicator_calculator.py tests/test_log_clean.py tests/test_log_contains_error_tags.py tests/test_memory.py tests/test_no_data_loss.py tests/test_purge_old_logs.py tests/test_report_format.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687436803ff883259822fbcb2734d317