### PR TITLE
openbb cache fonksiyonunu geliştir

### DIFF
--- a/openbb_missing.py
+++ b/openbb_missing.py
@@ -42,9 +42,22 @@ def is_available() -> bool:
     return getattr(obb, "technical", None) is not None
 
 
-def clear_cache() -> None:
-    """Empty the internal OpenBB function cache."""
-    _FUNC_CACHE.clear()
+def clear_cache(size: int | None = None) -> None:
+    """Empty the internal OpenBB function cache.
+
+    Parameters
+    ----------
+    size : int, optional
+        When provided and positive, the cache is recreated with the given
+        ``maxsize`` instead of simply being cleared. This allows adjusting
+        memory usage without reloading the module.
+    """
+
+    global _FUNC_CACHE
+    if size is not None and size > 0:
+        _FUNC_CACHE = LRUCache(maxsize=size)
+    else:
+        _FUNC_CACHE.clear()
 
 
 def _call_openbb(func_name: str, **kwargs) -> object:

--- a/tests/test_openbb_missing.py
+++ b/tests/test_openbb_missing.py
@@ -113,6 +113,14 @@ def test_clear_cache(monkeypatch):
     assert len(om._FUNC_CACHE) == 0
 
 
+def test_clear_cache_resize(monkeypatch):
+    """clear_cache should recreate the cache when ``size`` is given."""
+    monkeypatch.setattr(om, "_FUNC_CACHE", om.LRUCache(maxsize=4))
+    om.clear_cache(size=2)
+    assert isinstance(om._FUNC_CACHE, om.LRUCache)
+    assert om._FUNC_CACHE.maxsize == 2
+
+
 def test_is_available_reflects_import(monkeypatch):
     """is_available should detect the presence of the OpenBB package."""
 


### PR DESCRIPTION
## Ne değişti?
- `openbb_missing.clear_cache` artık isteğe bağlı `size` parametresi alıyor. Böylece önbellek boyutu modülü yeniden yüklemeden ayarlanabiliyor.
- Bu yeni davranışı doğrulayan `test_clear_cache_resize` eklendi.

## Neden yapıldı?
Önbellek boyutunun çalışma sırasında değiştirilmesine olanak tanıyarak bellek kullanımı üzerinde daha esnek kontrol sağlandı.

## Nasıl test edildi?
- `pre-commit` ile stil ve statik analizler çalıştırıldı.
- `pytest` tüm testleri geçti.

------
https://chatgpt.com/codex/tasks/task_e_687fdce0a4c88325a65166a0b3c37a71