### PR TITLE
openbb fonksiyon önbelleğini temizleme desteği

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 import pandas as pd
 from cachetools import LRUCache
 
-__all__ = ["ichimoku", "macd", "rsi"]
+__all__ = ["ichimoku", "macd", "rsi", "clear_cache"]
 
 try:  # pragma: no cover - optional dependency
     from openbb import obb  # type: ignore
@@ -22,6 +22,11 @@ except Exception:  # pragma: no cover - optional dependency
 # Cache for resolved OpenBB functions
 # Limit size to avoid unbounded growth when called with many names
 _FUNC_CACHE: LRUCache[str, Callable[..., Any]] = LRUCache(maxsize=16)
+
+
+def clear_cache() -> None:
+    """Empty the internal OpenBB function cache."""
+    _FUNC_CACHE.clear()
 
 
 def _call_openbb(func_name: str, **kwargs) -> object:

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -4,7 +4,7 @@ import openbb_missing as om
 
 
 def test_public_exports():
-    assert sorted(om.__all__) == ["ichimoku", "macd", "rsi"]
+    assert sorted(om.__all__) == ["clear_cache", "ichimoku", "macd", "rsi"]
 
 
 def test_wrappers_exist():
@@ -59,3 +59,21 @@ def test_call_openbb_function_missing(monkeypatch):
 
     with pytest.raises(NotImplementedError, match="bar"):
         om._call_openbb("bar")
+
+
+def test_clear_cache(monkeypatch):
+    """clear_cache should drop cached functions."""
+
+    class DummyTech:
+        def foo(self, x: int) -> int:
+            return x
+
+    dummy = type("DummyOBB", (), {"technical": DummyTech()})()
+
+    monkeypatch.setattr(om, "obb", dummy)
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+
+    om._call_openbb("foo", x=1)
+    assert len(om._FUNC_CACHE) == 1
+    om.clear_cache()
+    assert len(om._FUNC_CACHE) == 0


### PR DESCRIPTION
## Değişiklik Özeti
- `openbb_missing` modülüne `clear_cache` fonksiyonu eklendi
- `__all__` listesi güncellenerek yeni fonksiyon dışa aktarıldı
- önbelleği temizleme davranışını test eden `test_clear_cache` eklenip mevcut test güncellendi

## Testler
- `pre-commit` ile biçim ve statik analiz kontrolleri
- `pytest -q` ile tüm testlerin çalıştırılması

------
https://chatgpt.com/codex/tasks/task_e_687b5ca50c9883259725a651c1d8fb78