### PR TITLE
Kod iyilestirmeleri

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -75,7 +75,7 @@ def extract_columns_from_filters(
     df_filters: pd.DataFrame | None,
     series_series: list | None,
     series_value: list | None,
-) -> set:
+) -> set[str]:
     """Return column names referenced in filters and crossovers.
 
     Args:
@@ -84,7 +84,7 @@ def extract_columns_from_filters(
         series_value (list | None): List of series-to-value crossover tuples.
 
     Returns:
-        set: Unique column names required for indicator computation.
+        set[str]: Unique column names required for indicator computation.
     """
     try:
         from filter_engine import _extract_query_columns
@@ -118,7 +118,7 @@ def extract_columns_from_filters_cached(
     df_filters_csv: str,
     series_series: list | None,
     series_value: list | None,
-) -> set:
+) -> set[str]:
     """Return referenced columns using a CSV string for caching.
 
     Args:
@@ -127,7 +127,7 @@ def extract_columns_from_filters_cached(
         series_value (list | None): Series-to-value crossover configuration.
 
     Returns:
-        set: Unique column names collected from the CSV content.
+        set[str]: Unique column names collected from the CSV content.
     """
     df_filters = None
     if df_filters_csv:

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -6,6 +6,7 @@ during execution and emit a summarized list after completion.
 
 from collections import defaultdict
 from dataclasses import asdict, dataclass
+from typing import Union
 
 
 @dataclass
@@ -28,7 +29,7 @@ def clear_failures() -> None:
 
 def get_failures(
     as_dict: bool = False,
-) -> dict[str, list[FailedFilter]] | defaultdict[str, list[FailedFilter]]:
+) -> Union[dict[str, list[FailedFilter]], defaultdict[str, list[FailedFilter]]]:
     """Return recorded failures.
 
     Args:

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -26,7 +26,9 @@ def clear_failures() -> None:
     failures.clear()
 
 
-def get_failures(as_dict: bool = False):
+def get_failures(
+    as_dict: bool = False,
+) -> dict[str, list[FailedFilter]] | defaultdict[str, list[FailedFilter]]:
     """Return recorded failures.
 
     Args:


### PR DESCRIPTION
## Ne değişti?
- `utils.failure_tracker.get_failures` fonksiyonu için dönüş tipi eklendi.
- `utils` paketindeki iki fonksiyonun imzaları `set[str]` tip ipuçlarıyla netleştirildi.

## Neden yapıldı?
Tip bilgileri arttırılarak kod okunabilirliği yükseltildi ve statik analiz araçlarının uyarıları azaltıldı.

## Nasıl test edildi?
- `pre-commit` ile biçimlendirme ve statik analiz kontrolleri çalıştırıldı.
- `pytest` ile tüm testler başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_6878823efa7c8325af466f362d156f77