### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,7 +1,7 @@
-"""Measure CPU throughput by summing random integers.
+"""Benchmark CPU throughput by summing random integers.
 
-The benchmark generates one million numbers, sums them and writes the
-elapsed time to ``benchmark_output.txt``.
+This script generates one million integers, computes their sum and writes
+the elapsed time to ``benchmark_output.txt``.
 """
 
 import random

--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,9 +1,8 @@
-"""Create and update the project's Parquet cache.
+"""Create or refresh the project's Parquet cache.
 
-CSV files under ``veri/ham`` are concatenated into one Parquet file at
-``config.PARQUET_CACHE_PATH``.  A :class:`filelock.FileLock` guards the write
-operation so concurrent runs remain safe. Existing caches are reused on
-subsequent runs.
+CSV files located under ``veri/ham`` are concatenated into a single Parquet
+file at ``config.PARQUET_CACHE_PATH``. A :class:`filelock.FileLock` guards the
+write operation so concurrent runs remain safe.
 """
 
 from pathlib import Path

--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -1,8 +1,8 @@
 """In-memory cache for CSV and Excel loaders.
 
 Entries are keyed by absolute path and file metadata so repeated reads bypass
-disk access when the source has not changed. Cached items expire based on the
-configured ``ttl`` parameter.
+disk access when the source has not changed. Cached items expire according to
+the configured ``ttl`` parameter.
 """
 
 import os

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,8 +1,7 @@
 """Utility for generating unique column names.
 
 The :func:`unique_name` helper appends an incrementing suffix when ``base``
-already exists in ``seen`` and stores the new name so subsequent calls avoid
-collisions.
+already exists in ``seen`` so later calls avoid collisions.
 """
 
 __all__ = ["unique_name"]


### PR DESCRIPTION
## Summary
- refine benchmark description
- clarify Parquet cache module docstring
- tweak loader cache documentation
- shorten naming helper docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874bf2ebc908325bf07bf405057f4ba