### PR TITLE
Açık olmayan OpenBB fonksiyonlarını yakala

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -81,10 +81,11 @@ def _call_openbb(func_name: str, **kwargs) -> object:
 
     func = _FUNC_CACHE.get(func_name)
     if func is None:
-        func = getattr(technical, func_name, None)
-        if func is None:
+        attr = getattr(technical, func_name, None)
+        if not callable(attr):
             raise NotImplementedError(f"OpenBB indicator '{func_name}' is unavailable")
-        _FUNC_CACHE[func_name] = func
+        _FUNC_CACHE[func_name] = attr
+        func = attr
 
     return func(**kwargs)
 

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -68,6 +68,21 @@ def test_call_openbb_function_missing(monkeypatch):
         om._call_openbb("bar")
 
 
+def test_call_openbb_non_callable(monkeypatch):
+    """Non-callable attributes should raise ``NotImplementedError``."""
+
+    class DummyTech:
+        foo = 42
+
+    dummy = type("DummyOBB", (), {"technical": DummyTech()})()
+
+    monkeypatch.setattr(om, "obb", dummy)
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+
+    with pytest.raises(NotImplementedError, match="foo"):
+        om._call_openbb("foo")
+
+
 def test_call_openbb_without_technical(monkeypatch):
     """Missing ``technical`` attribute should raise ``NotImplementedError``."""
 


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing._call_openbb` fonksiyonu artık alınan özniteliğin çağrılabilir olup olmadığını kontrol ediyor.
- Çağrılabilir olmayan durumlar için `NotImplementedError` fırlatılıyor.
- Bu davranışı doğrulamak üzere `tests/test_openbb_missing.py` dosyasına yeni bir test eklendi.

## Neden yapıldı?
- Önceden `_call_openbb` istenen isimde bir öznitelik bulsa da bu öznitelik fonksiyon değilse `TypeError` oluşuyordu. Yeni kontrolle hata daha anlaşılır hale getirildi ve önceden yakalanıyor.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler (yeni eklenen test dahil) başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687fabbc94f48325ac954116235a2cff