### PR TITLE
TypeError için özel hata mesajı

### DIFF
--- a/tests/test_error_map.py
+++ b/tests/test_error_map.py
@@ -17,3 +17,9 @@ def test_get_reason_hint_not_implemented():
     reason, hint = em.get_reason_hint(NotImplementedError())
     assert reason == "Desteklenmiyor"
     assert hint == "İlgili paketi kurun veya güncelleyin"
+
+
+def test_get_reason_hint_type_error():
+    reason, hint = em.get_reason_hint(TypeError("bad type"))
+    assert reason == "Tip Hatası"
+    assert hint == "Parametre tiplerini kontrol edin"

--- a/utils/error_map.py
+++ b/utils/error_map.py
@@ -27,6 +27,10 @@ REASON_MAP: dict[str, tuple[str, str]] = {
         "Ge\u00e7ersiz De\u011fer",
         "Parametreleri kontrol edin",
     ),
+    "TypeError": (
+        "Tip Hatası",
+        "Parametre tiplerini kontrol edin",
+    ),
     "NotImplementedError": (
         "Desteklenmiyor",
         "İlgili paketi kurun veya güncelleyin",


### PR DESCRIPTION
## Ne değişti?
- `utils.error_map.REASON_MAP` tablosuna `TypeError` tanımı eklendi.
- `tests/test_error_map.py` dosyasında yeni bir test ile bu durum doğrulandı.

## Neden yapıldı?
`log_failure_exc` kullanan bölümlerde `TypeError` oluştuğunda kullanıcıya daha açıklayıcı bir mesaj verilmesi amaçlandı.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı ve tüm kontroller geçti.
- `pytest` ile testler çalıştırıldı; tüm testler başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_6880236123c08325be01798ff3a23519