### PR TITLE
Küçük iyileştirme: suffix çıkarımı basitleştirildi

### DIFF
--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -11,12 +11,13 @@ from itertools import count
 
 
 def _extract_suffix(name: str, prefix: str, delimiter: str) -> int | None:
-    """Return the numeric suffix from ``name`` when present."""
+    """Return the integer suffix from ``name`` if it matches ``prefix``."""
 
-    if not name.startswith(prefix + delimiter):
-        return None
-    tail = name[len(prefix) + len(delimiter) :]
-    return int(tail) if tail.isdigit() else None
+    token = f"{prefix}{delimiter}"
+    if name.startswith(token):
+        tail = name.removeprefix(token)
+        return int(tail) if tail.isdigit() else None
+    return None
 
 
 __all__ = ["unique_name"]


### PR DESCRIPTION
## Ne değişti?
- `utilities/naming.py` dosyasında `_extract_suffix` fonksiyonu `str.removeprefix` kullanılarak sadeleştirildi.

## Neden yapıldı?
- Daha okunabilir ve anlaşılır bir kod elde etmek için.

## Nasıl test edildi?
- `pre-commit` ve `pytest` komutları çalıştırıldı; tüm kontroller başarılı geçti.

------
https://chatgpt.com/codex/tasks/task_e_687cf50a42808325ba7b07ef51f8da87