### PR TITLE
Güncellenmiş type hint

### DIFF
--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -14,7 +14,7 @@ from pandas._libs.tslibs.nattype import NaTType
 
 
 def parse_date(
-    date_str: str | datetime | int | float | None,
+    date_str: str | datetime | date | int | float | None,
 ) -> pd.Timestamp | NaTType:
     """Parse ``date_str`` into a :class:`pandas.Timestamp` or ``pd.NaT``.
 


### PR DESCRIPTION
## Ne değişti?
- `parse_date` fonksiyonunun parametre tipine `date` eklendi.

## Neden yapıldı?
- Fonksiyon dokümantasyonunda yer alan `date` tipi type hint içinde belirtilmemişti. Bu uyumsuzluk giderildi.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı.
- Tüm testler `pytest` ile çalıştırıldı.


------
https://chatgpt.com/codex/tasks/task_e_687cd5f985e88325a2a3c70430c568d2