### PR TITLE
Küçük iyileştirme: tip dönüşümü

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -102,7 +102,7 @@ def _convert_numeric_columns(
         col_dtype = series.dtype
 
         if pd.api.types.is_numeric_dtype(col_dtype):
-            if col_dtype != float:
+            if not pd.api.types.is_float_dtype(col_dtype):
                 df[col] = series.astype(float, errors="ignore")
             continue
 


### PR DESCRIPTION
## Ne değişti?
- `preprocessor._convert_numeric_columns` fonksiyonunda kolon tipi zaten float ise tekrar dönüşüm yapılmıyor.

## Neden yapıldı?
- Var olan float kolonların gereksiz yere yeniden `astype(float)` ile dönüştürülmesi bellek ve işlem kaybına yol açıyordu.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687e44710f5883259b04dd10813f2742