### PR TITLE
log_failure yardımcısı

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -19,6 +19,7 @@ from pandas.errors import UndefinedVariableError as QueryError
 
 import settings
 from finansal_analiz_sistemi.logging_config import get_logger
+from utils.failure_tracker import log_failure_exc
 
 logger = get_logger(__name__)
 
@@ -222,11 +223,7 @@ def safe_eval(
             FAILED_FILTERS.append({"filtre_kodu": expr.get("code"), "hata": str(e)})
             logger.warning("QUERY_ERROR %s", e)
             try:
-                from utils.error_map import get_reason_hint
-                from utils.failure_tracker import log_failure
-
-                reason, hint = get_reason_hint(e)
-                log_failure("filters", expr.get("code", "unknown"), reason, hint)
+                log_failure_exc("filters", expr.get("code", "unknown"), e)
             except Exception:
                 pass
             raise
@@ -276,11 +273,7 @@ def run_single_filter(kod: str, query: str) -> dict[str, Any]:
         )
         logger.warning(f"QUERY_ERROR: {kod} – {msg}")
         try:
-            from utils.error_map import get_reason_hint
-            from utils.failure_tracker import log_failure
-
-            reason, hint = get_reason_hint(qe)
-            log_failure("filters", kod, reason, hint)
+            log_failure_exc("filters", kod, qe)
         except Exception:
             pass
     except MissingColumnError as me:
@@ -296,11 +289,7 @@ def run_single_filter(kod: str, query: str) -> dict[str, Any]:
         )
         logger.warning(f"GENERIC: {kod} – {msg}")
         try:
-            from utils.error_map import get_reason_hint
-            from utils.failure_tracker import log_failure
-
-            reason, hint = get_reason_hint(me)
-            log_failure("filters", kod, reason, hint)
+            log_failure_exc("filters", kod, me)
         except Exception:
             pass
     return atlanmis
@@ -382,11 +371,7 @@ def _apply_single_filter(
     except Exception as e:
         info.update(durum="HATA", sebep=str(e)[:120])
         try:
-            from utils.error_map import get_reason_hint
-            from utils.failure_tracker import log_failure
-
-            reason, hint = get_reason_hint(e)
-            log_failure("filters", kod, reason, hint)
+            log_failure_exc("filters", kod, e)
         except Exception:
             pass
         return None, info
@@ -559,11 +544,7 @@ def uygula_filtreler(
             )
             fn_logger.warning(f"QUERY_ERROR: {filtre_kodu} – {msg}")
             try:
-                from utils.error_map import get_reason_hint
-                from utils.failure_tracker import log_failure
-
-                reason, hint = get_reason_hint(qe)
-                log_failure("filters", filtre_kodu, reason, hint)
+                log_failure_exc("filters", filtre_kodu, qe)
             except Exception:
                 pass
             continue
@@ -580,11 +561,7 @@ def uygula_filtreler(
             )
             fn_logger.warning(f"GENERIC: {filtre_kodu} – {msg}")
             try:
-                from utils.error_map import get_reason_hint
-                from utils.failure_tracker import log_failure
-
-                reason, hint = get_reason_hint(me)
-                log_failure("filters", filtre_kodu, reason, hint)
+                log_failure_exc("filters", filtre_kodu, me)
             except Exception:
                 pass
             continue

--- a/utils/failure_tracker.py
+++ b/utils/failure_tracker.py
@@ -14,6 +14,7 @@ __all__ = [
     "clear_failures",
     "get_failures",
     "log_failure",
+    "log_failure_exc",
     "failures_to_df",
 ]
 
@@ -67,6 +68,18 @@ def log_failure(category: str, item: str, reason: str, hint: str = "") -> None:
         hint (str, optional): Additional hint for resolving the failure.
     """
     failures[category].append(FailedFilter(item, reason, hint))
+
+
+def log_failure_exc(category: str, item: str, exc: Exception) -> None:
+    """Record ``exc`` under ``category`` using mapped reason and hint."""
+
+    try:
+        from utils.error_map import get_reason_hint
+
+        reason, hint = get_reason_hint(exc)
+    except Exception:
+        reason, hint = type(exc).__name__, ""
+    log_failure(category, item, reason, hint)
 
 
 def failures_to_df() -> pd.DataFrame:


### PR DESCRIPTION
## Ne değişti?
- `utils.failure_tracker` modülüne `log_failure_exc` fonksiyonu eklendi.
- `filter_engine` içinde tekrarlanan hata kaydı kodları bu yeni yardımcıyı kullanacak şekilde sadeleştirildi.

## Neden yapıldı?
Tekrar eden `get_reason_hint` ve `log_failure` çağrıları tek bir fonksiyonda toplandı. Böylece kod okunabilirliği arttı ve hata kayıt işlemi standartlaştı.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı: tüm kontroller geçti.
- `pytest` komutu ile testler çalıştırıldı ve tamamı başarılı oldu.


------
https://chatgpt.com/codex/tasks/task_e_6879ead3a324832587581767fb6e9b9f