### PR TITLE
Klasik pivot hesaplamasını optimize et

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -118,10 +118,10 @@ def _calculate_classicpivots_1h_p(group_df: pd.DataFrame) -> pd.Series:
     sutun_adi = "classicpivots_1h_p"
     try:
         gerekli = ["high", "low", "close"]
-        if any(col not in group_df.columns for col in gerekli):
+        if not all(c in group_df.columns for c in gerekli):
             logger.debug(f"{hisse_str}: {sutun_adi} için gerekli sütunlar eksik.")
             return pd.Series(np.nan, index=group_df.index, name=sutun_adi)
-        pivot = (group_df["high"] + group_df["low"] + group_df["close"]) / 3
+        pivot = group_df[gerekli].mean(axis=1)
         return pivot.round(2).rename(sutun_adi)
     except Exception as e:
         logger.error(

--- a/tests/test_indicator_calculator.py
+++ b/tests/test_indicator_calculator.py
@@ -44,6 +44,24 @@ def test_classicpivots_crossover_column_exists():
     assert "close_keser_classicpivots_1h_p_yukari" in result.columns
 
 
+def test_classicpivots_value_calculation():
+    """Pivot values should equal the mean of high, low and close."""
+    df = pd.DataFrame(
+        {
+            "hisse_kodu": ["AAA"] * 3,
+            "tarih": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "open": [1, 2, 3],
+            "high": [2, 4, 6],
+            "low": [0, 1, 2],
+            "close": [1, 3, 5],
+            "volume": [10, 20, 30],
+        }
+    )
+    result = ic.hesapla_teknik_indikatorler_ve_kesisimler(df)
+    expected = df[["high", "low", "close"]].mean(axis=1).round(2)
+    assert result["classicpivots_1h_p"].equals(expected)
+
+
 def test_fallback_indicators_created_when_missing():
     """Fallback indicators should be generated if absent in input data."""
     data = {


### PR DESCRIPTION
## Ne değişti?
- `indicator_calculator._calculate_classicpivots_1h_p` fonksiyonu vektörel `mean` kullanacak şekilde sadeleştirildi.
- Pivot hesaplamasının doğruluğunu kontrol eden yeni bir test eklendi.

## Neden yapıldı?
- Tekrarlanan toplama işlemleri yerine `DataFrame.mean` ile daha okunaklı ve güvenilir hesaplama sağlandı.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarılı şekilde yürütüldü.

------
https://chatgpt.com/codex/tasks/task_e_687d66972a548325ac24ab59e0c50221