### PR TITLE
Hafta sonu tarih düzeltmesi

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -47,10 +47,14 @@ def fill_missing_business_day(
     offsets = (size - pos).where(mask, 0)
 
     norm = next_valid.dt.normalize()
+    # ``np.busday_offset`` rolls invalid (weekend/holiday) days before applying
+    # the offset. Using ``roll='forward'`` ensures weekend dates are first
+    # advanced to Monday and then shifted backwards, yielding the preceding
+    # business day regardless of the starting day.
     adjusted = np.busday_offset(
         norm.values.astype("datetime64[D]"),
         -offsets.values.astype(int),
-        roll="backward",
+        roll="forward",
     )
     df[date_col] = pd.to_datetime(adjusted) + (next_valid - norm)
     return df

--- a/tests/test_fill_missing_business_day_weekend.py
+++ b/tests/test_fill_missing_business_day_weekend.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+from src.preprocessor import fill_missing_business_day
+
+
+def test_fill_missing_business_day_handles_weekend():
+    df = pd.DataFrame({"tarih": [pd.NaT, pd.to_datetime("06.01.2024", dayfirst=True)]})
+    out = fill_missing_business_day(df, date_col="tarih")
+    assert out.loc[0, "tarih"] == pd.to_datetime("05.01.2024", dayfirst=True)


### PR DESCRIPTION
## Ne değişti?
- `fill_missing_business_day` fonksiyonunda hafta sonu tarihlerinin bir gün fazla geri gitmesine neden olan `np.busday_offset` parametresi düzeltildi.
- Hafta sonu senaryosunu doğrulayan yeni bir test eklendi.

## Neden yapıldı?
- `roll="backward"` kullanıldığında hafta sonundan önceki iş gününün yerine iki gün önceki tarih dönüyordu. `roll="forward"` kullanılarak doğru iş günü elde edildi.

## Nasıl test edildi?
- `pre-commit` ile stil ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler ve yeni eklenen test çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687f416e3edc83259fa04cde2d8f8ec1