### PR TITLE
Küçük iyileştirme: Excel önbellek girdisi

### DIFF
--- a/src/utils/excel_reader.py
+++ b/src/utils/excel_reader.py
@@ -21,11 +21,9 @@ __all__ = ["open_excel_cached", "read_excel_cached", "clear_cache"]
 # refreshes automatically when the workbook on disk changes.
 
 
-@dataclass
+@dataclass(slots=True)
 class ExcelCacheEntry:
     """Metadata for a cached workbook."""
-
-    __slots__ = ("mtime", "book")
 
     mtime: float
     book: pd.ExcelFile


### PR DESCRIPTION
## Ne değişti?
- `src/utils/excel_reader.py` dosyasında `ExcelCacheEntry` veri sınıfı `slots=True` parametresiyle tanımlandı.

## Neden yapıldı?
- `__slots__` tanımını manuel yapmaktansa `dataclasses` üzerinden kullanılması bellek kullanımını azaltır ve okunabilirliği artırır.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm `pytest` testleri başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687d57ba662c8325b3c43a287fba1765