### PR TITLE
Log dosyası temizliğinde dizin kontrolü

### DIFF
--- a/tests/test_purge_old_logs.py
+++ b/tests/test_purge_old_logs.py
@@ -62,3 +62,11 @@ def test_missing_directory_returns_zero(tmp_path):
     """Nonexistent ``log_dir`` should be handled gracefully."""
     missing = tmp_path / "missing"
     assert purge_old_logs(log_dir=missing, keep_days=7) == 0
+
+
+def test_log_dir_must_be_directory(tmp_path):
+    """``log_dir`` pointing to a file should raise ``NotADirectoryError``."""
+    file_path = tmp_path / "some.log"
+    file_path.write_text("x")
+    with pytest.raises(NotADirectoryError):
+        purge_old_logs(log_dir=file_path, keep_days=7)

--- a/utils/purge_old_logs.py
+++ b/utils/purge_old_logs.py
@@ -42,6 +42,7 @@ def purge_old_logs(
 
     Raises:
         ValueError: If ``keep_days`` is negative.
+        NotADirectoryError: If ``log_dir`` exists but is not a directory.
 
     Returns:
         int: Number of files processed (also when ``dry_run`` is ``True``).
@@ -53,6 +54,8 @@ def purge_old_logs(
     log_dir = Path("loglar") if log_dir is None else Path(log_dir)
     if not log_dir.exists():  # short-circuit when directory is absent
         return 0
+    if not log_dir.is_dir():
+        raise NotADirectoryError(str(log_dir))
     if patterns is None:
         patterns = ("*.log*",)
     elif isinstance(patterns, str):


### PR DESCRIPTION
## Değişiklik Özeti
- `purge_old_logs` fonksiyonunda `log_dir` parametresinin gerçekten dizin olup olmadığını doğrulayarak hatalı kullanımlara karşı koruma eklendi
- fonksiyon dokümantasyonuna yeni hata türü eklendi
- bu davranışı test eden ek unit test yazıldı

## Testler
- `pre-commit` ile stil ve statik analiz çalıştırıldı
- `pytest` ile tüm testler geçti

------
https://chatgpt.com/codex/tasks/task_e_687cfc84ae188325b8da892cb7d5c0b1