### PR TITLE
Tarih parse işlevini genişlet

### DIFF
--- a/tests/test_date_parse_none.py
+++ b/tests/test_date_parse_none.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pandas as pd
 
 from utils.date_utils import parse_date
@@ -9,3 +11,8 @@ def test_parse_date_handles_none_and_datetime():
     assert parse_date(None) is pd.NaT
     assert parse_date("") is pd.NaT
     assert parse_date(pd.NaT) is pd.NaT
+
+
+def test_parse_date_handles_date_object():
+    d = date(2025, 3, 7)
+    assert parse_date(d) == pd.Timestamp("2025-03-07")

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -6,7 +6,7 @@ The :func:`parse_date` helper converts diverse date strings to
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 
 import pandas as pd
 from dateutil import parser
@@ -23,13 +23,13 @@ def parse_date(
     yield ``pd.NaT`` instead of raising ``ValueError``.
 
     Args:
-        date_str (str | datetime | int | float | None): Date value to parse.
+        date_str (str | datetime | date | int | float | None): Date value to parse.
 
     Returns:
         pd.Timestamp | NaTType: Parsed timestamp or ``pd.NaT`` when parsing
         fails.
     """
-    if isinstance(date_str, datetime):
+    if isinstance(date_str, (datetime, date)):
         return pd.Timestamp(date_str)
 
     # Normalize value to a stripped string for further checks


### PR DESCRIPTION
## Değişiklik Özeti
- `parse_date` artık `datetime.date` nesnelerini doğrudan kabul ediyor
- buna yönelik test eklendi

## Test Planı
- `pre-commit` ile biçim ve statik kontroller çalıştırıldı
- yalnızca ilgili test dosyası için `pytest` çalıştırıldı

------
https://chatgpt.com/codex/tasks/task_e_687cd31591f48325b593c0559bbc5541