### PR TITLE
safe_set iyileştirmesi

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -19,17 +19,19 @@ def safe_set(df: pd.DataFrame, column: str, values: Iterable[Any]) -> None:
     Args:
         df (pd.DataFrame): Target DataFrame to modify.
         column (str): Column name to assign.
-        values (Iterable[Any]): Values to be set. ``values`` must be index-aligned
-            with ``df``. When the length differs, values are reindexed to ``df``
-            and missing entries become ``NaN``.
+        values (Iterable[Any] | pd.Series): Values assigned to ``df``. When the
+            provided series has a different index or length, it is reindexed to
+            ``df`` and missing entries become ``NaN``.
 
     """
     # Ensure the index matches the DataFrame to avoid misaligned assignment
-    try:
-        series = pd.Series(values, index=df.index)
-    except ValueError:
-        series = pd.Series(values)
-        series = series.reindex(df.index)
+    if isinstance(values, pd.Series):
+        series = values.reindex(df.index)
+    else:
+        try:
+            series = pd.Series(values, index=df.index)
+        except ValueError:
+            series = pd.Series(values).reindex(df.index)
 
     target_dtype = config.DTYPES_MAP.get(column)
     if target_dtype is None and column in df.columns:

--- a/tests/test_dtypes_ok.py
+++ b/tests/test_dtypes_ok.py
@@ -40,3 +40,11 @@ def test_safe_set_handles_length_mismatch():
     safe_set(df, "ema_5", [1, 2])
     assert list(df["ema_5"][:2]) == [1, 2]
     assert pd.isna(df["ema_5"].iloc[2])
+
+
+def test_safe_set_series_input_reindexes():
+    """Series input should be reindexed to match the DataFrame index."""
+    df = pd.DataFrame({"close": [10, 20]}, index=[5, 6])
+    series = pd.Series([1, 2], index=[6, 5])
+    safe_set(df, "ema_10", series)
+    assert list(df["ema_10"]) == [2, 1]


### PR DESCRIPTION
## Değişiklik Özeti
- `safe_set` fonksiyonunda pandas Series girdilerini DataFrame indeksine göre hizalayacak şekilde düzenleme yapıldı
- uzunluk uyuşmazlıklarında oluşan hatalar için yedek akış eklendi
- yeni davranışı doğrulamak üzere test eklendi

## Testler
- `pre-commit` ile stil ve statik analiz kontrolleri
- `pytest` ile tüm testlerin çalıştırılması

------
https://chatgpt.com/codex/tasks/task_e_687ad83b0a3c8325becd706bb106577d