### PR TITLE
Küçük hata düzeltmesi

### DIFF
--- a/report_stats.py
+++ b/report_stats.py
@@ -203,7 +203,8 @@ def build_ozet_df(
     df["satis_tarihi"] = satis_tarihi
     df.rename(
         columns={
-            "ort_getiri_%": "ort_getiri_%",
+            # Backwards compatibility with old summary column names
+            "ort_getiri": "ort_getiri_%",
             "en_yuksek": "en_yuksek_%",
             "en_dusuk": "en_dusuk_%",
         },


### PR DESCRIPTION
## Ne değişti?
- `report_stats.build_ozet_df` fonksiyonundaki kolon yeniden adlandırma tablosu düzenlendi. `ort_getiri` gibi eski isimler artık doğru şekilde `%` takısı eklenerek dönüştürülüyor.

## Neden yapıldı?
- Mevcut kodda `"ort_getiri_%": "ort_getiri_%"` eşlemesi işlevsizdi. Eski kolon adlarını desteklemek için düzenleme yapıldı.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler çalıştırıldı ve başarıyla sonuçlandı.

------
https://chatgpt.com/codex/tasks/task_e_68811996b6a08325b2e981850cf61831