### PR TITLE
Küçük hata düzeltmesi

### DIFF
--- a/finansal/utils/dtypes.py
+++ b/finansal/utils/dtypes.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from typing import Any
 
 import pandas as pd
+from pandas.api.types import is_integer_dtype
 
 from finansal_analiz_sistemi import config
 
@@ -43,7 +44,7 @@ def safe_set(df: pd.DataFrame, column: str, values: Iterable[Any]) -> None:
         try:
             series = series.astype(target_dtype)
         except (ValueError, TypeError):
-            if str(target_dtype).startswith("int"):
+            if is_integer_dtype(target_dtype):
                 try:
                     nullable = "Int32" if "32" in str(target_dtype) else "Int64"
                     series = series.astype(nullable)


### PR DESCRIPTION
## Ne değişti?
- `safe_set` fonksiyonunda hedef tipin tam sayı olup olmadığı artık `is_integer_dtype` ile kontrol ediliyor.

## Neden yapıldı?
- `dtype` adındaki farklı varyasyonların doğru algılanması sağlandı. Önceki `str().startswith('int')` kontrolü bazı özel tiplerde güvenilir değildi.

## Nasıl test edildi?
- `pre-commit` ile stil ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687e870176348325b4973758b57281ce