### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/cache_builder.py
+++ b/cache_builder.py
@@ -26,8 +26,11 @@ def build() -> None:
     Parquet file to ``CACHE``. When an existing cache is found, the
     function returns without rebuilding.
 
-    This helper uses a :class:`filelock.FileLock` to guard writes so
-    concurrent runs do not corrupt the cache.
+    A :class:`filelock.FileLock` guards the write operation so concurrent
+    runs do not corrupt the cache.
+
+    Returns:
+        None
     """
     with FileLock(str(LOCK_FILE)):
         if CACHE.exists() and CACHE.stat().st_size > 0:

--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -33,7 +33,10 @@ class DataLoaderCache:
         self.logger = logger
 
     def clear(self) -> None:
-        """Clear the internal cache."""
+        """Clear the internal cache.
+
+        All cached datasets are removed immediately.
+        """
         self.loaded_data.clear()
 
     def load_csv(self, filepath: str, **kwargs) -> pd.DataFrame:

--- a/run.py
+++ b/run.py
@@ -430,11 +430,11 @@ def _hazirla_rapor_alt_df(rapor_df: pd.DataFrame):
 
 
 def _run_gui(ozet_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
-    """Display results interactively using Streamlit.
+    """Display summary or detail tables in a Streamlit interface.
 
-    This helper is triggered by the ``--gui`` command-line flag and
-    presents either the summary, detail or a simple chart view based on
-    user selection. Percentage columns are plotted when available.
+    Triggered by the ``--gui`` flag, this helper lets the user switch
+    between summary, detail and basic chart views. Percentage columns are
+    plotted when available.
     """
     import streamlit as st
 

--- a/utils/error_map.py
+++ b/utils/error_map.py
@@ -24,11 +24,12 @@ DEFAULT_REASON: Tuple[str, str] = ("Bilinmeyen Hata", "Detay i\u00e7in loglara b
 
 
 def get_reason_hint(exc: Exception, _locale: str = "tr") -> Tuple[str, str]:
-    """Return a user-friendly reason/hint tuple for ``exc``.
+    """Return a user-friendly reason/hint pair for ``exc``.
 
     Args:
         exc (Exception): Exception instance to map.
-        _locale (str, optional): Reserved for future localization support.
+        _locale (str, optional): Reserved for future localization and
+            currently ignored.
 
     Returns:
         Tuple[str, str]: ``(reason, hint)`` describing the failure.


### PR DESCRIPTION
## Summary
- refine cache builder docstring
- clarify cache clearing description
- reword GUI helper docstring
- note locale param in error_map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a959d1b08325abcd936c3ed2d41b