### PR TITLE
OpenBB yardımcılarına eksik modül kontrolü eklendi

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -75,9 +75,13 @@ def _call_openbb(func_name: str, **kwargs) -> object:
     if obb is None:
         raise NotImplementedError("OpenBB package is not installed")
 
+    technical = getattr(obb, "technical", None)
+    if technical is None:
+        raise NotImplementedError("OpenBB technical module is unavailable")
+
     func = _FUNC_CACHE.get(func_name)
     if func is None:
-        func = getattr(obb.technical, func_name, None)
+        func = getattr(technical, func_name, None)
         if func is None:
             raise NotImplementedError(f"OpenBB indicator '{func_name}' is unavailable")
         _FUNC_CACHE[func_name] = func

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -68,6 +68,18 @@ def test_call_openbb_function_missing(monkeypatch):
         om._call_openbb("bar")
 
 
+def test_call_openbb_without_technical(monkeypatch):
+    """Missing ``technical`` attribute should raise ``NotImplementedError``."""
+
+    dummy = object()
+
+    monkeypatch.setattr(om, "obb", dummy)
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+
+    with pytest.raises(NotImplementedError, match="technical module"):
+        om._call_openbb("foo")
+
+
 def test_clear_cache(monkeypatch):
     """clear_cache should drop cached functions."""
 


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing._call_openbb` fonksiyonu, `technical` özniteliği bulunmadığında `NotImplementedError` döndürerek hatayı daha anlaşılır hale getirecek şekilde güncellendi.
- Bu durumu doğrulayan `test_call_openbb_without_technical` testi eklendi.

## Neden yapıldı?
- OpenBB paketinde `technical` modülü bulunmadığında fonksiyon `AttributeError` yerine açıklayıcı bir hata mesajı vermeli.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- Tüm testler `pytest` ile çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687e475f722c8325be85d2328c89b43a