### PR TITLE
Küçük hata düzeltmesi

### DIFF
--- a/finansal_analiz_sistemi/data_loader.py
+++ b/finansal_analiz_sistemi/data_loader.py
@@ -294,8 +294,8 @@ def load_excel_katalogu(
         log.debug(f"{path} kısa veri – atlandı")
         return None
 
-    parquet_p = path.replace(".xlsx", ".parquet")
-    if not os.path.exists(parquet_p):
+    parquet_p = Path(path).with_suffix(".parquet")
+    if not parquet_p.exists():
         try:
             df.to_parquet(parquet_p)
         except Exception as e:

--- a/tests/test_data_loader_param.py
+++ b/tests/test_data_loader_param.py
@@ -59,6 +59,18 @@ def test_load_excel_katalogu_long(tmp_path: Path):
     assert Path(str(p).replace(".xlsx", ".parquet")).exists()
 
 
+def test_load_excel_katalogu_xls(tmp_path: Path):
+    """``.xls`` files should also be cached as Parquet."""
+    pytest.importorskip("pyarrow")
+    df = pd.DataFrame({"a": range(252)})
+    p = tmp_path / "s.xls"
+    df.to_excel(p, index=False)
+    out = data_loader.load_excel_katalogu(str(p))
+    assert out is not None
+    assert len(out) == 252
+    assert p.with_suffix(".parquet").exists()
+
+
 def test_load_excel_katalogu_short(tmp_path: Path):
     """Excel files under 252 rows should return ``None``."""
     df = pd.DataFrame({"a": range(10)})


### PR DESCRIPTION
## Ne değişti?
- `load_excel_katalogu` fonksiyonu `.xls` uzantılı dosyalar için yanlış Parquet yolu oluşturuyordu. Dosya yolu artık `Path.with_suffix('.parquet')` ile belirleniyor.
- `.xls` dosyalarının da Parquet'e kaydedildiğini doğrulayan yeni test eklendi.

## Neden yapıldı?
- `.xls` dosyaları işlendiğinde Parquet dosyasının yanlış isimle oluşturulması engellendi.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarıyla tamamlandı.


------
https://chatgpt.com/codex/tasks/task_e_68813e2aa50083258def34a67adaf815