### PR TITLE
Tarih ayrıştırıcı güncellendi

### DIFF
--- a/tests/test_date_parse.py
+++ b/tests/test_date_parse.py
@@ -12,6 +12,7 @@ def test_parse_date_variants():
         "2025-03-07": "2025-03-07",
         "07/03/25": "2025-03-07",
         "20250307": "2025-03-07",
+        20250307.0: "2025-03-07",
         "\u00e7\u00f6p": pd.NaT,
     }
     for raw, expected in cases.items():

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -7,7 +7,6 @@ The :func:`parse_date` helper converts diverse date strings to
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Union
 
 import pandas as pd
 from dateutil import parser
@@ -15,7 +14,7 @@ from pandas._libs.tslibs.nattype import NaTType
 
 
 def parse_date(
-    date_str: Union[str, datetime, int, float, None],
+    date_str: str | datetime | int | float | None,
 ) -> pd.Timestamp | NaTType:
     """Parse ``date_str`` into a :class:`pandas.Timestamp` or ``pd.NaT``.
 
@@ -24,7 +23,7 @@ def parse_date(
     yield ``pd.NaT`` instead of raising ``ValueError``.
 
     Args:
-        date_str (Union[str, datetime, int, float, None]): Date value to parse.
+        date_str (str | datetime | int | float | None): Date value to parse.
 
     Returns:
         pd.Timestamp | NaTType: Parsed timestamp or ``pd.NaT`` when parsing
@@ -36,7 +35,11 @@ def parse_date(
     # Normalize value to a stripped string for further checks
     if pd.isna(date_str):
         return pd.NaT
-    value = str(date_str).strip()
+
+    if isinstance(date_str, float) and date_str.is_integer():
+        value = str(int(date_str))
+    else:
+        value = str(date_str).strip()
     if not value:
         return pd.NaT
 


### PR DESCRIPTION
## Ne değişti?
- `parse_date` artık ondalık tam sayıları da doğru biçimde işliyor.
- İlgili birim testi genişletilerek yeni durum için örnek eklendi.

## Neden yapıldı?
- Excel'den gelen tarihlerin `20250307.0` şeklinde olabileceği fark edildi. Bu değerler önceki sürümde `NaT` dönüyordu.

## Nasıl test edildi?
- `pre-commit` ile stil ve statik analiz kontrolleri yapıldı.
- `pytest` çalıştırılarak tüm testlerin başarıyla geçtiği doğrulandı.

------
https://chatgpt.com/codex/tasks/task_e_687bf10322948325a0d509fa8015c16e