### PR TITLE
📝 Yorum ve Docstring Temizliği & Standartlaştırma

### DIFF
--- a/cache_builder.py
+++ b/cache_builder.py
@@ -1,8 +1,8 @@
 """Create or refresh the project's Parquet cache.
 
-CSV files located under ``veri/ham`` are concatenated into a single Parquet
-file at ``config.PARQUET_CACHE_PATH``. A :class:`filelock.FileLock` guards the
-write operation so concurrent runs remain safe.
+CSV files from ``veri/ham`` are combined into one dataset written to
+``config.PARQUET_CACHE_PATH``. A :class:`filelock.FileLock` prevents
+concurrent write corruption.
 """
 
 from pathlib import Path

--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -1,7 +1,7 @@
 """In-memory cache for CSV and Excel files.
 
-Cache entries are keyed by absolute path and file metadata so repeated reads
-avoid disk access. Each entry expires after ``ttl`` seconds.
+Entries are keyed by absolute path and file metadata so repeated reads
+avoid disk access. Each cached dataset expires after ``ttl`` seconds.
 """
 
 import os

--- a/filtre_dogrulama.py
+++ b/filtre_dogrulama.py
@@ -1,7 +1,7 @@
-"""Validate filter CSV files and flag malformed queries.
+"""Validate filter CSV files and detect malformed queries.
 
-The helpers return reason codes so callers can surface meaningful error
-messages when filters cannot be executed.
+Helper functions return reason codes so that callers can display
+meaningful error messages when filter expressions fail to run.
 """
 
 import re

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,7 +1,7 @@
-"""Excel report generation utilities.
+"""Helpers to build Excel reports from backtest data.
 
-The module writes performance tables to ``xlsxwriter`` workbooks and
-optionally adds charts and structured error summaries.
+Performance tables are written using ``xlsxwriter`` and optional charts
+or structured error sheets can be included as needed.
 """
 
 from __future__ import annotations

--- a/run.py
+++ b/run.py
@@ -1,8 +1,8 @@
-"""Command-line interface for the demo backtest.
+"""Entry point for the example backtest CLI.
 
-This module ties together data loading, indicator calculation, filter
-evaluation and Excel reporting. Call :func:`main` with CLI arguments or
-run ``python -m finansal_analiz_sistemi``.
+This module orchestrates data loading, indicator calculation, filter
+evaluation and Excel reporting. Invoke :func:`main` with arguments or
+run ``python -m finansal_analiz_sistemi`` directly.
 """
 
 from __future__ import annotations

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -1,6 +1,6 @@
 """Helper exports for the :mod:`utilities` package.
 
-Only a minimal set of functions is re-exported here for convenience.
+Only a minimal set of functions is re-exported for convenience.
 """
 
 from .naming import unique_name

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,7 @@
 """Common helper routines for filters and logging.
 
-This package exposes crossover detection utilities, filter-column
-extraction helpers and log maintenance helpers used across the project.
+The package exposes crossover utilities, filter-column extraction
+helpers and log maintenance tools shared across the project.
 """
 
 from __future__ import annotations

--- a/utils/error_map.py
+++ b/utils/error_map.py
@@ -1,7 +1,8 @@
 """Map exceptions to user-friendly reason/hint pairs.
 
-Provides a lightweight translation layer from Python exception names to
-localized error messages.
+This lightweight table translates Python exception names into
+localized ``(reason, hint)`` tuples so callers can present concise
+error messages.
 """
 
 from typing import Dict, Tuple

--- a/utils/memory_profile.py
+++ b/utils/memory_profile.py
@@ -1,8 +1,8 @@
 """Context manager that logs peak memory usage.
 
-When used as ``with mem_profile():`` the peak RSS value is appended as a
-``timestamp,peak,diff`` row to ``reports/memory_profile.csv``. This
-provides a lightweight record of memory consumption for later review.
+Using ``with mem_profile():`` appends a ``timestamp,peak,diff`` line to
+``reports/memory_profile.csv`` so memory consumption can be reviewed
+after execution.
 """
 
 import os


### PR DESCRIPTION
## Summary
- clean up docstrings across helper modules
- standardize initial module comments

## Testing
- `pre-commit run --files cache_builder.py data_loader_cache.py filtre_dogrulama.py report_generator.py run.py utilities/__init__.py utils/__init__.py utils/error_map.py utils/memory_profile.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687576c3b6248325a7f0e6f65bfdac66