### PR TITLE
Küçük tarih dönüştürme iyileştirmesi

### DIFF
--- a/tests/test_date_parse_none.py
+++ b/tests/test_date_parse_none.py
@@ -16,3 +16,9 @@ def test_parse_date_handles_none_and_datetime():
 def test_parse_date_handles_date_object():
     d = date(2025, 3, 7)
     assert parse_date(d) == pd.Timestamp("2025-03-07")
+
+
+def test_parse_date_handles_invalid_strings():
+    """Common placeholders should return ``pd.NaT``."""
+    for raw in ["NaN", "none", "NULL"]:
+        assert parse_date(raw) is pd.NaT

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -3,7 +3,8 @@
 The :func:`parse_date` helper converts diverse date values into
 ``pandas.Timestamp`` objects without raising ``ValueError``. Supported
 inputs include strings, ``datetime`` objects, numeric representations and
-``numpy.datetime64`` instances.
+``numpy.datetime64`` instances. Common invalid strings such as ``"NaN"``
+or ``"None"`` are treated as missing and converted to ``pd.NaT``.
 """
 
 from __future__ import annotations
@@ -53,6 +54,8 @@ def parse_date(
         value = str(int(date_str))
     else:
         value = str(date_str).strip()
+        if value.lower() in {"nan", "none", "null"}:
+            return pd.NaT
     if not value:
         return pd.NaT
 


### PR DESCRIPTION
## Ne değişti?
- `parse_date` fonksiyonu "NaN", "none" ve "null" gibi metinleri `pd.NaT` olarak dönüştürüyor.
- Fonksiyon dokümantasyonu güncellendi.
- İlgili test senaryosu eklendi.

## Neden yapıldı?
Ham veride sıkça rastlanan boşluk belirteçleri hatalı tarihe yol açıyordu. Yeni kontrol ile bu değerler güvenli biçimde yok sayılıyor.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı.
- `pytest` ile tüm testler (yeni eklenenler dahil) başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687f89f2f34483258bccfa39979f40c1