### PR TITLE
unique_name iyileştirildi

### DIFF
--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -33,6 +33,13 @@ def test_unique_name_trailing_underscore():
     assert "foo_2" in seen
 
 
+def test_unique_name_multiple_trailing_delimiters():
+    """Only one delimiter should be trimmed when ``base`` has repeats."""
+    seen = {"bar__", "bar__1"}
+    assert unique_name("bar__", seen) == "bar__2"
+    assert "bar__2" in seen
+
+
 def test_unique_name_empty_base_raises():
     """Empty ``base`` should trigger ``ValueError``."""
     with pytest.raises(ValueError):

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -46,7 +46,10 @@ def unique_name(base: str, seen: set[str], *, delimiter: str = "_") -> str:
         seen.add(base)
         return base
 
-    prefix = base.rstrip(delimiter)
+    if base.endswith(delimiter):
+        prefix = base[: -len(delimiter)]
+    else:
+        prefix = base
     idx = 1
     while True:
         candidate = f"{prefix}{delimiter}{idx}"


### PR DESCRIPTION
## Değişiklik Özeti
- `unique_name` fonksiyonunda sondaki ayraçların tümünün silinmesi yerine yalnızca bir tanesinin kaldırılması sağlandı
- birden fazla ayraç içeren isimler için yeni test eklendi

## Testler
- `pre-commit` ile biçim ve statik analizler
- `pytest` ile tüm testler

------
https://chatgpt.com/codex/tasks/task_e_687d7185dc38832592997ad31c86c0d8