### PR TITLE
Tarih sütunu algılama geliştirmesi

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -59,11 +59,17 @@ DATE_COLUMN_CANDIDATES = (
 
 
 def _find_date_column(df: pd.DataFrame) -> str | None:
-    """Return the first matching date column name or ``None``."""
+    """Return the first matching date column name or ``None``.
+
+    The search includes standard column names and any column starting with
+    ``"Unnamed:"``. This accommodates exported Excel files that preserve an
+    index column.
+    """
 
     candidates = list(DATE_COLUMN_CANDIDATES)
-    if not df.empty and df.columns[0].startswith("Unnamed:"):
-        candidates.append(df.columns[0])
+    extra = next((col for col in df.columns if str(col).startswith("Unnamed:")), None)
+    if extra:
+        candidates.append(extra)
     return next((c for c in candidates if c in df.columns), None)
 
 

--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -66,13 +66,22 @@ def test_load_excel_katalogu_short(tmp_path: Path):
     assert data_loader.load_excel_katalogu(str(p)) is None
 
 
-@pytest.mark.parametrize("colname", ["Date", "Tarih", "tarih", "TARİH", "Unnamed: 0"])
+@pytest.mark.parametrize(
+    "colname", ["Date", "Tarih", "tarih", "TARİH", "Unnamed: 0", "Unnamed: 1"]
+)
 def test_standardize_date_column(colname):
     """Rename various date column names to ``tarih`` consistently."""
     df = pd.DataFrame({colname: ["2025-03-07"]})
     out = data_loader._standardize_date_column(df, "dummy")
     assert "tarih" in out.columns
     assert out.columns.tolist().count("tarih") == 1
+
+
+def test_standardize_date_column_unnamed_any_position():
+    """Unnamed columns should be detected even when not first."""
+    df = pd.DataFrame({"a": [1], "Unnamed: 3": ["2025-03-07"]})
+    out = data_loader._standardize_date_column(df, "dummy")
+    assert "tarih" in out.columns
 
 
 def test_standardize_date_column_no_match():


### PR DESCRIPTION
## Ne değişti?
- `_find_date_column` fonksiyonu, `Unnamed:` ile başlayan sütunları tüm DataFrame içinde arayacak şekilde genişletildi.
- İlgili docstring güncellendi.
- `test_data_loader_param` test dosyasına yeni bir parametre ve ek senaryo eklendi.

## Neden yapıldı?
- Excel'den alınan verilerde tarih bilgisi farklı sütunlarda yer alabiliyor. Algoritmanın tüm `Unnamed:` sütunlarını dikkate alması bu durumlarda doğru sütunun bulunmasını sağlar.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik analizler çalıştırıldı.
- Tüm testler `pytest` ile başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687a977ef2808325ba3f3b998ac0b987