### PR TITLE
OpenBB cache with LRU

### DIFF
--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -8,3 +8,27 @@ def test_public_exports():
 def test_wrappers_exist():
     for name in om.__all__:
         assert hasattr(om, name)
+
+
+def test_call_openbb_populates_cache(monkeypatch):
+    """_call_openbb should cache resolved functions."""
+
+    calls = []
+
+    class DummyTech:
+        def foo(self, x: int) -> int:
+            calls.append(x)
+            return x
+
+    dummy = type("DummyOBB", (), {"technical": DummyTech()})()
+
+    monkeypatch.setattr(om, "obb", dummy)
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+
+    out1 = om._call_openbb("foo", x=1)
+    out2 = om._call_openbb("foo", x=2)
+
+    assert out1 == 1 and out2 == 2
+    assert calls == [1, 2]
+    assert "foo" in om._FUNC_CACHE
+    assert len(om._FUNC_CACHE) == 1


### PR DESCRIPTION
## Değişiklik Özeti
- `openbb_missing.py` dosyasında OpenBB fonksiyonları için LRUCache kullanıldı
- `_call_openbb` fonksiyonu güncellenip önbelleği kullandığı test edildi
- `tests/test_openbb_missing.py` içerisine önbellek davranışını doğrulayan yeni test eklendi

## Testler
- `pre-commit` ile kod biçimi ve statik analizler çalıştırıldı
- `pytest` ile tüm testler çalıştırıldı

------
https://chatgpt.com/codex/tasks/task_e_687a522b58bc83259a92842fffcba43a