### PR TITLE
Excel önbelleği boyutu için ortam değişkeni

### DIFF
--- a/tests/test_excel_cache_env.py
+++ b/tests/test_excel_cache_env.py
@@ -1,0 +1,22 @@
+import importlib
+
+from src.utils import excel_reader
+
+
+def test_env_override_excel_cache_size(monkeypatch):
+    monkeypatch.setenv("EXCEL_CACHE_SIZE", "5")
+    mod = importlib.reload(excel_reader)
+    assert mod._excel_cache.maxsize == 5
+    monkeypatch.delenv("EXCEL_CACHE_SIZE", raising=False)
+    importlib.reload(excel_reader)
+
+
+def test_env_invalid_excel_cache_size(monkeypatch):
+    monkeypatch.setenv("EXCEL_CACHE_SIZE", "0")
+    mod = importlib.reload(excel_reader)
+    assert mod._excel_cache.maxsize == 8
+    monkeypatch.setenv("EXCEL_CACHE_SIZE", "-3")
+    mod = importlib.reload(excel_reader)
+    assert mod._excel_cache.maxsize == 8
+    monkeypatch.delenv("EXCEL_CACHE_SIZE", raising=False)
+    importlib.reload(excel_reader)


### PR DESCRIPTION
## Ne değişti?
- `src/utils/excel_reader.py` modülünde önbellek boyutu `EXCEL_CACHE_SIZE` ortam değişkeniyle yapılandırılabilir hâle getirildi.
- Bu değişikliğin test edilmesi için `tests/test_excel_cache_env.py` eklendi.

## Neden yapıldı?
Varsayılan 8 çalışma kitabı sınırı tüm ortamlarda yeterli olmayabiliyordu. Ortam değişkeni ile sınır kolayca ayarlanabilecek.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler, yeni eklenen testler dâhil, başarılı şekilde çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687f37602344832583d092032cf6e4bc