### PR TITLE
None verilerini atlayan safe_concat

### DIFF
--- a/tests/test_pandas_compat.py
+++ b/tests/test_pandas_compat.py
@@ -25,3 +25,10 @@ def test_safe_concat_iterable():
     frames = (pd.DataFrame({"a": [i]}) for i in range(3))
     result = safe_concat(frames, ignore_index=True)
     assert result.equals(pd.DataFrame({"a": [0, 1, 2]}))
+
+
+def test_safe_concat_ignores_none():
+    """``None`` values in the iterable should be skipped."""
+    frames = [pd.DataFrame({"a": [1]}), None, pd.DataFrame({"a": [2]})]
+    result = safe_concat(frames, ignore_index=True)
+    assert result.equals(pd.DataFrame({"a": [1, 2]}))

--- a/utils/compat/__init__.py
+++ b/utils/compat/__init__.py
@@ -16,8 +16,8 @@ __all__ = ["safe_concat", "safe_infer_objects", "safe_to_excel"]
 _PANDAS_HAS_COPY = _v.parse(pd.__version__) >= _v.parse("2.0.0")
 
 
-def safe_concat(frames: Iterable[pd.DataFrame], **kwargs) -> pd.DataFrame:
-    """Concatenate non-empty frames or return an empty ``DataFrame``.
+def safe_concat(frames: Iterable[pd.DataFrame | None], **kwargs) -> pd.DataFrame:
+    """Concatenate non-empty frames and ignore ``None`` entries.
 
     Parameters
     ----------
@@ -31,7 +31,7 @@ def safe_concat(frames: Iterable[pd.DataFrame], **kwargs) -> pd.DataFrame:
     pandas.DataFrame
         Concatenated frame or an empty frame when ``frames`` is empty.
     """
-    frames = [f for f in frames if not f.empty]
+    frames = [f for f in frames if isinstance(f, pd.DataFrame) and not f.empty]
     return pd.concat(frames, **kwargs) if frames else pd.DataFrame()
 
 


### PR DESCRIPTION
## Ne değişti?
- `safe_concat` artık `None` değerlerini yoksayıyor.
- İlgili işlevin dokümantasyonu ve parametre tipi güncellendi.
- `tests/test_pandas_compat.py` dosyasına `None` içeren listeyi doğrulayan yeni bir test eklendi.

## Neden yapıldı?
`safe_concat` fonksiyonuna `None` içeren diziler gönderildiğinde `AttributeError` oluşabiliyordu. Bu durum bazı çağrılarda hataya yol açıyordu.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler ve yeni eklenen test başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687aab5447048325840abaf624a9dc0f