### PR TITLE
ReportWriter artık yol döndürüyor

### DIFF
--- a/finansal_analiz_sistemi/cli.py
+++ b/finansal_analiz_sistemi/cli.py
@@ -78,8 +78,7 @@ def run_analysis(csv_path: Path) -> Path:
     """
     df = pd.read_csv(csv_path, sep=";")
     out_path = csv_path.with_suffix(".xlsx")
-    ReportWriter().write_report(df, out_path)
-    return out_path
+    return ReportWriter().write_report(df, out_path)
 
 
 @atexit.register

--- a/finansal_analiz_sistemi/report_writer.py
+++ b/finansal_analiz_sistemi/report_writer.py
@@ -18,17 +18,10 @@ class ReportWriter:
     :meth:`pandas.DataFrame.to_excel`.
     """
 
-    def write_report(self, df: pd.DataFrame, output_path: Path | str) -> None:
-        """Write ``df`` to an Excel file.
+    def write_report(self, df: pd.DataFrame, output_path: Path | str) -> Path:
+        """Write ``df`` to ``output_path`` and return the destination."""
 
-        Creates missing parent directories before calling
-        :meth:`pandas.DataFrame.to_excel`.
-
-        Args:
-            df (pd.DataFrame): Data to export.
-            output_path (Path | str): Target Excel file path.
-
-        """
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         df.to_excel(output_path, index=False)
+        return output_path

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -106,7 +106,8 @@ def test_report_writer_accepts_str(tmp_path):
     """Ensure ``ReportWriter`` accepts a path string as destination."""
     df = pd.DataFrame({"a": [1]})
     nested = tmp_path / "nested" / "out.xlsx"
-    ReportWriter().write_report(df, str(nested))
+    out_path = ReportWriter().write_report(df, str(nested))
+    assert out_path == nested
     assert nested.exists() and nested.stat().st_size > 0
 
 


### PR DESCRIPTION
## Ne değişti?
- `ReportWriter.write_report` artık oluşturulan dosya yolunu döndürüyor.
- CLI'deki `run_analysis` bu dönüş değerini kullanacak şekilde güncellendi.
- İlgili test güncellendi.

## Neden yapıldı?
Rapor dosyasının kaydedildiği yolu fonksiyon çağrısından hemen sonra almak kullanım kolaylığı sağlar.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı.
- `pytest` tüm testler başarılı.

------
https://chatgpt.com/codex/tasks/task_e_687fa3bf73c48325a4876283ae667d29