### PR TITLE
Sorgu kolon çıkarımında bracket desteği

### DIFF
--- a/tests/test_query_columns.py
+++ b/tests/test_query_columns.py
@@ -23,3 +23,10 @@ def test_apply_single_filter_string_literal():
     )
     _, info = filter_engine._apply_single_filter(df, "T1", 'aciklama == "BETA"')
     assert info["durum"] == "OK"
+
+
+def test_extract_bracket_notation():
+    """Bracket notation should yield the inner column name."""
+    expr = "close > df['BBM_20_2.0']"
+    cols = filter_engine._extract_query_columns(expr)
+    assert cols == {"close", "BBM_20_2.0"}


### PR DESCRIPTION
## Ne değişti?
- `_extract_query_columns` fonksiyonu `df['col']` biçimindeki ifadelerden kolon adlarını ayıklayacak şekilde güncellendi.
- Fonksiyonun açıklaması genişletildi ve yeni regex tanımlandı.
- `tests/test_query_columns.py` dosyasına bracket notasyonunun doğru çalıştığını kontrol eden bir test eklendi.

## Neden yapıldı?
Filtre tanımlarında köşeli parantez kullanılarak belirtilen kolonlar önceki sürümde tespit edilemiyordu. Bu güncelleme ile bu kolonlar da algılanıp ilgili indikatörler hesaplanabilecek.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687b923f5b44832585172a3a1170c3f7