### PR TITLE
parse_date kısa sayıları NaT dönüştürüyor

### DIFF
--- a/tests/test_date_parse.py
+++ b/tests/test_date_parse.py
@@ -19,6 +19,7 @@ def test_parse_date_variants():
         20250307.0: "2025-03-07",
         "250307": "2025-03-07",
         "070325": "2025-03-07",
+        0: pd.NaT,
         "\u00e7\u00f6p": pd.NaT,
     }
     for raw, expected in cases.items():

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -75,23 +75,25 @@ def parse_date(
         if pd.notna(ts):
             return ts
 
-    if value.isdigit() and len(value) == 8:
-        year = int(value[:4])
-        if 1900 <= year <= 2100:
-            ts = pd.to_datetime(value, format="%Y%m%d", errors="coerce")
+    if value.isdigit():
+        if len(value) == 8:
+            year = int(value[:4])
+            if 1900 <= year <= 2100:
+                ts = pd.to_datetime(value, format="%Y%m%d", errors="coerce")
+            else:
+                ts = pd.to_datetime(value, format="%d%m%Y", errors="coerce")
+            if pd.notna(ts):
+                return ts
+        elif len(value) == 6:
+            first = int(value[:2])
+            if first > 12:
+                ts = pd.to_datetime(value, format="%y%m%d", errors="coerce")
+            else:
+                ts = pd.to_datetime(value, format="%d%m%y", errors="coerce")
+            if pd.notna(ts):
+                return ts
         else:
-            ts = pd.to_datetime(value, format="%d%m%Y", errors="coerce")
-        if pd.notna(ts):
-            return ts
-
-    if value.isdigit() and len(value) == 6:
-        first = int(value[:2])
-        if first > 12:
-            ts = pd.to_datetime(value, format="%y%m%d", errors="coerce")
-        else:
-            ts = pd.to_datetime(value, format="%d%m%y", errors="coerce")
-        if pd.notna(ts):
-            return ts
+            return pd.NaT
 
     # Generic day-first parsing with coercion (handles 07/03/25 etc.)
     ts = pd.to_datetime(value, dayfirst=True, errors="coerce")


### PR DESCRIPTION
## Ne değişti?
- `utils.date_utils.parse_date` fonksiyonu kısa tüm-sayısal değerleri (`0`, `12345` vb.) artık tarih olarak yorumlamayıp `pd.NaT` döndürüyor.
- `tests/test_date_parse.py` dosyasına `0` girdisinin `pd.NaT` döndürdüğünü doğrulayan bir test eklendi.

## Neden yapıldı?
`parse_date` fonksiyonu tek haneli veya dörtten az haneli sayıları `pandas.to_datetime` aracılığıyla 1970-01-01 gibi anlamsız tarihlere çeviriyordu. Kısa sayılar tarih belirtmediğinden `pd.NaT` dönmek daha doğru bir davranış.

## Nasıl test edildi?
- `pre-commit` ile biçim ve statik analizler çalıştırıldı.
- `pytest` ile tüm testler başarıyla tamamlandı.

------
https://chatgpt.com/codex/tasks/task_e_68827bf4b8d083259258d35ea66d2aac