### PR TITLE
Filter sorgusu iyileştirme

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -67,6 +67,7 @@ class MissingColumnError(Exception):
 _STRING_RE = re.compile(r"(?:'[^']*'|\"[^\"]*\")")
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _BRACKET_RE = re.compile(r"df\[\s*(['\"])(?P<col>[^'\"]+)\1\s*\]")
+_ATTR_ACCESS_RE = re.compile(r"(?<!\d)\.[A-Za-z_][A-Za-z0-9_]*")
 _RESERVED_TOKENS = set(keyword.kwlist) | {"and", "or", "not", "True", "False", "df"}
 
 
@@ -82,6 +83,7 @@ def _extract_query_columns(query: str) -> set[str]:
 
     bracket_cols = {m.group("col") for m in _BRACKET_RE.finditer(query)}
     query = _STRING_RE.sub(" ", query)
+    query = _ATTR_ACCESS_RE.sub(" ", query)
     tokens = set(_IDENT_RE.findall(query))
     return (tokens | bracket_cols) - _RESERVED_TOKENS
 

--- a/tests/test_query_columns.py
+++ b/tests/test_query_columns.py
@@ -30,3 +30,10 @@ def test_extract_bracket_notation():
     expr = "close > df['BBM_20_2.0']"
     cols = filter_engine._extract_query_columns(expr)
     assert cols == {"close", "BBM_20_2.0"}
+
+
+def test_extract_ignores_method_calls():
+    """Method names after a dot should not be treated as columns."""
+    expr = "close > open.shift(1)"
+    cols = filter_engine._extract_query_columns(expr)
+    assert cols == {"close", "open"}


### PR DESCRIPTION
## Ne değişti?
- `_extract_query_columns` fonksiyonu nokta sonrası metod adlarını göz ardı edecek şekilde güncellendi.
- Yeni `test_extract_ignores_method_calls` testi eklendi.

## Neden yapıldı?
- Bazı filtre ifadelerinde `open.shift(1)` gibi yapılar kullanıldığında `shift` kelimesi yanlışlıkla sütun adı olarak algılanıyordu. Güncelleme bu hatayı önler.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler geçekleştirildi.

------
https://chatgpt.com/codex/tasks/task_e_687d37ec90bc8325ab6fe9b210c116da