### PR TITLE
safe_ma için aralık doğrulaması

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -294,12 +294,29 @@ def safe_ma(
     kind: str = "sma",
     logger_param: Optional[logging.Logger] = None,
 ) -> None:
-    """Append the requested moving-average column when missing."""
+    """Append the requested moving-average column when missing.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Frame to modify in-place.
+    n : int
+        Moving average period. Values less than ``1`` are ignored.
+    kind : str, optional
+        ``"sma"`` for simple moving average or ``"ema"`` for exponential,
+        by default ``"sma"``.
+    logger_param : Optional[logging.Logger], optional
+        Logger instance used for debug messages.
+    """
 
     if logger_param is None:
         logger_param = logger
     log = logger_param
     col_name = f"{kind}_{n}"
+
+    if n < 1:
+        log.warning("safe_ma: geçersiz periyot (%s) – atlandı", n)
+        return
 
     if "close" not in df.columns:
         log.debug("safe_ma: 'close' sütunu yok, işlem atlandı.")

--- a/tests/test_indicator_calc_hyp.py
+++ b/tests/test_indicator_calc_hyp.py
@@ -29,3 +29,12 @@ def test_safe_ma_adds_column(xs):
     assert "sma_5" in df.columns
     assert len(df["sma_5"]) == len(xs)
     assert df["sma_5"].notna().all()
+
+
+def test_safe_ma_invalid_period():
+    """Periods below one should be ignored without errors."""
+    df = pd.DataFrame({"close": [1, 2, 3]})
+    ic.safe_ma(df, 0)
+    assert "sma_0" not in df.columns
+    ic.safe_ma(df, -2)
+    assert "sma_-2" not in df.columns


### PR DESCRIPTION
## Ne değişti?
- `indicator_calculator.safe_ma` fonksiyonuna geçersiz periyotları (n<1) atlayan kontrol eklendi ve fonksiyonun dokümantasyonu genişletildi.
- `tests/test_indicator_calc_hyp.py` içinde geçersiz periyotların hata üretmemesini doğrulayan yeni test eklendi.

## Neden yapıldı?
Pozitif olmayan periyotlar `rolling`/`ewm` çağrılarında hata üretiyordu. Kontrol eklenerek hataların önüne geçildi.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` tüm testler ve yeni eklenen test için çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687e98b97e1483259a0de5284e562356