### PR TITLE
RSI çıktısı için varsayılan isim

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -237,4 +237,4 @@ def rsi(
     res_df = pd.DataFrame(obb_obj.results).set_index("date")
     rsi_col = [c for c in res_df.columns if c.lower().startswith("close_rsi")]
     col = rsi_col[0] if rsi_col else res_df.columns[-1]
-    return res_df[col].rename(close.name)
+    return res_df[col].rename(close.name or "rsi")


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing.rsi` fonksiyonunda, `close` serisinin adı tanımsızsa dönen seriye `"rsi"` adı verildi.

## Neden yapıldı?
- İsimlendirilmemiş serilerin sonraki işlemlerde sorun yaratmaması için varsayılan kolon adı atandı.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- Tüm birim testleri `pytest` ile çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687e7703cf3c8325903e05c2e1b0f654