### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -57,7 +57,7 @@ def calistir_basit_backtest(
         )
         return pd.DataFrame(), pd.DataFrame()
 
-    # Retrieve buy/sell timing configuration and commission
+    # Read buy/sell timing settings and commission
     alim_fiyat_sutunu = config.ALIM_ZAMANI  # e.g. "open"
     satis_fiyat_sutunu = config.SATIS_ZAMANI  # e.g. "open" or "close"
     komisyon_orani = config.KOMISYON_ORANI
@@ -66,7 +66,7 @@ def calistir_basit_backtest(
         alim_fiyat_sutunu = "close"
     if satis_fiyat_sutunu not in df_tum_veri.columns:
         satis_fiyat_sutunu = "close"
-    # Record the strategy type for downstream reporting
+    # Store the strategy name for later reporting
     config.UYGULANAN_STRATEJI = "basit_backtest"
 
     summary_records = []

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -17,12 +17,12 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 def _call_openbb(func_name: str, **kwargs) -> object:
-    """Delegate to ``openbb.technical`` and return the raw result.
+    """Call the requested helper under ``openbb.technical``.
 
-    This internal helper calls the matching OpenBB indicator when the
-    :mod:`openbb` package is installed.  Callers receive a
-    :class:`NotImplementedError` when the dependency or the requested
-    function is unavailable.
+    The function invokes the matching OpenBB indicator when the
+    :mod:`openbb` package is available.  If the dependency or the
+    requested helper is missing, a :class:`NotImplementedError` is
+    raised.
 
     Args:
         func_name (str): Name of the technical indicator under

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -15,7 +15,7 @@ from pandas._libs.tslibs.nattype import NaTType
 
 
 def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
-    """Return ``date_str`` parsed into a timestamp.
+    """Parse ``date_str`` into a :class:`pandas.Timestamp` or ``pd.NaT``.
 
     The function tries ISO ``YYYY-MM-DD`` and ``DD.MM.YYYY`` formats first,
     then falls back to a day-first parse via :mod:`dateutil`. Invalid inputs


### PR DESCRIPTION
## Summary
- refine `_call_openbb` helper docs
- clarify comments in `backtest_core`
- improve docstring for `parse_date`

## Testing
- `pre-commit run --files openbb_missing.py backtest_core.py utils/date_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c91ae4c4832588a14e7ba46ee1b2