### PR TITLE
Ensure future annotations import is first

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,2 +1,4 @@
 """Backtest Project - 1G (T close -> T+1 close) pipeline."""
+from __future__ import annotations
+
 __version__ = "1.0.0"

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import pandas as pd
 
 def run_1g_returns(df_with_next: pd.DataFrame, signals: pd.DataFrame) -> pd.DataFrame:

--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pandas as pd
 import io, csv
 

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import pandas as pd
 from typing import Optional, Set, Iterable
 

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import click, os, pandas as pd
 from .config import load_config
 from .data_loader import read_excels_long

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional
 import yaml, os

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -1,6 +1,6 @@
-import re
 from __future__ import annotations
 
+import re
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import pandas as pd
 from typing import Dict, List
 import pandas_ta as ta

--- a/backtest/normalizer.py
+++ b/backtest/normalizer.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import pandas as pd
 
 def normalize(df: pd.DataFrame) -> pd.DataFrame:

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os, pandas as pd
 from typing import List, Dict, Optional
 

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import pandas as pd
 import re
 

--- a/backtest/utils.py
+++ b/backtest/utils.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 from loguru import logger
 from pathlib import Path
 

--- a/backtest/validator.py
+++ b/backtest/validator.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 import pandas as pd
 
 def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import pandas as pd
 from backtest.backtester import run_1g_returns

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import pandas as pd
 from backtest.calendars import add_next_close

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import pandas as pd
 from backtest.screener import run_screener

--- a/tests/test_summary_diff.py
+++ b/tests/test_summary_diff.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 
 def test_summary_and_winrate():


### PR DESCRIPTION
## Summary
- Place `from __future__ import annotations` at the top of every module and test file
- Clean up import order and spacing after relocating the future import

## Testing
- `python -m py_compile $(find backtest tests -name '*.py')`
- `PYTHONPATH=. pytest -q` *(fails: KeyError: "['next_date'] not in index")*

------
https://chatgpt.com/codex/tasks/task_e_6892947daa308325ae1f6267c0a75220