### PR TITLE
Log temizleme fonksiyonunda eksik klasör kontrolü

### DIFF
--- a/tests/test_purge_old_logs.py
+++ b/tests/test_purge_old_logs.py
@@ -56,3 +56,9 @@ def test_patterns_as_string(tmp_path):
     removed = purge_old_logs(log_dir=tmp_path, keep_days=7, patterns="*.log")
     assert removed == 1
     assert not log.exists()
+
+
+def test_missing_directory_returns_zero(tmp_path):
+    """Nonexistent ``log_dir`` should be handled gracefully."""
+    missing = tmp_path / "missing"
+    assert purge_old_logs(log_dir=missing, keep_days=7) == 0

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -27,7 +27,8 @@ def purge_old_logs(
     Files matching ``patterns`` (``*.log*`` by default) and orphan ``*.lock``
     entries older than ``keep_days`` days are deleted. ``patterns`` may be a
     single glob string or an iterable of patterns. When ``dry_run`` is ``True``
-    the function only prints which files would be removed.
+    the function only prints which files would be removed. If ``log_dir`` does
+    not exist the function returns ``0`` without raising an error.
 
     Args:
         log_dir (Path | None, optional): Directory containing log files.
@@ -50,6 +51,8 @@ def purge_old_logs(
         raise ValueError("keep_days must be non-negative")
 
     log_dir = Path("loglar") if log_dir is None else Path(log_dir)
+    if not log_dir.exists():  # short-circuit when directory is absent
+        return 0
     if patterns is None:
         patterns = ("*.log*",)
     elif isinstance(patterns, str):


### PR DESCRIPTION
## Ne değişti?
- `purge_old_logs` fonksiyonu, belirtilen log dizini yoksa `0` dönecek şekilde güncellendi.
- Fonksiyon açıklamasına bu yeni davranış eklendi.
- Eksik klasör durumunu doğrulayan yeni bir test eklendi.

## Neden yapıldı?
Log dizini henüz oluşturulmamışsa fonksiyon hata vermeden çıkmalıydı. Bu ek kontrol sayesinde gereksiz hata riski ortadan kalktı.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- `pytest` ile tüm testler ve yeni eklenen test başarıyla çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687ced57cefc832596baf6e47b1028de