### PR TITLE
safe_concat None entries

### DIFF
--- a/tests/test_pandas_compat.py
+++ b/tests/test_pandas_compat.py
@@ -25,3 +25,11 @@ def test_safe_concat_iterable():
     frames = (pd.DataFrame({"a": [i]}) for i in range(3))
     result = safe_concat(frames, ignore_index=True)
     assert result.equals(pd.DataFrame({"a": [0, 1, 2]}))
+
+
+def test_safe_concat_ignores_none():
+    """None entries should be skipped during concatenation."""
+    df1 = pd.DataFrame({"a": [1]})
+    df2 = pd.DataFrame({"a": [2]})
+    result = safe_concat([df1, None, df2], ignore_index=True)
+    assert result.equals(pd.DataFrame({"a": [1, 2]}))

--- a/utils/compat/__init__.py
+++ b/utils/compat/__init__.py
@@ -16,13 +16,13 @@ __all__ = ["safe_concat", "safe_infer_objects", "safe_to_excel"]
 _PANDAS_HAS_COPY = _v.parse(pd.__version__) >= _v.parse("2.0.0")
 
 
-def safe_concat(frames: Iterable[pd.DataFrame], **kwargs) -> pd.DataFrame:
-    """Concatenate non-empty frames or return an empty ``DataFrame``.
+def safe_concat(frames: Iterable[pd.DataFrame | None], **kwargs) -> pd.DataFrame:
+    """Concatenate ``frames`` while skipping ``None`` and empty inputs.
 
     Parameters
     ----------
-    frames : Iterable[pandas.DataFrame]
-        Sequence of DataFrames to concatenate.
+    frames : Iterable[pandas.DataFrame | None]
+        Sequence of DataFrames to concatenate. ``None`` values are ignored.
     **kwargs : Any
         Additional arguments forwarded to :func:`pandas.concat`.
 
@@ -31,8 +31,8 @@ def safe_concat(frames: Iterable[pd.DataFrame], **kwargs) -> pd.DataFrame:
     pandas.DataFrame
         Concatenated frame or an empty frame when ``frames`` is empty.
     """
-    frames = [f for f in frames if not f.empty]
-    return pd.concat(frames, **kwargs) if frames else pd.DataFrame()
+    valid_frames = [f for f in frames if isinstance(f, pd.DataFrame) and not f.empty]
+    return pd.concat(valid_frames, **kwargs) if valid_frames else pd.DataFrame()
 
 
 def safe_infer_objects(df: pd.DataFrame, *, copy: bool = False) -> pd.DataFrame:


### PR DESCRIPTION
## Değişiklik Özeti
- `safe_concat` artık `None` ve boş DataFrame girdilerini yoksayıyor
- buna yönelik yeni bir test eklendi

## Testler
- `pre-commit` ile biçim ve statik analizler
- `pytest` tüm testler

------
https://chatgpt.com/codex/tasks/task_e_687b512dfab48325851b1d19badb8d26