### PR TITLE
Küçük iyileştirmeler

### DIFF
--- a/finansal/utils/__init__.py
+++ b/finansal/utils/__init__.py
@@ -6,23 +6,23 @@ chunks and :func:`safe_set` for dtype-safe DataFrame assignment.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Generator, Sequence, TypeVar
+from collections.abc import Iterable, Iterator
+from typing import Sequence, TypeVar
 
 from .dtypes import safe_set
 
 T = TypeVar("T")
 
 
-def lazy_chunk(seq: Iterable[T], size: int) -> Generator[Sequence[T], None, None]:
-    """Yield ``seq`` in chunks of ``size`` without loading everything.
+def lazy_chunk(seq: Iterable[T], size: int) -> Iterator[Sequence[T]]:
+    """Yield ``seq`` in immutable chunks of ``size``.
 
     Args:
         seq (Iterable[T]): Source sequence to iterate over.
         size (int): Number of items per chunk; must be positive.
 
     Yields:
-        Sequence[T]: Consecutive chunks from the input sequence.
+        Sequence[T]: Consecutive tuples from the input sequence.
 
     """
     if size <= 0:
@@ -32,10 +32,10 @@ def lazy_chunk(seq: Iterable[T], size: int) -> Generator[Sequence[T], None, None
     for item in seq:
         chunk.append(item)
         if len(chunk) >= size:
-            yield chunk
+            yield tuple(chunk)
             chunk = []
     if chunk:
-        yield chunk
+        yield tuple(chunk)
 
 
 __all__ = ["lazy_chunk", "safe_set"]

--- a/tests/test_lazy_chunk.py
+++ b/tests/test_lazy_chunk.py
@@ -6,10 +6,10 @@ from finansal.utils import lazy_chunk
 
 
 def test_lazy_chunk_yields_groups():
-    """Chunking should lazily yield lists of the given size."""
+    """Chunking should lazily yield tuples of the given size."""
     data = list(range(5))
     chunks = list(lazy_chunk(data, 2))
-    assert chunks == [[0, 1], [2, 3], [4]]
+    assert chunks == [(0, 1), (2, 3), (4,)]
 
 
 def test_lazy_chunk_invalid_size():


### PR DESCRIPTION
## Ne değişti?
- `lazy_chunk` artık sabit boyutlu demetler döndürüyor.
- İlgili test beklentileri güncellendi.

## Neden yapıldı?
Liste döndürmek yerine demet kullanmak, dışarıdan yapılacak istenmeyen değişiklikleri engeller ve daha tutarlı bir API sunar.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687d51a90544832591004d622f6a0cd6