### PR TITLE
Kesişen EMA listesini önbelleğe al

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -62,6 +62,7 @@ def load_crossover_names(
     return sorted(names)
 
 
+@lru_cache(maxsize=1)
 def load_ema_close_crossovers(
     csv_path: str | Path | None = None,
     *,
@@ -87,5 +88,7 @@ def load_ema_close_crossovers(
 
 
 def clear_cache() -> None:
-    """Clear cached results of :func:`load_crossover_names`."""
+    """Clear cached results of :func:`load_crossover_names` and
+    :func:`load_ema_close_crossovers`."""
     load_crossover_names.cache_clear()
+    load_ema_close_crossovers.cache_clear()


### PR DESCRIPTION
## Ne değişti?
- `config_loader.load_ema_close_crossovers` fonksiyonu LRU önbellek ile sarmalandı.
- `clear_cache` artık bu fonksiyonun önbelleğini de temizliyor.

## Neden yapıldı?
Sık kullanılan EMA-close kesişim listesinin tekrar tekrar oluşturulması engellendi. Böylece aynı dosya okunurken gereksiz işlem maliyeti düşürüldü.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` komutu ile tüm testler başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_687fc37d97448325bcde9c51155becef