### PR TITLE
Improve unique_name helper

### DIFF
--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -15,3 +15,10 @@ def test_unique_name_large_set():
     seen = {"ema_10"} | {f"ema_10_{i}" for i in range(1, 11)}
     assert unique_name("ema_10", seen) == "ema_10_11"
     assert "ema_10_11" in seen
+
+
+def test_unique_name_fills_gap():
+    """Smallest unused suffix should be selected."""
+    seen = {"ema_10", "ema_10_1", "ema_10_3"}
+    assert unique_name("ema_10", seen) == "ema_10_2"
+    assert "ema_10_2" in seen

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -27,15 +27,9 @@ def unique_name(base: str, seen: set[str]) -> str:
         seen.add(base)
         return base
 
-    import re
-
-    pattern = re.compile(re.escape(base) + r"_(\d+)$")
-    max_idx = 0
-    for name in seen:
-        match = pattern.fullmatch(name)
-        if match:
-            max_idx = max(max_idx, int(match.group(1)))
-
-    new = f"{base}_{max_idx + 1}"
+    index = 1
+    while f"{base}_{index}" in seen:
+        index += 1
+    new = f"{base}_{index}"
     seen.add(new)
     return new


### PR DESCRIPTION
## Ne değişti?
- `unique_name` fonksiyonu ardışık boş indeksleri bulacak şekilde sadeleştirildi.
- `tests/test_unique_name.py` dosyasına aradaki boş numarayı kullanma durumunu test eden yeni bir senaryo eklendi.

## Neden yapıldı?
- Önceki algoritma isimler arasında boşluk olduğunda en yüksek değeri kullanıyordu. Yeni yöntem en küçük kullanılmamış indeksi seçerek gereksiz numara atlamalarının önüne geçiyor.

## Nasıl test edildi?
- `pre-commit` ile kod biçimlendirme ve statik analiz kontrolleri çalıştırıldı.
- `pytest` ile tüm testler başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_687a3a759b5c8325b9baec8eb7b3f95a