### PR TITLE
is_available fonksiyonu dışa aktarıldı

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 import pandas as pd
 from cachetools import LRUCache
 
-__all__ = ["ichimoku", "macd", "rsi", "clear_cache"]
+__all__ = ["ichimoku", "macd", "rsi", "clear_cache", "is_available"]
 
 try:  # pragma: no cover - optional dependency
     from openbb import obb  # type: ignore

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -4,7 +4,14 @@ import openbb_missing as om
 
 
 def test_public_exports():
-    assert sorted(om.__all__) == ["clear_cache", "ichimoku", "macd", "rsi"]
+    expected = [
+        "clear_cache",
+        "ichimoku",
+        "is_available",
+        "macd",
+        "rsi",
+    ]
+    assert sorted(om.__all__) == expected
 
 
 def test_wrappers_exist():
@@ -77,3 +84,11 @@ def test_clear_cache(monkeypatch):
     assert len(om._FUNC_CACHE) == 1
     om.clear_cache()
     assert len(om._FUNC_CACHE) == 0
+
+
+def test_is_available_reflects_import(monkeypatch):
+    """is_available should detect the presence of the OpenBB package."""
+    monkeypatch.setattr(om, "obb", object())
+    assert om.is_available() is True
+    monkeypatch.setattr(om, "obb", None)
+    assert om.is_available() is False


### PR DESCRIPTION
## Değişiklik Özeti
- `openbb_missing` modülünün `__all__` listesine `is_available` eklendi
- İlgili testler güncellenip `is_available` için yeni kontrol eklendi

## Testler
- `pre-commit` ile biçim ve statik analizler
- `pytest` ile tüm testler

------
https://chatgpt.com/codex/tasks/task_e_687cf242ef04832587a3441949097986