### PR TITLE
Küçük yan etki düzeltmesi

### DIFF
--- a/backtest_core.py
+++ b/backtest_core.py
@@ -57,6 +57,9 @@ def _get_fiyat(
         else "Bilinmeyen Hisse"
     )
 
+    # Avoid mutating the caller's DataFrame when ensuring datetime dtype
+    df_hisse_veri = df_hisse_veri.copy()
+
     try:
         # Ensure the date column is of datetime type. The preprocessor should
         # normally handle this conversion.


### PR DESCRIPTION
## Ne değişti?
- `_get_fiyat` fonksiyonu, aldığı DataFrame üzerinde tarih sütunu dönüşümü yaparken çağıranın verisini değiştirmeyecek şekilde kopya oluşturarak güncellendi.

## Neden yapıldı?
- Fonksiyon içindeki tip dönüşümü dışarıdan gelen DataFrame'i değiştirebiliyordu. Bu yan etki sonraki işlemlerde beklenmedik hatalara yol açabilirdi.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler yürütüldü.

------
https://chatgpt.com/codex/tasks/task_e_687eb38282bc8325b8efb0b01fded1fb