### PR TITLE
📐 Fonksiyon ve Sınıf Sırası Düzenlemesi

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -58,6 +58,21 @@ class MissingColumnError(Exception):
         self.missing = missing
 
 
+def _extract_query_columns(query: str) -> set:
+    """Return column-like identifiers referenced in a filter query."""
+
+    query = re.sub(r"(?:'[^']*'|\"[^\"]*\")", " ", query)
+    tokens = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", query))
+    reserved = set(keyword.kwlist) | {"and", "or", "not", "True", "False", "df"}
+    return tokens - reserved
+
+
+def _extract_columns_from_query(query: str) -> set:
+    """Return referenced columns using the unified naming scheme."""
+
+    return _extract_query_columns(query)
+
+
 def _apply_single_filter(df, kod, query):
     """Run a filter expression on ``df`` and collect diagnostics.
 
@@ -161,30 +176,6 @@ def _build_solution(err_type: str, msg: str) -> str:
     if err_type == "NO_STOCK":
         return "Filtre koşullarını gevşetin veya tarih aralığını genişletin."
     return ""
-
-
-def _extract_columns_from_query(query: str) -> set:
-    """Return referenced columns using the unified naming scheme.
-
-    Args:
-        query (str): Filter expression written in ``pandas.query`` syntax.
-
-    Returns:
-        set: Column names referenced in ``query`` after normalization.
-    """
-    return _extract_query_columns(query)
-
-
-def _extract_query_columns(query: str) -> set:
-    """Return column-like identifiers referenced in a filter query.
-
-    String literals are stripped before running the regular expression so
-    column names embedded in quotes are ignored.
-    """
-    query = re.sub(r"(?:'[^']*'|\"[^\"]*\")", " ", query)
-    tokens = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", query))
-    reserved = set(keyword.kwlist) | {"and", "or", "not", "True", "False", "df"}
-    return tokens - reserved
 
 
 def clear_failed() -> None:


### PR DESCRIPTION
## Summary
- organize helper ordering in `filter_engine.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_6877a1e8ff008325b81c4f68813c3362