### PR TITLE
Küçük iyileştirme: cache anahtarında stat çağrısı

### DIFF
--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -80,11 +80,17 @@ class DataLoaderCache:
         -------
         tuple
             ``((abs_path, kind), mtime_ns, size)`` describing the file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``filepath`` does not exist.
         """
         abs_path = Path(os.fspath(filepath)).expanduser().resolve()
-        if not abs_path.exists():
+        try:
+            stat = abs_path.stat()
+        except FileNotFoundError:
             raise FileNotFoundError(str(abs_path))
-        stat = abs_path.stat()
         return (str(abs_path), kind), stat.st_mtime_ns, stat.st_size
 
     def clear(self) -> None:


### PR DESCRIPTION
## Ne değişti?
- `DataLoaderCache._get_cache_key` artık dosya varlığını `stat()` ile kontrol ediyor.
- Docstring'e `FileNotFoundError` durumu eklendi.

## Neden yapıldı?
- Tek sistem çağrısıyla dosya durumu okunarak gereksiz `exists()` kontrolü kaldırıldı.
- Hata durumları docstring'de açıklığa kavuştu.

## Nasıl test edildi?
- `pre-commit` ve `pytest` komutları çalıştırıldı; tüm kontroller başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687f2ad648dc8325863e0129deb320f6