### PR TITLE
Add import validation tests for backtest modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path for imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_backtest_imports.py
+++ b/tests/test_backtest_imports.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import backtest
+
+
+def test_backtest_all_modules_importable():
+    for module_info in pkgutil.iter_modules(backtest.__path__):
+        name = module_info.name
+        if name == "__init__":
+            continue
+        module_name = f"{backtest.__name__}.{name}"
+        try:
+            importlib.import_module(module_name)
+        except (ImportError, SyntaxError) as exc:
+            raise AssertionError(f"Failed to import {module_name}: {exc}")

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -10,6 +10,7 @@ def test_pipeline_smoke():
         "date":pd.to_datetime(["2024-01-05","2024-01-08"]).date,
         "close":[10.0, 11.0],
         "next_close":[11.0, None],
+        "next_date":pd.to_datetime(["2024-01-08","2024-01-09"]).date,
         "open":[10.0,11.0],
         "high":[10.0,11.0],
         "low":[10.0,11.0],


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adding project root to `sys.path`
- add a test that imports every `backtest` module to catch syntax or import errors
- fix pipeline smoke test by including required `next_date` column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68929a5d7834832595858f29464b6f3f