### PR TITLE
Data loader cache clears Excel workbook cache

### DIFF
--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -13,6 +13,7 @@ import pandas as pd
 from cachetools import TTLCache
 
 from finansal_analiz_sistemi import config
+from src.utils.excel_reader import clear_cache as clear_excel_cache
 from src.utils.excel_reader import open_excel_cached
 
 
@@ -66,11 +67,9 @@ class DataLoaderCache:
         return (abs_path, kind), stat.st_mtime_ns, stat.st_size
 
     def clear(self) -> None:
-        """Clear the internal cache.
-
-        All cached datasets are removed immediately.
-        """
+        """Clear all cached datasets and Excel workbooks."""
         self.loaded_data.clear()
+        clear_excel_cache()
 
     def load_csv(self, filepath: str, **kwargs) -> pd.DataFrame:
         """Load ``filepath`` through the in-memory cache.

--- a/tests/test_data_loader_cache.py
+++ b/tests/test_data_loader_cache.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from data_loader_cache import DataLoaderCache
+from src.utils.excel_reader import open_excel_cached
+
+
+def test_clear_also_empties_excel_cache(tmp_path):
+    path = tmp_path / "a.xlsx"
+    pd.DataFrame({"x": [1]}).to_excel(path, index=False)
+
+    cache = DataLoaderCache()
+    first = cache.load_excel(str(path))
+    # ensure the workbook comes from the cache
+    second = open_excel_cached(path)
+    assert first is second
+
+    cache.clear()
+    new = cache.load_excel(str(path))
+    assert new is not first


### PR DESCRIPTION
## Ne değişti?
- `DataLoaderCache.clear` artık `excel_reader` önbelleğini de temizliyor.
- Yeni `tests/test_data_loader_cache.py` dosyasıyla bu davranış doğrulandı.

## Neden yapıldı?
Excel dosyaları bellekte açık kaldığı için sonraki işlemlerde güncel dosya okunamıyordu. Bellek sızıntısını önlemek adına önbellek tamamen sıfırlanıyor.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analiz kontrolleri çalıştırıldı.
- `pytest` tüm testleri başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_6878f7c8e4dc8325898f137a0f3574b4