### PR TITLE
Küçük tarih dönüşüm düzeltmesi

### DIFF
--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -49,6 +49,6 @@ def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
 
     # Fallback to dateutil for other variants
     try:
-        return parser.parse(str(date_str), dayfirst=True)
+        return pd.Timestamp(parser.parse(str(date_str), dayfirst=True))
     except Exception:
         return pd.NaT


### PR DESCRIPTION
## Ne değişti?
- `parse_date` fonksiyonunun tarih yorumlama adımında `dateutil` çıktısı artık `pd.Timestamp` tipine çevriliyor.

## Neden yapıldı?
- Fonksiyon dokümantasyonu `pd.Timestamp` döneceğini belirtmesine rağmen son aşamada `datetime` nesnesi dönüyordu. Bu tutarsızlık testlerde fark edildi.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı ve başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_6878eddd2da0832595382eaa6c3ef0c9