### PR TITLE
Hata düzeltmesi: MACD sütunları ve TEMA fallback

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -279,7 +279,11 @@ def _tema20(series: pd.Series) -> pd.Series:
 
     if hasattr(ta, "tema"):
         try:
-            return ta.tema(series, length=20)
+            out = ta.tema(series, length=20)
+            if isinstance(out, pd.Series):
+                return out
+            if isinstance(out, pd.DataFrame) and not out.empty:
+                return out.iloc[:, 0]
         except Exception:  # pragma: no cover - manual fallback
             pass
     ema1 = series.ewm(span=20, adjust=False).mean()

--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -192,7 +192,7 @@ def macd(
         signal=signal,
     )
     res_df = pd.DataFrame(obb_obj.results).set_index("date")
-    macd_cols = [c for c in res_df.columns if c.lower().startswith("close_macd")]
+    macd_cols = [c for c in res_df.columns if "macd" in c.lower()]
     return res_df[macd_cols]
 
 


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing.macd` fonksiyonu MACD çıktısındaki sütunları artık `"macd"` içeren isimlere göre seçiyor.
- `_tema20` fonksiyonu pandas_ta'dan dönen None veya DataFrame durumlarını ele alarak güvenli şekilde sonuç döndürüyor.

## Neden yapıldı?
- Bazı OpenBB sürümlerinde MACD sütun isimleri farklılık gösterebiliyor. Genişletilmiş filtre daha sağlam.
- `pandas_ta` kütüphanesi seri girdiğinde `None` döndürebiliyor ve bu da testlerde hataya neden oluyordu.

## Nasıl test edildi?
- `pre-commit` kancaları çalıştırıldı.
- `pytest` ile tüm testler başarıyla geçirildi.

------
https://chatgpt.com/codex/tasks/task_e_687e9e828b1c8325b046d3cefbe2c95e