### PR TITLE
Küçük iyileştirmeler

### DIFF
--- a/finansal_analiz_sistemi/utils/normalize.py
+++ b/finansal_analiz_sistemi/utils/normalize.py
@@ -11,7 +11,8 @@ def normalize_filtre_kodu(df: pd.DataFrame) -> pd.DataFrame:
     """Normalize the ``filtre_kodu`` column name.
 
     Possible variants like ``FilterCode`` or ``filtercode`` are converted to
-    ``filtre_kodu`` after stripping surrounding whitespace. When multiple
+    ``filtre_kodu`` after stripping surrounding whitespace. Aliases containing
+    spaces or underscores are also recognized. When multiple
     columns match, only the first is kept. Raises ``KeyError`` if no matching
     column exists.
 
@@ -29,11 +30,11 @@ def normalize_filtre_kodu(df: pd.DataFrame) -> pd.DataFrame:
     normalized = {c: c.strip().lower() for c in out.columns}
 
     # Aliases to be mapped to 'filtre_kodu'
-    alias_map = {
-        col: "filtre_kodu"
-        for col, norm in normalized.items()
-        if norm in {"filtercode", "filtre_kodu"}
-    }
+    alias_map = {}
+    for col, norm in normalized.items():
+        key = norm.replace(" ", "").replace("_", "")
+        if key in {"filtercode", "filtrekodu"}:
+            alias_map[col] = "filtre_kodu"
 
     out = out.rename(columns=alias_map)
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -22,6 +22,14 @@ def test_normalize_removes_duplicate_aliases():
     assert out["filtre_kodu"].tolist() == ["F1"]
 
 
+def test_normalize_accepts_spaced_alias():
+    """Aliases with spaces should also normalize correctly."""
+    df = pd.DataFrame({"Filter Code": ["F2"]})
+    out = normalize_filtre_kodu(df)
+    assert list(out.columns) == ["filtre_kodu"]
+    assert out["filtre_kodu"].tolist() == ["F2"]
+
+
 def test_normalize_missing_column():
     """Invalid DataFrames should raise ``KeyError``."""
     df = pd.DataFrame({"other": ["X"]})


### PR DESCRIPTION
## Değişiklik Özeti
- filtre_kodu normalizasyonunda boşluk ve alt çizgi içeren isimler destekleniyor
- ilgili test senaryosu eklendi

## Testler
- `pre-commit` çalıştırıldı
- `pytest` tüm testler

------
https://chatgpt.com/codex/tasks/task_e_687e3aa701608325b11fe0ae96660500