### PR TITLE
safe_set jeneratör desteği

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -6,7 +6,8 @@ and casts values to a suitable dtype whenever possible.
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 import pandas as pd
 
@@ -28,10 +29,11 @@ def safe_set(df: pd.DataFrame, column: str, values: Iterable[Any]) -> None:
     if isinstance(values, pd.Series):
         series = values if values.index.equals(df.index) else values.reindex(df.index)
     else:
+        items = list(values)
         try:
-            series = pd.Series(values, index=df.index)
+            series = pd.Series(items, index=df.index)
         except ValueError:
-            series = pd.Series(values).reindex(df.index)
+            series = pd.Series(items).reindex(df.index)
 
     target_dtype = config.DTYPES_MAP.get(column)
     if target_dtype is None and column in df.columns:

--- a/tests/test_safe_set_generator.py
+++ b/tests/test_safe_set_generator.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from finansal.utils import safe_set
+
+
+def test_safe_set_accepts_generator():
+    df = pd.DataFrame({"close": [1, 2, 3]})
+    values = (v * 2 for v in range(2))
+    safe_set(df, "foo", values)
+    assert list(df["foo"])[:2] == [0, 2]
+    assert pd.isna(df["foo"].iloc[2])


### PR DESCRIPTION
## Ne değişti?
- `safe_set` fonksiyonu iterable değerleri listeye çevirerek uzunluk uyuşmazlığında verilerin kaybolmasını önlüyor.
- Jeneratör kullanımı için yeni `test_safe_set_generator` testi eklendi.

## Neden yapıldı?
- Önceki sürümde jeneratör ile kısa liste verildiğinde değerler tüketiliyor ve `NaN` dönüyordu. Listeye çevirme ile bu sorun çözüldü.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı.
- Tüm testler `pytest` ile başarıyla geçtirildi.

------
https://chatgpt.com/codex/tasks/task_e_687e3464ac808325ab0cce1b0de01ef3