### PR TITLE
parse_date fonksiyonuna yeni tarih formatı

### DIFF
--- a/tests/test_date_parse.py
+++ b/tests/test_date_parse.py
@@ -9,6 +9,7 @@ def test_parse_date_variants():
     """Ensure ``parse_date`` handles multiple common formats."""
     cases = {
         "07.03.2025": "2025-03-07",
+        "07-03-2025": "2025-03-07",
         "2025-03-07": "2025-03-07",
         "07/03/25": "2025-03-07",
         "2025/03/07": "2025-03-07",

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -22,7 +22,8 @@ def parse_date(
     """Parse ``date_str`` into a :class:`pandas.Timestamp` or ``pd.NaT``.
 
     The function tries common ISO and day-first patterns first
-    (``YYYY-MM-DD``, ``DD.MM.YYYY``, ``YYYY/MM/DD`` and ``DD/MM/YYYY``)
+    (``YYYY-MM-DD``, ``DD.MM.YYYY``, ``DD-MM-YYYY``, ``YYYY/MM/DD`` and
+    ``DD/MM/YYYY``)
     and also understands pure digit forms like ``YYYYMMDD`` or ``DDMMYYYY``.
     If those attempts fail it falls back to a day-first parse via
     :mod:`dateutil`. Invalid inputs yield ``pd.NaT`` instead of raising
@@ -54,7 +55,14 @@ def parse_date(
         return pd.NaT
 
     # Try explicit formats before falling back to dateutil
-    for fmt in ("%Y-%m-%d", "%Y.%m.%d", "%d.%m.%Y", "%Y/%m/%d", "%d/%m/%Y"):
+    for fmt in (
+        "%Y-%m-%d",
+        "%Y.%m.%d",
+        "%d.%m.%Y",
+        "%d-%m-%Y",
+        "%Y/%m/%d",
+        "%d/%m/%Y",
+    ):
         ts = pd.to_datetime(value, format=fmt, errors="coerce")
         if pd.notna(ts):
             return ts


### PR DESCRIPTION
## Ne değişti?
- `parse_date` artık `DD-MM-YYYY` biçimindeki tarihleri de tanıyor.
- İlgili açıklamalar güncellendi.
- Yeni format için test eklendi.

## Neden yapıldı?
- Avrupa tarzı `07-03-2025` gibi tarihlerin desteklenmemesi hata riskine yol açıyordu.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687e71ad09a48325ad4ee21d8a643db9