### PR TITLE
Plotly import caching

### DIFF
--- a/report_stats.py
+++ b/report_stats.py
@@ -9,6 +9,7 @@ generated as well.
 from __future__ import annotations
 
 import warnings
+from functools import lru_cache
 from typing import Any
 
 import numpy as np
@@ -19,12 +20,14 @@ from finansal_analiz_sistemi import config
 from utils.pandas_option_safe import option_context
 
 
+@lru_cache(maxsize=1)
 def _get_plotly():
     """Return the Plotly graphing modules if available.
 
     Lazily imports :mod:`plotly.graph_objects` and
     :func:`plotly.subplots.make_subplots` so that optional
-    plotting dependencies are only required when needed.
+    plotting dependencies are only required when needed. The result is
+    cached so repeated calls avoid the import overhead.
 
     Returns:
         tuple[module, Callable]: Graph objects module and ``make_subplots``.


### PR DESCRIPTION
## Ne değişti?
- `report_stats._get_plotly` fonksiyonu `lru_cache` ile önbelleğe alındı.
- Fonksiyon dokümantasyonu güncellenerek tekrar çağrılarda yükün azaldığı belirtildi.

## Neden yapıldı?
Plotly modülünün her çağrıda tekrar import edilmesi gereksiz yere süre kaybına yol açıyordu. Küçük de olsa performans kazancı sağlamak için modül ilk kullanımda yüklenip daha sonra önbellekten okunacak şekilde güncellendi.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı ve tamamının geçtiği doğrulandı.


------
https://chatgpt.com/codex/tasks/task_e_687e94d46710832582934d4bd83b2294