### PR TITLE
safe_set NaN int columns

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -32,7 +32,13 @@ def safe_set(df: pd.DataFrame, column: str, values) -> None:
         try:
             series = series.astype(target_dtype)
         except (ValueError, TypeError):
-            # fall back to float if incompatible (e.g., float into int column)
-            series = series.astype("float32")
+            if str(target_dtype).startswith("int"):
+                try:
+                    nullable = "Int32" if "32" in str(target_dtype) else "Int64"
+                    series = series.astype(nullable)
+                except Exception:
+                    series = series.astype("float32")
+            else:
+                series = series.astype("float32")
 
     df[column] = series

--- a/tests/test_dtypes_ok.py
+++ b/tests/test_dtypes_ok.py
@@ -30,4 +30,4 @@ def test_safe_set_fallback_dtype():
     """Fallback to float dtype when ``NaN`` values are present."""
     df = pd.DataFrame({"volume": pd.Series([1, 2], dtype="int32")})
     safe_set(df, "volume", [1, np.nan])
-    assert df["volume"].dtype == "float32"
+    assert str(df["volume"].dtype) == "Int32"


### PR DESCRIPTION
## Ne değişti?
- `safe_set` fonksiyonu, NaN içeren tam sayı sütunlarında önce pandas `Int32/Int64` türlerini deneyecek şekilde güncellendi.
- Uygunluk testi `test_safe_set_fallback_dtype` yeni davranışı doğrulayacak şekilde düzenlendi.

## Neden yapıldı?
NaN değer barındıran tam sayı sütunları eskiden otomatik olarak `float32`'ye çevriliyordu. Nullable tamsayı tipleri kullanılarak bellek verimliliği ve veri bütünlüğü korunmuş oldu.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm `pytest` testleri başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_6879efbb8c748325bf3d5d4ff6259b89