### PR TITLE
Tarih ayrıştırmasında NaT kontrolü düzeltildi

### DIFF
--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -46,17 +46,17 @@ def parse_date(
     # Try explicit formats before falling back to dateutil
     for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
         ts = pd.to_datetime(value, format=fmt, errors="coerce")
-        if ts is not pd.NaT:
+        if pd.notna(ts):
             return ts
 
     if value.isdigit() and len(value) == 8:
         ts = pd.to_datetime(value, format="%Y%m%d", errors="coerce")
-        if ts is not pd.NaT:
+        if pd.notna(ts):
             return ts
 
     # Generic day-first parsing with coercion (handles 07/03/25 etc.)
     ts = pd.to_datetime(value, dayfirst=True, errors="coerce")
-    if ts is not pd.NaT:
+    if pd.notna(ts):
         return ts
 
     # Fallback to dateutil for other variants


### PR DESCRIPTION
## Ne değişti?
- `parse_date` fonksiyonunda tarih dönüştürme işlemlerinde `pd.notna` kontrolü kullanılmaya başlandı.

## Neden yapıldı?
- `pd.NaT` karşılaştırması nesne kimliğine dayanıyordu; `pd.notna` ile daha güvenilir bir kontrol sağlandı.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm birim testleri `pytest` ile başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687cd7de9d548325a980a676f02828ae