### PR TITLE
MemoryProfile yol çözümleme iyileştirmesi

### DIFF
--- a/tests/test_memory_profile.py
+++ b/tests/test_memory_profile.py
@@ -32,3 +32,15 @@ def test_memory_profile_creates_parent_dir(tmp_path):
     with MemoryProfile(path=nested):
         pass
     assert nested.exists()
+
+
+def test_memory_profile_resolves_relative_path(tmp_path, monkeypatch):
+    """Relative paths should be expanded to absolute ones."""
+    monkeypatch.chdir(tmp_path)
+    mp = MemoryProfile(path="rel/foo.csv")
+    assert mp.path.is_absolute()
+    expected = (tmp_path / "rel/foo.csv").resolve()
+    assert mp.path == expected
+    with mp:
+        pass
+    assert expected.exists()

--- a/utils/memory_profile.py
+++ b/utils/memory_profile.py
@@ -29,8 +29,8 @@ class MemoryProfile:
     start: int = field(init=False)
 
     def __post_init__(self) -> None:
-        """Normalize the ``path`` attribute to a :class:`~pathlib.Path`."""
-        self.path = Path(self.path)
+        """Expand and resolve ``path`` to an absolute :class:`~pathlib.Path`."""
+        self.path = Path(self.path).expanduser().resolve()
 
     def __enter__(self) -> "MemoryProfile":
         """Start tracking process memory usage and return ``self``."""


### PR DESCRIPTION
## Ne değişti?
- `MemoryProfile.__post_init__` fonksiyonu verilen yolu `expanduser` ve `resolve` ile mutlak hâle getiriyor.
- Göreli yol çözümlemesini test eden yeni bir birim testi eklendi.

## Neden yapıldı?
Kullanıcı tarafından `~` veya göreli olarak verilen dosya yollarının doğru şekilde işlenmesi sağlandı. Bu sayede rapor dosyası beklenmedik dizinlere yazılmıyor.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler geçti.

------
https://chatgpt.com/codex/tasks/task_e_687f97b8fad48325acec79be1556cbe6