### PR TITLE
safe_ma hatalı tür kontrolü

### DIFF
--- a/indicator_calculator.py
+++ b/indicator_calculator.py
@@ -307,8 +307,8 @@ def safe_ma(
     n : int
         Moving average period. Values less than ``1`` are ignored.
     kind : str, optional
-        ``"sma"`` for simple moving average or ``"ema"`` for exponential,
-        by default ``"sma"``.
+        Moving average type. Supported values are ``"sma"`` for simple and
+        ``"ema"`` for exponential averages. Defaults to ``"sma"``.
     logger_param : Optional[logging.Logger], optional
         Logger instance used for debug messages.
     """
@@ -317,6 +317,10 @@ def safe_ma(
         logger_param = logger
     log = logger_param
     col_name = f"{kind}_{n}"
+
+    if kind not in {"sma", "ema"}:
+        log.error("safe_ma: bilinmeyen hareketli ortalama türü '%s'", kind)
+        return
 
     if n < 1:
         log.warning("safe_ma: geçersiz periyot (%s) – atlandı", n)

--- a/tests/test_safe_ma_kind.py
+++ b/tests/test_safe_ma_kind.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+import indicator_calculator as ic
+
+
+def test_safe_ma_unknown_kind(caplog):
+    df = pd.DataFrame({"close": [1, 2, 3, 4]})
+    with caplog.at_level("ERROR"):
+        ic.safe_ma(df, 5, "xyz")
+    assert "xyz_5" not in df.columns
+    assert any("bilinmeyen" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Ne değişti?
- `safe_ma` fonksiyonu geçersiz `kind` parametresinde hata mesajı verip hesaplama yapmadan dönüyor.
- Geçerli türler docstring'de belirtildi.
- Yeni test dosyası ile bu davranış doğrulandı.

## Neden yapıldı?
Yanlış parametre kullanımında otomatik EMA hesaplanması istenmeyen sonuçlara yol açıyordu. Artık kullanıcı hatası belirgin şekilde kaydediliyor.

## Nasıl test edildi?
- `pre-commit` ile statik kontroller çalıştırıldı.
- `pytest` ile tüm testler, eklenen test dâhil, başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687f83dd8b0883258df95cf3d0ecb332