### PR TITLE
OpenBB cache varsayilan kontrolü

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -14,13 +14,16 @@ import pandas as pd
 from cachetools import LRUCache
 
 # Default size for the OpenBB function cache. The value can be overridden via
-# the ``OPENBB_FUNC_CACHE_SIZE`` environment variable. Invalid values fall back
-# to the default of ``16``.
+# the ``OPENBB_FUNC_CACHE_SIZE`` environment variable. Invalid or non-positive
+# values fall back to this default of ``16``.
+DEFAULT_CACHE_SIZE = 16
 _env_val = os.getenv("OPENBB_FUNC_CACHE_SIZE")
 try:
-    FUNC_CACHE_SIZE = int(_env_val) if _env_val else 16
+    size = int(_env_val) if _env_val else DEFAULT_CACHE_SIZE
 except ValueError:  # pragma: no cover - environment error
-    FUNC_CACHE_SIZE = 16
+    size = DEFAULT_CACHE_SIZE
+
+FUNC_CACHE_SIZE = size if size > 0 else DEFAULT_CACHE_SIZE
 
 __all__ = ["ichimoku", "macd", "rsi", "clear_cache", "is_available"]
 

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -103,3 +103,17 @@ def test_env_override_cache_size(monkeypatch):
     assert mod._FUNC_CACHE.maxsize == 7
     monkeypatch.delenv("OPENBB_FUNC_CACHE_SIZE", raising=False)
     importlib.reload(om)
+
+
+def test_env_invalid_cache_size(monkeypatch):
+    """Invalid or non-positive values should revert to the default."""
+    import importlib
+
+    monkeypatch.setenv("OPENBB_FUNC_CACHE_SIZE", "0")
+    mod = importlib.reload(om)
+    assert mod._FUNC_CACHE.maxsize == 16
+    monkeypatch.setenv("OPENBB_FUNC_CACHE_SIZE", "-5")
+    mod = importlib.reload(om)
+    assert mod._FUNC_CACHE.maxsize == 16
+    monkeypatch.delenv("OPENBB_FUNC_CACHE_SIZE", raising=False)
+    importlib.reload(om)


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing.py` içinde `OPENBB_FUNC_CACHE_SIZE` değeri sıfır veya negatifse varsayılan 16’ya geri dönüyor.
- Buna yönelik `tests/test_openbb_missing.py` dosyasına yeni test eklendi.

## Neden yapıldı?
Hatalı çevre değişkeni değerlerinin önlenmesi ve ön tanımlı davranışın korunması için.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı.
- `pytest` ile tüm testler (yeni eklenen test dahil) başarıyla geçti.


------
https://chatgpt.com/codex/tasks/task_e_687e2df02d1083258f1828a224b0b121