### PR TITLE
_get_fiyat string param support

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -4,6 +4,8 @@ These functions simulate simple buy/sell scenarios based on filter
 results and provide summary statistics for reporting.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Optional
 

--- a/backtest_core.py
+++ b/backtest_core.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 
 def _get_fiyat(
     df_hisse_veri: pd.DataFrame,
-    tarih: pd.Timestamp,
+    tarih: pd.Timestamp | str,
     zaman_sutun_adi: str,
     logger_param: Optional[logging.Logger] = None,
 ) -> float:
@@ -29,7 +29,7 @@ def _get_fiyat(
 
     Args:
         df_hisse_veri (pd.DataFrame): Stock data for a single ticker.
-        tarih (pd.Timestamp): Date of interest.
+        tarih (pd.Timestamp | str): Date of interest.
         zaman_sutun_adi (str): Column name holding the desired price.
         logger_param (logging.Logger, optional): Logger instance for debug
             output.
@@ -40,6 +40,15 @@ def _get_fiyat(
     if logger_param is None:
         logger_param = logger
     log = logger_param
+    tarih_ts = (
+        tarih
+        if isinstance(tarih, pd.Timestamp)
+        else pd.to_datetime(tarih, dayfirst=True, errors="coerce")
+    )
+    if pd.isna(tarih_ts):
+        log.warning("Geçersiz tarih değeri: %s", tarih)
+        return np.nan
+    tarih = tarih_ts
     hisse_kodu_log = (
         df_hisse_veri["hisse_kodu"].iloc[0]
         if not df_hisse_veri.empty and "hisse_kodu" in df_hisse_veri.columns

--- a/tests/test_backtest_core_param.py
+++ b/tests/test_backtest_core_param.py
@@ -70,3 +70,16 @@ def test_get_fiyat_string_dates():
     )
     out = bc._get_fiyat(df, pd.to_datetime("10.03.2025", dayfirst=True), "close")
     assert out == 11.0
+
+
+def test_get_fiyat_accepts_string_date():
+    """The ``tarih`` argument may be a string."""
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"],
+            "tarih": [pd.to_datetime("07.03.2025", dayfirst=True)],
+            "close": [10.0],
+        }
+    )
+    out = bc._get_fiyat(df, "07.03.2025", "close")
+    assert out == 10.0


### PR DESCRIPTION
## Değişiklik Özeti
- `_get_fiyat` fonksiyonu artık `tarih` parametresi olarak metin değerleri de kabul ediyor. Geçersiz tarihler uyarı vererek `NaN` döndürüyor.
- Yeni kullanım senaryosunu doğrulamak için `test_get_fiyat_accepts_string_date` eklendi.

## Testler
- `pre-commit` ile kod biçimlendirme ve statik analizden geçildi.
- `pytest` ile tüm testler başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687c268817008325a18ce6c4d2e54393