### PR TITLE
Küçük iyileştirme: run_pipeline tarih okuma

### DIFF
--- a/run.py
+++ b/run.py
@@ -257,9 +257,11 @@ def run_pipeline(
         comment="#",
         header=None,
         names=["code", "date", "open", "high", "low", "close", "volume"],
+        parse_dates=["date"],
     )
     df = df.rename(columns={"code": "hisse_kodu", "date": "tarih"})
-    df["tarih"] = df["tarih"].apply(parse_date)
+    if not pd.api.types.is_datetime64_any_dtype(df["tarih"]):
+        df["tarih"] = df["tarih"].apply(parse_date)
 
     with open(filter_def, encoding="utf-8") as f:
         filt = yaml.safe_load(f) or []


### PR DESCRIPTION
## Ne değişti?
- `run_pipeline` fonksiyonunda `read_csv` çağrısına `parse_dates` parametresi eklendi.
- Tarih sütunu zaten datetime değilse `parse_date` ile dönüştürme yapılıyor.

## Neden yapıldı?
- CSV'deki ISO tarihleri daha hızlı okuyarak gereksiz `apply` kullanımını önlemek.

## Nasıl test edildi?
- `pre-commit` ile stil ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı.

------
https://chatgpt.com/codex/tasks/task_e_687fd8366fb8832593c3313edb50ca5a