### PR TITLE
Kesişim sorgu önbelleğini sıfırlama fonksiyonu eklendi

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -156,6 +156,12 @@ def clear_failed() -> None:
     FAILED_FILTERS.clear()
 
 
+def clear_query_cache() -> None:
+    """Reset the cached results of :func:`_extract_query_columns`."""
+
+    _extract_query_columns.cache_clear()
+
+
 def evaluate_filter(
     fid: str | dict,
     df: Any | None = None,

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -11,3 +11,11 @@ def test_query_columns_cache():
     filter_engine._extract_query_columns(query)
     after = filter_engine._extract_query_columns.cache_info().hits
     assert after - before == 1
+
+
+def test_clear_query_cache():
+    query = "close > 0"
+    filter_engine._extract_query_columns(query)
+    assert filter_engine._extract_query_columns.cache_info().currsize > 0
+    filter_engine.clear_query_cache()
+    assert filter_engine._extract_query_columns.cache_info().currsize == 0


### PR DESCRIPTION
## Değişiklik Özeti
- `filter_engine` modülüne önbelleği temizleyen `clear_query_cache` fonksiyonu eklendi
- Önceki LRU önbelleğini test etmek amacıyla yeni bir test senaryosu yazıldı

## Test Sonuçları
- `pre-commit` kontrolleri: **başarılı**
- `pytest` testleri: **başarılı**

------
https://chatgpt.com/codex/tasks/task_e_687f75c0b34c832586de80f83b5a004c