### PR TITLE
Çevresel değişkenle önbellek ayarı

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -7,13 +7,20 @@ available and otherwise raise :class:`NotImplementedError`.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Callable
 
 import pandas as pd
 from cachetools import LRUCache
 
-# Default size for the OpenBB function cache
-FUNC_CACHE_SIZE = 16
+# Default size for the OpenBB function cache. The value can be overridden via
+# the ``OPENBB_FUNC_CACHE_SIZE`` environment variable. Invalid values fall back
+# to the default of ``16``.
+_env_val = os.getenv("OPENBB_FUNC_CACHE_SIZE")
+try:
+    FUNC_CACHE_SIZE = int(_env_val) if _env_val else 16
+except ValueError:  # pragma: no cover - environment error
+    FUNC_CACHE_SIZE = 16
 
 __all__ = ["ichimoku", "macd", "rsi", "clear_cache", "is_available"]
 

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -92,3 +92,14 @@ def test_is_available_reflects_import(monkeypatch):
     assert om.is_available() is True
     monkeypatch.setattr(om, "obb", None)
     assert om.is_available() is False
+
+
+def test_env_override_cache_size(monkeypatch):
+    """Environment variable should configure cache size."""
+    import importlib
+
+    monkeypatch.setenv("OPENBB_FUNC_CACHE_SIZE", "7")
+    mod = importlib.reload(om)
+    assert mod._FUNC_CACHE.maxsize == 7
+    monkeypatch.delenv("OPENBB_FUNC_CACHE_SIZE", raising=False)
+    importlib.reload(om)


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing` modülünde önbellek boyutu `OPENBB_FUNC_CACHE_SIZE` ortam değişkeniyle ayarlanabilir hale getirildi.
- Bu davranışı doğrulayan birim testi eklendi.

## Neden yapıldı?
- Kullanıcılara önbelleğin boyutunu çalışma ortamına göre değiştirme imkânı sağlamak için.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarılı şekilde tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_687e28273a548325bba0d425d1f793ef