### PR TITLE
Yeni cache dosyası kontrolü

### DIFF
--- a/finansal/parquet_cache.py
+++ b/finansal/parquet_cache.py
@@ -26,6 +26,10 @@ class ParquetCacheManager:
         self.cache_path = cache_path
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
 
+    def exists(self) -> bool:
+        """Return ``True`` when the cache file is present."""
+        return self.cache_path.is_file()
+
     def load(self) -> DataFrame:
         """Return the cached Parquet file as a DataFrame."""
         import pandas as pd

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -32,3 +32,12 @@ def test_load_missing(tmp_path: Path) -> None:
     mngr = ParquetCacheManager(tmp_path / "missing.parquet")
     with pytest.raises(FileNotFoundError):
         _ = mngr.load()
+
+
+def test_exists(tmp_path: Path) -> None:
+    """exists should reflect the file system state."""
+    cache_path = tmp_path / "cache.parquet"
+    mngr = ParquetCacheManager(cache_path)
+    assert mngr.exists() is False
+    pd.DataFrame({"x": [1]}).to_parquet(cache_path)
+    assert mngr.exists() is True


### PR DESCRIPTION
## Ne değişti?
- `ParquetCacheManager` sınıfına cache dosyasının varlığını sorgulayan `exists` metodu eklendi.
- İlgili birim testine `test_exists` fonksiyonu eklendi.

## Neden yapıldı?
Cache dosyasının hazır olup olmadığını kolayca tespit edebilmek için ek kontrol sağlandı.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` komutu ile tüm testler çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687d7f347cf883259a34fc1718372e63