### PR TITLE
Küçük iyileştirme: filtre_engine önbelleği

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -12,6 +12,7 @@ import keyword
 import logging
 import os
 import re
+from functools import lru_cache
 from typing import Any, Optional
 
 import pandas as pd
@@ -65,6 +66,7 @@ _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _RESERVED_TOKENS = set(keyword.kwlist) | {"and", "or", "not", "True", "False", "df"}
 
 
+@lru_cache(maxsize=256)
 def _extract_query_columns(query: str) -> set[str]:
     """Return column-like identifiers referenced in ``query``.
 

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -1,0 +1,13 @@
+"""Tests for _extract_query_columns caching."""
+
+import filter_engine
+
+
+def test_query_columns_cache():
+    query = "close > 0"
+    filter_engine._extract_query_columns.cache_clear()
+    filter_engine._extract_query_columns(query)
+    before = filter_engine._extract_query_columns.cache_info().hits
+    filter_engine._extract_query_columns(query)
+    after = filter_engine._extract_query_columns.cache_info().hits
+    assert after - before == 1


### PR DESCRIPTION
## Ne değişti?
- `_extract_query_columns` fonksiyonu `lru_cache` ile önbelleklendi.
- Fonksiyon için yeni bir test dosyası eklendi.

## Neden yapıldı?
- Aynı sorgular tekrarlandığında gereksiz regex işleminden kaçınılarak performans kazanmak için.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- `pytest` ile tüm testler (yeni test dahil) başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687b5f6202b083259f9d1568287b24c8