### PR TITLE
Bellek profil aracında dosya yolu parametreleştirildi

### DIFF
--- a/utils/memory_profile.py
+++ b/utils/memory_profile.py
@@ -7,12 +7,19 @@ after execution.
 
 import os
 import time
+from dataclasses import dataclass, field
+from pathlib import Path
 
 import psutil
 
+__all__ = ["mem_profile"]
 
+
+@dataclass
 class mem_profile:
     """Context manager that records peak memory usage to disk."""
+
+    path: Path = field(default_factory=lambda: Path("reports/memory_profile.csv"))
 
     def __enter__(self):
         """Start tracking process memory usage and return ``self``."""
@@ -23,13 +30,12 @@ class mem_profile:
     def __exit__(self, *exc):
         """Log peak memory usage and allow exception propagation.
 
-        A ``timestamp,peak,diff`` entry is appended to
-        ``reports/memory_profile.csv``. ``False`` is returned so any
-        exception raised inside the ``with`` block is re-raised.
+        A ``timestamp,peak,diff`` entry is appended to ``self.path``. ``False`` is
+        returned so any exception raised inside the ``with`` block is re-raised.
         """
         peak = self.proc.memory_info().rss
         diff = peak - self.start
-        os.makedirs("reports", exist_ok=True)
-        with open("reports/memory_profile.csv", "a") as f:
+        self.path.parent.mkdir(exist_ok=True)
+        with self.path.open("a") as f:
             f.write(f"{time.time()},{peak},{diff}\n")
         return False


### PR DESCRIPTION
## Değişiklik Özeti
- `mem_profile` bağlam yöneticisi `dataclass` hâline getirilerek dosya yolu
  konfigüre edilebilir yapıldı.
- Varsayılan `reports/memory_profile.csv` yolu korunarak geriye dönük
  uyumluluk sağlandı.

## Testler
- `pre-commit` ile biçimlendirme ve statik analiz kontrolleri yapıldı.
- Tüm testler `pytest` ile çalıştırıldı; 184 test geçti, 9 tanesi atlandı ve 8 tanesi seçilmedi.

------
https://chatgpt.com/codex/tasks/task_e_687858bb024083258eefaa8a5777fd98