### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,7 +1,8 @@
-"""Benchmark CPU throughput by summing random integers.
+"""Measure CPU throughput by summing random integers.
 
-Generates one million random numbers, sums them and writes the elapsed
-time to ``benchmark_output.txt``.
+This script generates one million random numbers, sums them and saves
+the elapsed time to ``benchmark_output.txt``.  The function
+:func:`run_bench` returns the runtime in seconds.
 """
 
 import random

--- a/run.py
+++ b/run.py
@@ -410,9 +410,10 @@ def raporla(rapor_df: pd.DataFrame, detay_df: pd.DataFrame) -> None:
 
 
 def _hazirla_rapor_alt_df(rapor_df: pd.DataFrame):
-    """Derive summary, detail and stats tables from ``rapor_df``.
+    """Return summary, detail and stats tables derived from ``rapor_df``.
 
-    Returns three empty frames when ``rapor_df`` is empty.
+    An empty ``rapor_df`` yields three empty ``DataFrame`` objects. The
+    returned tuple follows the order ``(summary_df, detail_df, stats_df)``.
     """
     if rapor_df is None or rapor_df.empty:
         return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()

--- a/utils/memory_profile.py
+++ b/utils/memory_profile.py
@@ -1,7 +1,8 @@
 """Context manager that logs peak memory usage.
 
-Using ``with mem_profile():`` appends ``timestamp,peak,diff`` rows to
-``reports/memory_profile.csv`` for later analysis.
+When used as ``with mem_profile():`` the peak RSS value is appended as a
+``timestamp,peak,diff`` row to ``reports/memory_profile.csv``. This
+provides a lightweight record of memory consumption for later review.
 """
 
 import os


### PR DESCRIPTION
## Summary
- clarify benchmark module docstring
- expand memory profiling documentation
- document tuple order for `_hazirla_rapor_alt_df`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756e1205388325992f5ba84989dbbc