### PR TITLE
Küçük iyileştirmeler

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -33,6 +33,9 @@ else:
     _cfg = {}
 MIN_STOCKS_PER_FILTER = _cfg.get("min_stocks_per_filter", 1)
 
+# Ratio of ``NaN`` values in a column that triggers the DATASIZ warning
+NAN_RATIO_THRESHOLD = 0.9
+
 _missing_re = re.compile(r"Eksik sütunlar?:\s*(?P<col>[A-Za-z0-9_]+)")
 _undefined_re = re.compile(r"Tanımsız sütun/değişken:\s*'(?P<col>[^']+)")
 
@@ -344,7 +347,7 @@ def _apply_single_filter(
 
     if req_cols:
         nan_ratios = df[list(req_cols)].isna().mean()
-        mostly_nan = nan_ratios[nan_ratios > 0.9].index.tolist()
+        mostly_nan = nan_ratios[nan_ratios > NAN_RATIO_THRESHOLD].index.tolist()
     else:
         mostly_nan = []
 

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -84,3 +85,18 @@ def test_recursive_filter_detection():
 
     with pytest.raises(filter_engine.CyclicFilterError):
         filter_engine.evaluate_filter(f1, df)
+
+
+def test_apply_single_filter_reports_mostly_nan():
+    """Columns with >90% ``NaN`` values should be reported."""
+    rows = 20
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"] * rows,
+            "tarih": [pd.Timestamp("2025-03-01")] * rows,
+            "foo": [np.nan] * (rows - 1) + [1],
+        }
+    )
+    _, info = filter_engine._apply_single_filter(df, "T_nan", "foo > 0")
+    assert info["durum"] == "OK"
+    assert info["nan_sutunlar"] == "foo"


### PR DESCRIPTION
## Ne değişti?
- `_apply_single_filter` içindeki NAN oranı eşik değeri sabit hale getirildi.
- Bu eşik `NAN_RATIO_THRESHOLD` sabitiyle tanımlandı.
- NAN oranı raporlamasının korunduğunu doğrulamak için yeni bir test eklendi.

## Neden yapıldı?
- Magic number kullanımını azaltıp kod okunabilirliğini artırmak.
- Fonksiyonun `NaN` oranını raporlama davranışını testlerle güvence altına almak.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687be679abd4832596f223c6f0b83328