### PR TITLE
Küçük iyileştirme: parse_date

### DIFF
--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -32,6 +32,10 @@ def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
     if pd.isna(date_str) or str(date_str).strip() == "":
         return pd.NaT
 
+    # Short-circuit for already parsed dates
+    if isinstance(date_str, datetime):
+        return pd.Timestamp(date_str)
+
     # Try explicit ISO first
     ts = pd.to_datetime(date_str, format="%Y-%m-%d", errors="coerce")
     if ts is not pd.NaT:


### PR DESCRIPTION
## Ne değişti?
- `utils/date_utils.parse_date` fonksiyonu artık `datetime` nesnelerini doğrudan `Timestamp`'a çevirmek için erken dönüş yapıyor.

## Neden yapıldı?
- Tarih değeri zaten `datetime` tipindeyse gereksiz `to_datetime` çağrıları önlendi, kod okunabilirliği arttı.

## Nasıl test edildi?
- İlgili birim testleri (`test_date_parse.py`, `test_iso_date.py`, `test_date_parse_iso.py`) çalıştırıldı.
- `pre-commit` kancaları sorunsuz geçti.

------
https://chatgpt.com/codex/tasks/task_e_68791e395a0c83259ca3e938517b4d66