### PR TITLE
Pozitif env okuması düzeltildi

### DIFF
--- a/tests/test_positive_int_env.py
+++ b/tests/test_positive_int_env.py
@@ -1,0 +1,15 @@
+from utils.env_utils import positive_int_env
+
+
+def test_env_whitespace(monkeypatch):
+    monkeypatch.setenv("TEST_INT_ENV", " 42 ")
+    assert positive_int_env("TEST_INT_ENV", 1) == 42
+    monkeypatch.delenv("TEST_INT_ENV", raising=False)
+
+
+def test_env_invalid(monkeypatch):
+    monkeypatch.setenv("TEST_INT_ENV", "notanint")
+    assert positive_int_env("TEST_INT_ENV", 5) == 5
+    monkeypatch.setenv("TEST_INT_ENV", "-3")
+    assert positive_int_env("TEST_INT_ENV", 7) == 7
+    monkeypatch.delenv("TEST_INT_ENV", raising=False)

--- a/utils/env_utils.py
+++ b/utils/env_utils.py
@@ -6,12 +6,16 @@ __all__ = ["positive_int_env"]
 
 
 def positive_int_env(name: str, default: int) -> int:
-    """Return a positive integer from ``name`` or ``default`` when invalid."""
+    """Return a positive integer from ``name`` or ``default`` when invalid.
+
+    Environment variables with leading or trailing whitespace are stripped
+    before conversion to avoid ``ValueError`` due to formatting.
+    """
     val = os.getenv(name)
     if val is None:
         return default
     try:
-        num = int(val)
+        num = int(val.strip())
     except ValueError:
         return default
     return num if num > 0 else default


### PR DESCRIPTION
## Ne değişti?
- `positive_int_env` fonksiyonu artık ortam değişkenindeki baştaki ve sondaki boşlukları ayıklıyor.
- Bu işlev için `tests/test_positive_int_env.py` eklendi.

## Neden yapıldı?
- Boşluk içeren ortam değişkenleri önceki sürümde `ValueError` üreterek varsayılana dönüyordu. Bu düzeltme değerlerin doğru okunmasını sağlar.

## Nasıl test edildi?
- `pre-commit` çalıştırıldı: tüm kontroller geçti.
- `pytest` çalıştırıldı: tüm testler (yeni eklenenler dahil) başarıyla geçti.

------
https://chatgpt.com/codex/tasks/task_e_688231685e94832597af229db3fb2cc2