### PR TITLE
Küçük iyileştirme: Excel önbellek girdisi

### DIFF
--- a/src/utils/excel_reader.py
+++ b/src/utils/excel_reader.py
@@ -15,11 +15,13 @@ from typing import Any
 import pandas as pd
 from cachetools import LRUCache
 
+__all__ = ["open_excel_cached", "read_excel_cached", "clear_cache"]
+
 # Cache ``ExcelFile`` objects keyed by path and modification time. The cache
 # refreshes automatically when the workbook on disk changes.
 
 
-@dataclass
+@dataclass(slots=True)
 class ExcelCacheEntry:
     """Metadata for a cached workbook."""
 


### PR DESCRIPTION
## Değişiklik Özeti
- `ExcelCacheEntry` veri sınıfı artık `slots` kullanıyor
- `excel_reader` modülüne `__all__` listesi eklendi
- pre-commit ve pytest çalıştırıldı

## Testler
- `pre-commit` çıktısı: `Check requirements consistency...........................................Passed`
- `pytest -q` çıktısı: `77 passed, 1 skipped`

------
https://chatgpt.com/codex/tasks/task_e_687c0008a770832589c909ff8b83801f