### PR TITLE
safe_set fonksiyonu optimize edildi

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -26,7 +26,7 @@ def safe_set(df: pd.DataFrame, column: str, values: Iterable[Any]) -> None:
     """
     # Ensure the index matches the DataFrame to avoid misaligned assignment
     if isinstance(values, pd.Series):
-        series = values.reindex(df.index)
+        series = values if values.index.equals(df.index) else values.reindex(df.index)
     else:
         try:
             series = pd.Series(values, index=df.index)


### PR DESCRIPTION
## Ne değişti?
- `safe_set` artık parametre olarak verilen `Series` nesnelerinin indeksleri zaten uyumluysa `reindex` yapmıyor.

## Neden yapıldı?
- Gereksiz `reindex` çağrılarının önüne geçilerek bellek ve zaman kullanımı azaltıldı.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analiz çalıştırıldı.
- Tüm `pytest` testleri başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687c23b72e988325b133e69c1d81050f