### PR TITLE
Detay raporu fonksiyonunda boş liste hatası giderildi

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -101,7 +101,13 @@ def _build_detay_df(
     -------
     pandas.DataFrame
         Combined detail rows enriched with trade results when available.
+        When ``detay_list`` is empty an empty frame with ``trades`` columns
+        is returned.
     """
+    if not detay_list:
+        cols = trades.columns if trades is not None else None
+        return pd.DataFrame(columns=cols)
+
     detay_df = pd.concat(detay_list, ignore_index=True)
     if trades is not None and not trades.empty:
         detay_df = detay_df.merge(

--- a/tests/test_detay_not_empty.py
+++ b/tests/test_detay_not_empty.py
@@ -25,3 +25,20 @@ def test_detay_not_empty():
     critical = ["hisse_kodu", "getiri_%", "basari", "strateji", "sebep_kodu"]
     # ensure none of the critical columns contain missing values
     assert detay_df[critical].notna().all().all()
+
+
+def test_detay_empty_list():
+    """Empty input should yield an empty DataFrame with expected columns."""
+    trades = pd.DataFrame(
+        {
+            "filtre_kodu": ["F1"],
+            "hisse_kodu": ["AAA"],
+            "getiri_%": [5.0],
+            "basari": ["BAŞARILI"],
+            "strateji": ["S"],
+            "sebep_kodu": ["OK"],
+        }
+    )
+    df = _build_detay_df([], trades)
+    assert df.empty
+    assert list(df.columns) == list(trades.columns)


### PR DESCRIPTION
## Ne değişti?
- `_build_detay_df` fonksiyonu, boş `detay_list` parametresi ile çağrıldığında artık hata vermeyip boş bir DataFrame döndürüyor.
- Bu davranışı doğrulayan `test_detay_empty_list` adlı yeni bir test eklendi.

## Neden yapıldı?
Boş liste durumunda `pd.concat` çağrısı `ValueError` hatası oluşturuyordu. Fonksiyonun daha güvenli çalışması için erken dönüş eklendi.

## Nasıl test edildi?
- `pre-commit` ile biçimlendirme ve statik analiz kontrolleri çalıştırıldı.
- İlgili iki test senaryosu `pytest` ile başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_6879496ebcc8832591dc1ca4275c3015