### PR TITLE
Excel önbellek anahtarını normalize et

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -31,8 +31,17 @@ _read_excel = partial(pd.read_excel, engine="openpyxl")
 
 
 @lru_cache(maxsize=None)
+def _read_excel_cached_normalized(path: str) -> pd.DataFrame:
+    """Read ``path`` with ``openpyxl`` and cache the result."""
+
+    return _read_excel(path)
+
+
 def _read_excel_cached(path: str | Path) -> pd.DataFrame:
     """Return an Excel file read via ``openpyxl`` with caching.
+
+    ``path`` values are normalized to strings so ``Path`` objects and
+    string arguments share the same cache entry.
 
     Parameters
     ----------
@@ -44,7 +53,8 @@ def _read_excel_cached(path: str | Path) -> pd.DataFrame:
     pandas.DataFrame
         Okunan Excel içeriği.
     """
-    return _read_excel(str(path))
+
+    return _read_excel_cached_normalized(str(path))
 
 
 DATE_COLUMN_CANDIDATES = (


### PR DESCRIPTION
## Ne değişti?
- `_read_excel_cached` fonksiyonu için dahili bir `_read_excel_cached_normalized` eklenerek `Path` ve `str` girişleri aynı önbellek anahtarında toplandı.
- Fonksiyonun dokümantasyonu güncellendi.

## Neden yapıldı?
- `Path` ve `str` olarak verilen aynı dosya yolu ayrı anahtarlar oluşturduğundan önbellek etkili çalışmıyordu. Yollar normalleştirilerek gereksiz tekrar okuma engellendi.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- `pytest` komutu ile tüm testler geçirildi.


------
https://chatgpt.com/codex/tasks/task_e_687e6675e96c8325b730dd48476629f4