### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/finansal/parquet_cache.py
+++ b/finansal/parquet_cache.py
@@ -1,9 +1,7 @@
-"""Utilities for reading, writing and refreshing the Parquet cache.
+"""Manage loading and updating the Parquet cache.
 
-The :class:`ParquetCacheManager` abstracts file operations behind ``load``
-and ``refresh`` helpers. Cached data is stored as Parquet and protected by
-a file lock during updates. The default location is
-``config.PARQUET_CACHE_PATH``.
+The :class:`ParquetCacheManager` wraps file operations and guards writes
+with a lock. Cached data resides at ``config.PARQUET_CACHE_PATH``.
 """
 
 from __future__ import annotations

--- a/finansal_analiz_sistemi/utils/normalize.py
+++ b/finansal_analiz_sistemi/utils/normalize.py
@@ -1,4 +1,8 @@
-"""Helpers for normalizing filter CSV column names."""
+"""Normalize column names used in filter CSV files.
+
+Utilities here ensure variants like ``FilterCode`` or ``filtercode`` are
+mapped to the canonical ``filtre_kodu`` label before processing.
+"""
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- clarify module description in `utils.normalize`
- shorten introduction of `parquet_cache`

## Testing
- `pre-commit run --files finansal_analiz_sistemi/utils/normalize.py finansal/parquet_cache.py`
- `pytest -q` *(fails: ModuleNotFoundError: openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68756837ff988325beaab7d68298ac7b