### PR TITLE
Hata tespiti fonksiyonunu güncelle

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -38,8 +38,8 @@ _FUNC_CACHE: LRUCache[str, Callable[..., Any]] = LRUCache(maxsize=FUNC_CACHE_SIZ
 
 
 def is_available() -> bool:
-    """Return ``True`` when the OpenBB package is importable."""
-    return obb is not None
+    """Return ``True`` when ``openbb.technical`` is available."""
+    return getattr(obb, "technical", None) is not None
 
 
 def clear_cache() -> None:

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -100,8 +100,14 @@ def test_clear_cache(monkeypatch):
 
 def test_is_available_reflects_import(monkeypatch):
     """is_available should detect the presence of the OpenBB package."""
-    monkeypatch.setattr(om, "obb", object())
+
+    class Dummy:
+        technical = object()
+
+    monkeypatch.setattr(om, "obb", Dummy())
     assert om.is_available() is True
+    monkeypatch.setattr(om, "obb", object())
+    assert om.is_available() is False
     monkeypatch.setattr(om, "obb", None)
     assert om.is_available() is False
 


### PR DESCRIPTION
## Ne değişti?
- `is_available` fonksiyonu artık sadece `openbb` paketinin varlığını değil, `technical` modülünün de erişilebilir olup olmadığını kontrol ediyor.
- Bu yeni davranışa uygun olarak `test_is_available_reflects_import` testi güncellendi.

## Neden yapıldı?
- `openbb` import edildiğinde ancak `technical` modülü bulunmadığında eski fonksiyon yanlış şekilde `True` döndürüyordu. Bu durum hatalı paket kurulumlarında sorun yaratabiliyordu.

## Nasıl test edildi?
- `pre-commit` ile biçimlendirme ve statik analizden geçildi.
- `pytest` ile tüm testler çalıştırıldı ve başarıyla sonuçlandı.

------
https://chatgpt.com/codex/tasks/task_e_687f9a061b9c8325b62edf38814c32a9