### PR TITLE
Hata gizlenmesini önle

### DIFF
--- a/src/utils/excel_reader.py
+++ b/src/utils/excel_reader.py
@@ -6,6 +6,7 @@ entries refresh automatically whenever the underlying file changes.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict
@@ -24,6 +25,8 @@ class ExcelCacheEntry:
     book: pd.ExcelFile
 
 
+logger = logging.getLogger(__name__)
+
 _excel_cache: Dict[str, ExcelCacheEntry] = {}
 
 
@@ -32,8 +35,8 @@ def clear_cache() -> None:
     for entry in _excel_cache.values():
         try:
             entry.book.close()
-        except Exception:
-            pass
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            logger.warning("Çalışma kitabı kapatılamadı: %s", exc)
     _excel_cache.clear()
 
 
@@ -56,8 +59,8 @@ def open_excel_cached(path: str | os.PathLike[str], **kwargs: Any) -> pd.ExcelFi
         if cached is not None:
             try:
                 cached.book.close()
-            except Exception:
-                pass
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.warning("Önceki çalışma kitabı kapatılamadı: %s", exc)
         _excel_cache[abs_path] = ExcelCacheEntry(
             mtime, pd.ExcelFile(abs_path, **kwargs)
         )


### PR DESCRIPTION
## Ne değişti?
- `src/utils/excel_reader.py` içinde kapatma hataları artık yutulmak yerine uyarı olarak loglanıyor.

## Neden yapıldı?
- Sessizce geçilen hatalar sorun tespitini zorlaştırıyordu. Loglama ile dosya kapanırken oluşabilecek problemlerin anlaşılması kolaylaştı.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı ve tümü geçti.
- `pytest` komutu ile test paketi çalıştırıldı, tüm testler başarıyla sonuçlandı.

------
https://chatgpt.com/codex/tasks/task_e_68796bcb4f108325915d0fd14053b3b5