### PR TITLE
Küçük hata düzeltmesi

### DIFF
--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -18,6 +18,16 @@ import pandas as pd
 from dateutil import parser
 from pandas._libs.tslibs.nattype import NaTType
 
+# Common explicit date formats tried before falling back to ``dateutil``.
+_EXPLICIT_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d",
+    "%Y.%m.%d",
+    "%d.%m.%Y",
+    "%d-%m-%Y",
+    "%Y/%m/%d",
+    "%d/%m/%Y",
+)
+
 
 def parse_date(
     date_str: str | datetime | date | int | float | np.datetime64 | None,
@@ -60,14 +70,7 @@ def parse_date(
         return pd.NaT
 
     # Try explicit formats before falling back to dateutil
-    for fmt in (
-        "%Y-%m-%d",
-        "%Y.%m.%d",
-        "%d.%m.%Y",
-        "%d-%m-%Y",
-        "%Y/%m/%d",
-        "%d/%m/%Y",
-    ):
+    for fmt in _EXPLICIT_FORMATS:
         ts = pd.to_datetime(value, format=fmt, errors="coerce")
         if pd.notna(ts):
             return ts


### PR DESCRIPTION
## Ne değişti?
- `parse_date` artık denenecek tarih formatlarını `_EXPLICIT_FORMATS` adlı bir sabitte tutuyor.
- Fonksiyon bu sabiti kullanarak gereksiz tuple oluşturma maliyetinden kurtuldu.

## Neden yapıldı?
- Sık kullanılan `parse_date` fonksiyonunda yinelenen format listesi kaldırılarak kod okunabilirliği artırıldı ve ufak bir performans iyileştirmesi sağlandı.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_688003564a648325bf24a87bd44208c7