### PR TITLE
unique_name geliştirmesi

### DIFF
--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -44,3 +44,16 @@ def test_unique_name_empty_base_raises():
     """Empty ``base`` should trigger ``ValueError``."""
     with pytest.raises(ValueError):
         unique_name("", set())
+
+
+def test_unique_name_custom_start():
+    """Custom starting index should be honored."""
+    seen = {"x", "x_1", "x_2"}
+    assert unique_name("x", seen, start=3) == "x_3"
+    assert "x_3" in seen
+
+
+def test_unique_name_invalid_start_raises():
+    """Start value below 1 should raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        unique_name("y", set(), start=0)

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 __all__ = ["unique_name"]
 
 
-def unique_name(base: str, seen: set[str], *, delimiter: str = "_") -> str:
+def unique_name(
+    base: str,
+    seen: set[str],
+    *,
+    delimiter: str = "_",
+    start: int = 1,
+) -> str:
     """Return a unique column name derived from ``base``.
 
     The chosen label is added to ``seen`` so subsequent calls with the same
@@ -26,6 +32,8 @@ def unique_name(base: str, seen: set[str], *, delimiter: str = "_") -> str:
         Set of names already in use; updated in-place.
     delimiter : str, optional
         Character used between ``base`` and the numeric suffix.
+    start : int, optional
+        Initial numeric suffix when ``base`` already exists. ``1`` by default.
 
     Returns
     -------
@@ -36,11 +44,13 @@ def unique_name(base: str, seen: set[str], *, delimiter: str = "_") -> str:
     Raises
     ------
     ValueError
-        If ``base`` is an empty string.
+        If ``base`` is an empty string or ``start`` is less than ``1``.
     """
 
     if not base:
         raise ValueError("base must be a non-empty string")
+    if start < 1:
+        raise ValueError("start must be >= 1")
 
     if base not in seen:
         seen.add(base)
@@ -50,7 +60,7 @@ def unique_name(base: str, seen: set[str], *, delimiter: str = "_") -> str:
         prefix = base[: -len(delimiter)]
     else:
         prefix = base
-    idx = 1
+    idx = start
     while True:
         candidate = f"{prefix}{delimiter}{idx}"
         if candidate not in seen:


### PR DESCRIPTION
## Ne değişti?
- `unique_name` fonksiyonuna başlangıç değeri belirlemek için `start` parametresi eklendi.
- Uygun olmayan `start` değerlerinde `ValueError` fırlatılıyor.
- Yeni özellik için iki adet test eklendi.

## Neden yapıldı?
- Bazı durumlarda isimlendirme sayacının belirli bir değerden başlaması gerekiyor. Bu değişiklik esnekliği artırıyor.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler geçekleştirildi ve başarılı sonuç alındı.

------
https://chatgpt.com/codex/tasks/task_e_687d78cde2ac83258040cbe9fcdb57c7