### PR TITLE
Küçük rapor iyileştirmesi

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -86,7 +86,7 @@ EXPECTED_COLUMNS = [
 
 
 def _build_detay_df(
-    detay_list: list[pd.DataFrame], trades: pd.DataFrame
+    detay_list: list[pd.DataFrame], trades: pd.DataFrame | None = None
 ) -> pd.DataFrame:
     """Combine partial detail frames and attach trade results.
 
@@ -94,8 +94,9 @@ def _build_detay_df(
     ----------
     detay_list : list[pandas.DataFrame]
         Partial detail frames generated per filter.
-    trades : pandas.DataFrame
+    trades : pandas.DataFrame | None, optional
         Trade information to merge on ``filtre_kodu`` and ``hisse_kodu``.
+        ``None`` results in a plain concatenation without merging.
 
     Returns
     -------

--- a/tests/test_detay_not_empty.py
+++ b/tests/test_detay_not_empty.py
@@ -42,3 +42,9 @@ def test_detay_empty_list():
     df = _build_detay_df([], trades)
     assert df.empty
     assert list(df.columns) == list(trades.columns)
+
+
+def test_detay_none_trades():
+    """Passing ``None`` as trades should not raise and return empty frame."""
+    out = _build_detay_df([], None)
+    assert out.empty and list(out.columns) == []


### PR DESCRIPTION
## Ne değişti?
- `_build_detay_df` fonksiyonu artık `trades` parametresini opsiyonel kabul ediyor.
- Fonksiyon açıklaması güncellendi.
- `tests/test_detay_not_empty.py` dosyasına `None` durumunu doğrulayan yeni bir test eklendi.

## Neden yapıldı?
`_build_detay_df` fonksiyonunun bazı kullanım senaryolarında `trades` verisi olmayabilir. Parametreyi opsiyonel hale getirerek hata olasılığı ortadan kaldırıldı.

## Nasıl test edildi?
- `pre-commit` ile kod biçimi ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler (eklenen test dahil) başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687e74c4eee88325bb622f57d2d20d82