### PR TITLE
openbb wrapper hata kontrolü geliştirildi

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -50,11 +50,10 @@ def _call_openbb(func_name: str, **kwargs) -> object:
         If :mod:`openbb` or the requested function is unavailable.
     """
     if obb is None:
-        raise NotImplementedError(f"OpenBB indicator '{func_name}' is unavailable")
+        raise NotImplementedError("OpenBB package is not installed")
 
-    try:
-        func = _FUNC_CACHE[func_name]
-    except KeyError:
+    func = _FUNC_CACHE.get(func_name)
+    if func is None:
         func = getattr(obb.technical, func_name, None)
         if func is None:
             raise NotImplementedError(f"OpenBB indicator '{func_name}' is unavailable")

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -1,3 +1,5 @@
+import pytest
+
 import openbb_missing as om
 
 
@@ -32,3 +34,28 @@ def test_call_openbb_populates_cache(monkeypatch):
     assert calls == [1, 2]
     assert "foo" in om._FUNC_CACHE
     assert len(om._FUNC_CACHE) == 1
+
+
+def test_call_openbb_package_missing(monkeypatch):
+    """NotImplementedError should be raised when OpenBB is absent."""
+
+    monkeypatch.setattr(om, "obb", None)
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+
+    with pytest.raises(NotImplementedError, match="package"):
+        om._call_openbb("foo")
+
+
+def test_call_openbb_function_missing(monkeypatch):
+    """NotImplementedError should be raised for unknown functions."""
+
+    class DummyTech:
+        pass
+
+    dummy = type("DummyOBB", (), {"technical": DummyTech()})()
+
+    monkeypatch.setattr(om, "obb", dummy)
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+
+    with pytest.raises(NotImplementedError, match="bar"):
+        om._call_openbb("bar")


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing._call_openbb` fonksiyonu OpenBB paketi yüklü olmadığında artık daha açıklayıcı bir mesaj döndürüyor ve önbellek erişimi basitleştirildi.
- Eksik paket ve tanımsız fonksiyon durumlarını doğrulayan iki yeni test eklendi.

## Neden yapıldı?
- Hata mesajlarını iyileştirerek kullanıcıya daha net bilgi sağlamak.
- Fonksiyonun davranışını güvence altına almak için test kapsamını artırmak.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik analiz kontrolleri çalıştırıldı.
- `pytest` ile tüm testler başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687aa66894c08325a81c71deee07821e