### PR TITLE
Tarih parse fonksiyonuna numpy.datetime64 desteği

### DIFF
--- a/tests/test_date_parse_numpy.py
+++ b/tests/test_date_parse_numpy.py
@@ -1,0 +1,9 @@
+import numpy as np
+import pandas as pd
+
+from utils.date_utils import parse_date
+
+
+def test_parse_date_numpy_datetime64():
+    ts = parse_date(np.datetime64("2025-03-07"))
+    assert ts == pd.Timestamp("2025-03-07")

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -1,20 +1,23 @@
 """Utilities for robust date parsing.
 
-The :func:`parse_date` helper converts diverse date strings to
-``pd.Timestamp`` objects without raising ``ValueError``.
+The :func:`parse_date` helper converts diverse date values into
+``pandas.Timestamp`` objects without raising ``ValueError``. Supported
+inputs include strings, ``datetime`` objects, numeric representations and
+``numpy.datetime64`` instances.
 """
 
 from __future__ import annotations
 
 from datetime import date, datetime
 
+import numpy as np
 import pandas as pd
 from dateutil import parser
 from pandas._libs.tslibs.nattype import NaTType
 
 
 def parse_date(
-    date_str: str | datetime | date | int | float | None,
+    date_str: str | datetime | date | int | float | np.datetime64 | None,
 ) -> pd.Timestamp | NaTType:
     """Parse ``date_str`` into a :class:`pandas.Timestamp` or ``pd.NaT``.
 
@@ -24,7 +27,8 @@ def parse_date(
     yield ``pd.NaT`` instead of raising ``ValueError``.
 
     Args:
-        date_str (str | datetime | date | int | float | None): Date value to parse.
+        date_str (str | datetime | date | int | float | np.datetime64 | None):
+            Date value to parse.
 
     Returns:
         pd.Timestamp | NaTType: Parsed timestamp or ``pd.NaT`` when parsing
@@ -32,6 +36,9 @@ def parse_date(
     """
     if isinstance(date_str, (datetime, date)):
         return pd.Timestamp(date_str)
+
+    if isinstance(date_str, np.datetime64):
+        return pd.to_datetime(date_str)
 
     # Normalize value to a stripped string for further checks
     if pd.isna(date_str):


### PR DESCRIPTION
## Değişiklik Özeti
- `utils.date_utils.parse_date` artık `numpy.datetime64` değerlerini de kabul ediyor
- yeni test dosyası `tests/test_date_parse_numpy.py` eklendi

## Neden
`parse_date` fonksiyonu `numpy.datetime64` türündeki değerleri işleyemiyordu. Bu tür verilerden alınan tarihlerin de sorunsuz çevrilebilmesi için fonksiyon güncellendi.

## Nasıl Test Edildi
- `pre-commit` ile biçim ve statik analiz çalıştırıldı
- `pytest` ile tüm testler geçirildi

------
https://chatgpt.com/codex/tasks/task_e_687d1b5bcc088325856822c0035282ee