### PR TITLE
Kayıp CSV okuma hatası loglandı

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -6,6 +6,7 @@ files and configuration lists.
 
 from __future__ import annotations
 
+import logging
 import re
 from functools import lru_cache
 from pathlib import Path
@@ -35,7 +36,8 @@ def load_crossover_names(csv_path: str | Path | None = None) -> list[str]:
     names: set[str] = set()
     try:
         df = pd.read_csv(path, sep=";", engine="python")
-    except Exception:
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Filter CSV '%s' okunamadı: %s", path, exc)
         df = pd.DataFrame()
     if "PythonQuery" in df.columns:
         for expr in df["PythonQuery"].dropna().astype(str):


### PR DESCRIPTION
## Değişiklik Özeti
- `config_loader.load_crossover_names` fonksiyonunda oluşan `read_csv` hataları artık `logging` ile uyarı olarak kaydediliyor.

## Neden Yapıldı
- Daha önce CSV okunamadığında sessizce boş DataFrame dönüyordu. Hata bilgisi kayıt altına alınmadığından sorunların tespiti zorlaşıyordu.

## Nasıl Test Edildi
- `pre-commit` kancaları çalıştırıldı.
- Tüm `pytest` testleri başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_687b3102c8808325aa32e8043699ed55