### PR TITLE
check_and_create_dirs fonksiyonu çıktı döndürüyor

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -186,13 +186,26 @@ def _standardize_ohlcv_columns(
     return df
 
 
-def check_and_create_dirs(*dir_paths: str | Path) -> None:
-    """Create missing directories from ``dir_paths``.
+def check_and_create_dirs(*dir_paths: str | Path) -> list[Path]:
+    """Ensure each path in ``dir_paths`` exists as a directory.
 
-    Paths are expanded with ``~`` and resolved relative to the current
-    working directory. Existing directories are left untouched while
-    name clashes with files trigger an error log entry.
+    Paths are expanded and resolved to absolute :class:`~pathlib.Path`
+    instances. Missing directories are created as needed. Any path that
+    already exists as a file triggers an error log entry and is skipped.
+
+    Parameters
+    ----------
+    *dir_paths : str | pathlib.Path
+        One or more directory paths to verify or create.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        A list of directories that were created during the call. Existing
+        directories are not included.
     """
+
+    created: list[Path] = []
 
     for path in dir_paths:
         if not path:
@@ -204,11 +217,14 @@ def check_and_create_dirs(*dir_paths: str | Path) -> None:
         if not p.exists():
             try:
                 p.mkdir(parents=True, exist_ok=True)
+                created.append(p)
                 logger.info("Dizin oluşturuldu: %s", p)
             except Exception as exc:  # pragma: no cover - I/O errors
                 logger.error(
                     "Dizin oluşturulamadı: %s. Hata: %s", p, exc, exc_info=True
                 )
+
+    return created
 
 
 def load_data(path: str) -> pd.DataFrame:

--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -13,8 +13,9 @@ CSV_CONTENT = "col\n1\n2\n3"
 def test_check_and_create_dirs(tmp_path: Path):
     """Created directories should exist after invocation."""
     new_dir = tmp_path / "nested"
-    data_loader.check_and_create_dirs(new_dir)
+    created = data_loader.check_and_create_dirs(new_dir)
     assert new_dir.exists()
+    assert created == [new_dir]
 
 
 def test_load_data_cache_refresh(tmp_path: Path):


### PR DESCRIPTION
## Ne değişti?
- `check_and_create_dirs` artık oluşturulan dizinleri `list[Path]` olarak döndürüyor ve docstring genişletildi.
- İlgili test güncellenerek fonksiyon çıktısı doğrulanıyor.

## Neden yapıldı?
Dizin oluşturma işleminin sonucunu çağıran kodlar için görünür kılmak ve fonksiyonun davranışını netleştirmek amacıyla fonksiyon çıkış değeri eklendi.

## Nasıl test edildi?
- `pre-commit` ile biçimlendirme ve statik analiz çalıştırıldı.
- `pytest` komutu ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687d5479de18832597d730338681a1e0