### PR TITLE
Veri önbellek süresi testi eklendi

### DIFF
--- a/tests/test_data_loader_cache.py
+++ b/tests/test_data_loader_cache.py
@@ -1,3 +1,5 @@
+import time
+
 import pandas as pd
 import pytest
 
@@ -41,3 +43,14 @@ def test_csv_caching(tmp_path):
     first = cache.load_csv(str(path))
     second = cache.load_csv(str(path))
     assert first is second
+
+
+def test_cache_entry_expires(tmp_path):
+    path = tmp_path / "d.csv"
+    pd.DataFrame({"x": [1]}).to_csv(path, index=False)
+
+    cache = DataLoaderCache(ttl=1)
+    first = cache.load_csv(str(path))
+    time.sleep(1.1)
+    second = cache.load_csv(str(path))
+    assert first is not second


### PR DESCRIPTION
## Ne değişti?
- `tests/test_data_loader_cache.py` dosyasına önbelleğin TTL süresi dolunca tekrar yüklendiğini doğrulayan yeni bir test eklendi.

## Neden yapıldı?
- `DataLoaderCache` sınıfının zaman aşımı davranışı sınanmıyordu. Bu ek test ile önbelleğin süresi dolduğunda yeniden okuma yapıldığı güvence altına alındı.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı ve tüm kontroller geçti.
- `pytest` ile tüm testler çalıştırıldı; yeni test dahil hepsi başarılı oldu.

------
https://chatgpt.com/codex/tasks/task_e_6879646da50c8325b76e2cfcfe396524