### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,7 +1,7 @@
-"""Wrappers around :mod:`finansal_analiz_sistemi.data_loader`.
+"""Convenience wrappers around :mod:`finansal_analiz_sistemi.data_loader`.
 
-Selected helpers are re-exported so they can be imported directly from
-this module.
+Common helpers are re-exported for direct import and a helper is provided
+to load the cached Parquet dataset.
 """
 
 from pathlib import Path

--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -1,8 +1,7 @@
-"""In-memory cache for CSV and Excel loaders.
+"""In-memory cache for CSV and Excel files.
 
-Entries are keyed by absolute path and file metadata so repeated reads bypass
-disk access when the source has not changed. Cached items expire according to
-the configured ``ttl`` parameter.
+Cache entries are keyed by absolute path and file metadata so repeated reads
+avoid disk access. Each entry expires after ``ttl`` seconds.
 """
 
 import os

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -1,9 +1,8 @@
-"""Fallback wrappers for optional ``openbb.technical`` indicators.
+"""Helper stubs for ``openbb.technical`` indicators.
 
-The helpers transparently call the matching implementation from
-``openbb.technical`` when the package is available. If the dependency
-is missing they raise :class:`NotImplementedError` so callers can
-gracefully skip unsupported indicators.
+The wrappers invoke the OpenBB implementation when available. If the
+package is missing they raise :class:`NotImplementedError` so callers
+can gracefully skip unsupported features.
 """
 
 from __future__ import annotations

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -267,17 +267,10 @@ def on_isle_hisse_verileri(
 
 
 def _temizle_sayisal_deger(deger):
-    """Normalize ``deger`` and return its numeric value.
+    """Return the numeric value of ``deger``.
 
-    String inputs have thousand separators removed and decimal commas
-    replaced with dots before conversion. Anything that cannot be parsed
-    is returned as ``np.nan``.
-
-    Args:
-        deger: Value to sanitize. May be ``str`` or numeric.
-
-    Returns:
-        float: Parsed float value or ``np.nan`` when conversion fails.
+    Thousands separators are stripped and decimal commas converted to dots.
+    Unparseable values yield ``np.nan``.
     """
     if pd.isna(deger):
         return np.nan

--- a/run.py
+++ b/run.py
@@ -410,16 +410,9 @@ def raporla(rapor_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
 
 
 def _hazirla_rapor_alt_df(rapor_df: pd.DataFrame):
-    """Prepare derived summary, detail and stats tables.
+    """Derive summary, detail and stats tables from ``rapor_df``.
 
-    Args:
-        rapor_df (pd.DataFrame): Backtest output produced by
-            :func:`backtest_yap`.
-
-    Returns:
-        tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-            ``(summary_df, detail_df, stats_df)`` trio. Empty frames are
-            returned when ``rapor_df`` has no rows.
+    Returns three empty frames when ``rapor_df`` is empty.
     """
     if rapor_df is None or rapor_df.empty:
         return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()


### PR DESCRIPTION
## Summary
- refine docstrings in `openbb_missing`, `data_loader`, `data_loader_cache`
- simplify `_temizle_sayisal_deger` explanation in `preprocessor.py`
- shorten `_hazirla_rapor_alt_df` docstring in `run.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754e2574508325b28b12a4985f4d11