### PR TITLE
Kısa safe_set iyileştirmesi

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -6,23 +6,30 @@ and casts values to a suitable dtype whenever possible.
 
 from __future__ import annotations
 
+from typing import Any, Iterable
+
 import pandas as pd
 
 from finansal_analiz_sistemi import config
 
 
-def safe_set(df: pd.DataFrame, column: str, values) -> None:
-    """Assign series to DataFrame with dtype safety.
+def safe_set(df: pd.DataFrame, column: str, values: Iterable[Any]) -> None:
+    """Assign ``values`` to ``df[column]`` with dtype safety.
 
     Args:
         df (pd.DataFrame): Target DataFrame to modify.
         column (str): Column name to assign.
-        values (iterable): Values to be set. ``values`` must be index-aligned
-            with ``df``.
+        values (Iterable[Any]): Values to be set. ``values`` must be index-aligned
+            with ``df``. When the length differs, values are reindexed to ``df``
+            and missing entries become ``NaN``.
 
     """
     # Ensure the index matches the DataFrame to avoid misaligned assignment
-    series = pd.Series(values, index=df.index)
+    try:
+        series = pd.Series(values, index=df.index)
+    except ValueError:
+        series = pd.Series(values)
+        series = series.reindex(df.index)
 
     target_dtype = config.DTYPES_MAP.get(column)
     if target_dtype is None and column in df.columns:

--- a/tests/test_dtypes_ok.py
+++ b/tests/test_dtypes_ok.py
@@ -31,3 +31,12 @@ def test_safe_set_fallback_dtype():
     df = pd.DataFrame({"volume": pd.Series([1, 2], dtype="int32")})
     safe_set(df, "volume", [1, np.nan])
     assert str(df["volume"].dtype) == "Int32"
+
+
+def test_safe_set_handles_length_mismatch():
+    """Input shorter than DataFrame length should be reindexed with NaN."""
+    df = pd.DataFrame({"close": [10, 20, 30]})
+    # Provide only two values for three rows
+    safe_set(df, "ema_5", [1, 2])
+    assert list(df["ema_5"][:2]) == [1, 2]
+    assert pd.isna(df["ema_5"].iloc[2])


### PR DESCRIPTION
## Ne değişti?
- `safe_set` fonksiyonu uzunluk uyumsuzluklarında hataya düşmeyecek şekilde güncellendi.
- Fonksiyona tip ipucu eklendi ve dokümantasyon genişletildi.
- Uyumlu olmayan uzunlukların NaN ile tamamlandığını doğrulayan yeni bir test eklendi.

## Neden yapıldı?
`safe_set` kullanımı sırasında değer dizisi ile DataFrame uzunluğu uyuşmadığında pandas hata veriyordu. Bu durum fonksiyonun esnekliğini azaltıyordu. Güncelleme ile veri kaybı olmadan NaN doldurulması sağlandı.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik kontroller çalıştırıldı.
- `pytest` ile tüm testler ve eklenen yeni test yürütüldü.

------
https://chatgpt.com/codex/tasks/task_e_687a9c52ba148325ae2681521d371439