### PR TITLE
Küçük hata düzeltmesi

### DIFF
--- a/data_loader_cache.py
+++ b/data_loader_cache.py
@@ -161,12 +161,12 @@ class DataLoaderCache:
         pd.DataFrame
             Cached or newly loaded data.
         """
-        kwargs.setdefault("dtype", config.DTYPES)
+        params = {"dtype": config.DTYPES, **kwargs}
 
         return self._load_file(
             filepath,
             kind="__csv__",
-            loader=lambda p: pd.read_csv(p, **kwargs),
+            loader=lambda p: pd.read_csv(p, **params),
         )
 
     def load_excel(self, filepath: str | os.PathLike[str], **kwargs) -> pd.ExcelFile:


### PR DESCRIPTION
## Ne değişti?
- `DataLoaderCache.load_csv` fonksiyonu, gelen `kwargs` sözlüğünü artık değiştirmiyor.
- Varsayılan `dtype` parametresi kopyalanarak ekleniyor.

## Neden yapıldı?
- Fonksiyonun dışarıdan verilen sözlüğü değiştirmesi yan etkiye sebep oluyordu.
- Daha güvenli ve öngörülebilir bir API sağlandı.

## Nasıl test edildi?
- `pre-commit` ile stil ve statik analiz kontrolleri çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı.


------
https://chatgpt.com/codex/tasks/task_e_687f5024d4c083259bd76051a8c4094a