### PR TITLE
unique_name fonksiyonu bos isme izin vermesin

### DIFF
--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -1,5 +1,7 @@
 """Unit tests for unique_name."""
 
+import pytest
+
 from utilities.naming import unique_name
 
 
@@ -29,3 +31,9 @@ def test_unique_name_trailing_underscore():
     seen = {"foo_", "foo_1"}
     assert unique_name("foo_", seen) == "foo_2"
     assert "foo_2" in seen
+
+
+def test_unique_name_empty_base_raises():
+    """Empty ``base`` should trigger ``ValueError``."""
+    with pytest.raises(ValueError):
+        unique_name("", set())

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -32,7 +32,15 @@ def unique_name(base: str, seen: set[str], *, delimiter: str = "_") -> str:
     str
         ``base`` itself if unused, otherwise a numbered variant such as
         ``base_1``.
+
+    Raises
+    ------
+    ValueError
+        If ``base`` is an empty string.
     """
+
+    if not base:
+        raise ValueError("base must be a non-empty string")
 
     if base not in seen:
         seen.add(base)


### PR DESCRIPTION
## Ne değişti?
- `unique_name` artık boş `base` parametresi verilince `ValueError` fırlatıyor.
- Bu durumu test eden yeni bir senaryo eklendi.

## Neden yapıldı?
- Boş sütun adı üretilmesinin önüne geçmek için kontrol eklendi.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik analiz kontrolleri çalıştırıldı.
- `pytest` ile tüm testler başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687c06bdd06c83258b6d679ac9b27dce