### PR TITLE
Tarih değerlerinin esnek yorumlanması

### DIFF
--- a/run.py
+++ b/run.py
@@ -260,7 +260,7 @@ def run_pipeline(
         names=["code", "date", "open", "high", "low", "close", "volume"],
     )
     df = df.rename(columns={"code": "hisse_kodu", "date": "tarih"})
-    df["tarih"] = pd.to_datetime(df["tarih"])
+    df["tarih"] = df["tarih"].apply(parse_date)
 
     with open(filter_def, encoding="utf-8") as f:
         filt = yaml.safe_load(f) or []


### PR DESCRIPTION
## Ne değişti?
- `run_pipeline` fonksiyonunda okunan tarih değerleri `parse_date` yardımıyla dönüştürülüyor.

## Neden yapıldı?
- `pd.to_datetime` tek formatta olmayan girdilerde hata verebiliyor. `parse_date` fonksiyonu farklı tarih biçimlerini sorunsuz algılayarak daha güvenilir sonuç veriyor.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı ve tüm kontroller geçti.
- `pytest` ile tüm testler çalıştırıldı; mevcut testler başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_687e4bc3377c83258af664163423dbf7