### PR TITLE
Boş seri dönüş değerinde tip düzeltmesi

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,11 +76,11 @@ def test_crosses_below_misaligned_index_length_matches_intersection():
 
 
 @pytest.mark.parametrize("func", [crosses_above, crosses_below])
-def test_cross_functions_with_none_returns_empty_false_series(func):
-    """Passing ``None`` yields an empty ``False`` series."""
+def test_cross_functions_with_none_returns_empty_series(func):
+    """Passing ``None`` yields an empty boolean series."""
     s = pd.Series([1, 2, 3])
     result = func(None, s)
-    expected = pd.Series(False, index=[])
+    expected = pd.Series(dtype=bool)
     pd.testing.assert_series_equal(result, expected)
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -50,7 +50,7 @@ def _crosses(a: pd.Series | None, b: pd.Series | None, above: bool) -> pd.Series
         pd.Series: Boolean mask indexed like the aligned input series.
     """
     if a is None or b is None:
-        return pd.Series(False, index=[])
+        return pd.Series(dtype=bool)
     x, y = _align(a, b)
     if above:
         return (x.shift(1) < y.shift(1)) & (x >= y)


### PR DESCRIPTION
## Ne değişti?
- `utils._crosses` fonksiyonu artık `None` girişinde boş bool seri döndürüyor.
- İlgili test beklentisi güncellendi.

## Neden yapıldı?
- Önceki dönüş değeri `object` tipindeydi; tip tutarlılığı sağlandı.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik analiz kontrolleri çalıştırıldı.
- `pytest` ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_6878c79e60a883259bfb34868da7c470