### PR TITLE
Excel cache boyutunu dinamik ayarlama

### DIFF
--- a/tests/test_excel_cache_env.py
+++ b/tests/test_excel_cache_env.py
@@ -20,3 +20,20 @@ def test_env_invalid_excel_cache_size(monkeypatch):
     assert mod._excel_cache.maxsize == 8
     monkeypatch.delenv("EXCEL_CACHE_SIZE", raising=False)
     importlib.reload(excel_reader)
+
+
+def test_clear_cache_resize(monkeypatch, tmp_path):
+    """Cache should recreate itself when ``size`` is provided."""
+    path = tmp_path / "c.xlsx"
+    # build a dummy workbook
+    import pandas as pd
+
+    pd.DataFrame({"a": [1]}).to_excel(path, index=False)
+
+    cache = excel_reader._WorkbookCache(maxsize=4)
+    monkeypatch.setattr(excel_reader, "_excel_cache", cache)
+    _ = excel_reader.open_excel_cached(path)
+    assert len(excel_reader._excel_cache) == 1
+    excel_reader.clear_cache(size=2)
+    assert len(excel_reader._excel_cache) == 0
+    assert excel_reader._excel_cache.maxsize == 2


### PR DESCRIPTION
## Değişiklik Özeti
- `excel_reader.clear_cache` fonksiyonu artık isteğe bağlı `size` parametresi alıyor
- `EXCEL_CACHE_SIZE` testi yeni fonksiyonu doğrulayacak şekilde güncellendi

## Testler
- `pre-commit` çıktısı
- `pytest` çıktısı

------
https://chatgpt.com/codex/tasks/task_e_688234f1ef10832593675d94ba68cdde