### PR TITLE
Add DataFrame export for failure logs

### DIFF
--- a/tests/test_failure_tracker_df.py
+++ b/tests/test_failure_tracker_df.py
@@ -1,0 +1,12 @@
+import utils.failure_tracker as ft
+
+
+def test_failures_to_df():
+    ft.clear_failures()
+    ft.log_failure("filters", "T1", "missing")
+    ft.log_failure("indicators", "RSI", "calc", "install")
+    df = ft.failures_to_df()
+    assert list(df.columns) == ["category", "item", "reason", "hint"]
+    assert len(df) == 2
+    assert df.loc[0, "category"] == "filters"
+    assert df.loc[1, "hint"] == "install"

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -4,9 +4,14 @@ Failures are kept in a global dictionary so helpers can append entries
 during execution and emit a summarized list after completion.
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import asdict, dataclass
-from typing import Union
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    import pandas as pd
 
 
 @dataclass
@@ -55,3 +60,26 @@ def log_failure(category: str, item: str, reason: str, hint: str = "") -> None:
         hint (str, optional): Additional hint for resolving the failure.
     """
     failures[category].append(FailedFilter(item, reason, hint))
+
+
+def failures_to_df() -> pd.DataFrame:
+    """Return a ``DataFrame`` with all recorded failures.
+
+    The resulting frame contains the columns ``category``, ``item``, ``reason``
+    and ``hint``. The order of rows reflects the insertion order.
+    """
+    import pandas as pd
+
+    records = [
+        {
+            "category": cat,
+            "item": f.item,
+            "reason": f.reason,
+            "hint": f.hint,
+        }
+        for cat, rows in failures.items()
+        for f in rows
+    ]
+    return pd.DataFrame.from_records(
+        records, columns=["category", "item", "reason", "hint"]
+    )


### PR DESCRIPTION
## Ne değişti?
- `utils.failure_tracker` modülüne tüm hata kayıtlarını `DataFrame` olarak döndüren `failures_to_df` fonksiyonu eklendi.
- Yeni fonksiyon için `tests/test_failure_tracker_df.py` testi yazıldı.

## Neden yapıldı?
- Hata kayıtlarının raporlara kolayca eklenebilmesi için kayıtların `DataFrame` formatında alınması gerekiyordu.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm `pytest` testleri başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_6878bc12ab508325be26eeeaee7a4c5d