### PR TITLE
OpenBB önbellek boyutu sabitlendi

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -12,6 +12,9 @@ from typing import Any, Callable
 import pandas as pd
 from cachetools import LRUCache
 
+# Default size for the OpenBB function cache
+FUNC_CACHE_SIZE = 16
+
 __all__ = ["ichimoku", "macd", "rsi", "clear_cache", "is_available"]
 
 try:  # pragma: no cover - optional dependency
@@ -21,7 +24,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 # Cache for resolved OpenBB functions
 # Limit size to avoid unbounded growth when called with many names
-_FUNC_CACHE: LRUCache[str, Callable[..., Any]] = LRUCache(maxsize=16)
+_FUNC_CACHE: LRUCache[str, Callable[..., Any]] = LRUCache(maxsize=FUNC_CACHE_SIZE)
 
 
 def is_available() -> bool:


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing.py` dosyasında OpenBB fonksiyon önbelleğinin boyutu `FUNC_CACHE_SIZE` sabitiyle tanımlandı.
- `_FUNC_CACHE` bu sabit kullanılarak oluşturuldu.

## Neden yapıldı?
- Sihirli sayı kullanımını azaltıp okunabilirliği artırmak için.

## Nasıl test edildi?
- `black`, `isort`, `flake8` ve `ruff` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı ve başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687d68ce7de8832588c9c96b5241be3d