### PR TITLE
Config loader cache reset

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -15,6 +15,12 @@ import pandas as pd
 
 from finansal_analiz_sistemi import config
 
+__all__ = [
+    "load_crossover_names",
+    "load_ema_close_crossovers",
+    "clear_cache",
+]
+
 # Regex to capture any crossover column name
 CROSSOVER_NAME_RE = re.compile(r"([A-Za-z0-9_]+_keser_[A-Za-z0-9_]+_(?:yukari|asagi))")
 EMA_CLOSE_RE = re.compile(r"ema_(\d+)_keser_close_(yukari|asagi)")
@@ -62,3 +68,8 @@ def load_ema_close_crossovers(csv_path: str | Path | None = None) -> list[str]:
 
     """
     return [n for n in load_crossover_names(csv_path) if EMA_CLOSE_RE.fullmatch(n)]
+
+
+def clear_cache() -> None:
+    """Clear cached results of :func:`load_crossover_names`."""
+    load_crossover_names.cache_clear()

--- a/tests/test_config_loader_cache.py
+++ b/tests/test_config_loader_cache.py
@@ -1,0 +1,13 @@
+import config_loader
+
+
+def test_clear_cache_refreshes_results(tmp_path):
+    csv = tmp_path / "filters.csv"
+    csv.write_text("PythonQuery\nclose_keser_open_yukari")
+    first = config_loader.load_crossover_names(csv)
+    csv.write_text("PythonQuery\nclose_keser_open_asagi")
+    cached = config_loader.load_crossover_names(csv)
+    assert cached == first
+    config_loader.clear_cache()
+    refreshed = config_loader.load_crossover_names(csv)
+    assert refreshed != first


### PR DESCRIPTION
## Ne değişti?
- `config_loader` modülüne `clear_cache` fonksiyonu ve `__all__` tanımı eklendi.
- Fonksiyonun çalışmasını doğrulayan yeni `test_config_loader_cache` testi yazıldı.

## Neden yapıldı?
Önbelleğe alınan crossover isimleri güncellendiğinde belleğin temizlenebilmesi için basit bir arayüz sağlamak gerekiyordu.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` komutu ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687d2c512a348325a87819c024827076