### PR TITLE
Küçük tip düzeltmesi

### DIFF
--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -11,7 +11,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Tuple, TypeVar
+from typing import Callable, TypeVar
 
 import pandas as pd
 from cachetools import TTLCache
@@ -23,19 +23,13 @@ from src.utils.excel_reader import open_excel_cached
 T = TypeVar("T")
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True, frozen=True)
 class CachedItem:
     """Metadata and payload for a cached file."""
 
     mtime: int
     size: int
     data: object
-
-    __slots__ = (
-        "mtime",
-        "size",
-        "data",
-    )
 
 
 class DataLoaderCache:
@@ -72,7 +66,7 @@ class DataLoaderCache:
 
     def _get_cache_key(
         self, filepath: str | os.PathLike[str], kind: str
-    ) -> Tuple[Tuple[str, str], int, int]:
+    ) -> tuple[tuple[str, str], int, int]:
         """Return cache key and file metadata for ``filepath``.
 
         Parameters


### PR DESCRIPTION
## Ne değişti?
- `DataLoaderCache`'de `CachedItem` veri sınıfı artık `slots=True` kullanıyor.
- `_get_cache_key` dönüş türü yerleşik `tuple` ile tanımlandı ve gereksiz `Tuple` importu kaldırıldı.

## Neden yapıldı?
- Daha yeni `dataclasses` özelliklerinden yararlanılarak bellek kullanımı azaltıldı.
- Modern tip ipuçlarıyla kod okunabilirliği artırıldı.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm `pytest` testleri çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687d1dae6af48325a320e16f4ea6bd13