### PR TITLE
Kayıt dosyası sızıntısını önle

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -651,13 +651,18 @@ def kaydet_uc_sekmeli_excel(
             "%(asctime)s | %(levelname)s | %(message)s", "%Y-%m-%d %H:%M:%S"
         )
     )
-    logging.getLogger().addHandler(fh)
+    root = logging.getLogger()
+    root.addHandler(fh)
 
     log_fn = logger_param.info
     if ozet_df.empty and detay_df.empty and istatistik_df.empty:
         log_fn = logger_param.warning
-    log_fn("Saved report to %s", fname)
-    logger_param.info("Per-run log file: %s", run_log)
+    try:
+        log_fn("Saved report to %s", fname)
+        logger_param.info("Per-run log file: %s", run_log)
+    finally:
+        root.removeHandler(fh)
+        fh.close()
     return fname
 
 


### PR DESCRIPTION
## Ne değişti?
`kaydet_uc_sekmeli_excel` fonksiyonunda açılan `FileHandler` artık işlem sonunda kapatılıyor ve logger'dan kaldırılıyor.

## Neden yapıldı?
Dosya tanıtıcılarının açık kalması sonraki işlemlerde logların yinelenmesine ve kaynak sızıntısına yol açıyordu. Handler'ın düzgün kapatılması bu problemi giderir.

## Nasıl test edildi?
- `pre-commit` ile statik kontroller çalıştırıldı.
- `pytest` ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687eb0b2caa08325a06df80f6c2f880f