### PR TITLE
Küçük iyileştirme: parse_date fonksiyonu güncellendi

### DIFF
--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -14,7 +14,9 @@ from dateutil import parser
 from pandas._libs.tslibs.nattype import NaTType
 
 
-def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
+def parse_date(
+    date_str: Union[str, datetime, int, float, None],
+) -> pd.Timestamp | NaTType:
     """Parse ``date_str`` into a :class:`pandas.Timestamp` or ``pd.NaT``.
 
     The function tries ISO ``YYYY-MM-DD`` and ``DD.MM.YYYY`` formats first,
@@ -22,38 +24,40 @@ def parse_date(date_str: Union[str, datetime]) -> pd.Timestamp | NaTType:
     yield ``pd.NaT`` instead of raising ``ValueError``.
 
     Args:
-        date_str (Union[str, datetime]): Date string or datetime object to
-            parse.
+        date_str (Union[str, datetime, int, float, None]): Date value to parse.
 
     Returns:
         pd.Timestamp | NaTType: Parsed timestamp or ``pd.NaT`` when parsing
         fails.
     """
-    if pd.isna(date_str) or str(date_str).strip() == "":
-        return pd.NaT
-
-    # Short-circuit for already parsed dates
     if isinstance(date_str, datetime):
         return pd.Timestamp(date_str)
 
+    # Normalize value to a stripped string for further checks
+    if pd.isna(date_str):
+        return pd.NaT
+    value = str(date_str).strip()
+    if not value:
+        return pd.NaT
+
     # Try explicit formats before falling back to dateutil
     for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
-        ts = pd.to_datetime(date_str, format=fmt, errors="coerce")
+        ts = pd.to_datetime(value, format=fmt, errors="coerce")
         if ts is not pd.NaT:
             return ts
 
-    if str(date_str).isdigit() and len(str(date_str)) == 8:
-        ts = pd.to_datetime(date_str, format="%Y%m%d", errors="coerce")
+    if value.isdigit() and len(value) == 8:
+        ts = pd.to_datetime(value, format="%Y%m%d", errors="coerce")
         if ts is not pd.NaT:
             return ts
 
     # Generic day-first parsing with coercion (handles 07/03/25 etc.)
-    ts = pd.to_datetime(date_str, dayfirst=True, errors="coerce")
+    ts = pd.to_datetime(value, dayfirst=True, errors="coerce")
     if ts is not pd.NaT:
         return ts
 
     # Fallback to dateutil for other variants
     try:
-        return pd.Timestamp(parser.parse(str(date_str), dayfirst=True))
+        return pd.Timestamp(parser.parse(value, dayfirst=True))
     except Exception:
         return pd.NaT


### PR DESCRIPTION
## Değişiklik Özeti
- `parse_date` fonksiyonunun parametre türleri genişletildi ve tekrarlanan `str` çağrıları kaldırıldı
- docstring güncellendi
- kod `black` ve `isort` ile biçimlendirildi

## Neden
Farklı veri tiplerini daha tutarlı biçimde işlemek ve gereksiz dönüştürmeleri azaltmak.

## Nasıl Test Edildi
- `pre-commit` ile stil ve statik analiz kontrolleri çalıştırıldı
- `pytest` ile tüm testler çalıştırıldı

------
https://chatgpt.com/codex/tasks/task_e_687b70afcc488325a2a0b10d3a954343