### PR TITLE
Küçük iyileştirme: pandas option_context

### DIFF
--- a/utils/pandas_option_safe.py
+++ b/utils/pandas_option_safe.py
@@ -4,7 +4,7 @@ Unknown options are ignored instead of raising ``OptionError``.
 """
 
 from collections.abc import Iterator
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 
 import pandas as pd
 
@@ -38,11 +38,7 @@ def option_context(name: str, value) -> Iterator[None]:
         None.
     """
     try:
-        ctx = pd.option_context(name, value)
-    except (AttributeError, KeyError, pd.errors.OptionError):
-        ctx = nullcontext()
-    try:
-        with ctx:
+        with pd.option_context(name, value):
             yield
     except (AttributeError, KeyError, pd.errors.OptionError):
         yield


### PR DESCRIPTION
## Ne değişti?
- `utils/pandas_option_safe.option_context` fonksiyonu sadeleştirildi.
- Gereksiz `nullcontext` kullanımı kaldırıldı, hata durumunda doğrudan seçenek atlanıyor.

## Neden yapıldı?
- Kod okunabilirliğini artırmak ve olası hata senaryolarında davranışı netleştirmek için.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm testler `pytest` ile çalıştırıldı.


------
https://chatgpt.com/codex/tasks/task_e_687bd1e98ac08325969e44cc33bfe6c1