### PR TITLE
Fix syntax issues and enforce style

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,4 +1,6 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Backtest Project - 1G (T close -> T+1 close) pipeline."""
+
 from __future__ import annotations
 
 __version__ = "1.0.0"

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1,17 +1,33 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 
+
 def run_1g_returns(df_with_next: pd.DataFrame, signals: pd.DataFrame) -> pd.DataFrame:
     if signals.empty:
-        return pd.DataFrame(columns=["FilterCode","Symbol","Date","EntryClose","ExitClose","ReturnPct","Win"])
-    base = df_with_next[["symbol","date","close","next_date","next_close"]].copy()
-    merged = signals.merge(base, left_on=["Symbol","Date"], right_on=["symbol","date"], how="left")
-    merged = merged.drop(columns=["symbol","date"])
-    merged = merged.dropna(subset=["close","next_close"])
+        return pd.DataFrame(
+            columns=[
+                "FilterCode",
+                "Symbol",
+                "Date",
+                "EntryClose",
+                "ExitClose",
+                "ReturnPct",
+                "Win",
+            ]
+        )
+    base = df_with_next[["symbol", "date", "close", "next_date", "next_close"]].copy()
+    merged = signals.merge(
+        base, left_on=["Symbol", "Date"], right_on=["symbol", "date"], how="left"
+    )
+    merged = merged.drop(columns=["symbol", "date"])
+    merged = merged.dropna(subset=["close", "next_close"])
     merged["EntryClose"] = merged["close"]
     merged["ExitClose"] = merged["next_close"]
     merged["ReturnPct"] = (merged["ExitClose"] / merged["EntryClose"] - 1.0) * 100.0
     merged["Win"] = merged["ReturnPct"] > 0.0
-    out = merged[["FilterCode","Symbol","Date","EntryClose","ExitClose","ReturnPct","Win"]].copy()
+    out = merged[
+        ["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win"]
+    ].copy()
     return out

--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,7 +1,8 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
-import io, csv
+
 
 def _read_csv_any(path: str) -> pd.DataFrame:
     # Try default, then ; separator, decimal comma
@@ -14,17 +15,27 @@ def _read_csv_any(path: str) -> pd.DataFrame:
         dec = "," if sample.count(",") > sample.count(".") and sep == ";" else "."
         return pd.read_csv(path, sep=sep, decimal=dec)
 
+
 def load_xu100_pct(csv_path: str) -> pd.Series:
     df = _read_csv_any(csv_path)
     cols = {c.lower().strip(): c for c in df.columns}
     # date column
     c_date = cols.get("date") or cols.get("tarih") or list(df.columns)[0]
     # close-like column
-    cand = ["close","kapanış","kapanis","adjclose","adj_close","kapanis_tl","fiyat"]
+    cand = [
+        "close",
+        "kapanış",
+        "kapanis",
+        "adjclose",
+        "adj_close",
+        "kapanis_tl",
+        "fiyat",
+    ]
     close_col = None
     for k in cand:
         if k in cols:
-            close_col = cols[k]; break
+            close_col = cols[k]
+            break
     if close_col is None:
         # fallback: second column
         close_col = list(df.columns)[1]

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -1,28 +1,37 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 from typing import Optional, Set, Iterable
 
+
 def add_next_close(df: pd.DataFrame) -> pd.DataFrame:
     """Price-driven next bar (symbol-based)."""
-    df = df.copy().sort_values(["symbol","date"])
+    df = df.copy().sort_values(["symbol", "date"])
     df["next_date"] = df.groupby("symbol")["date"].shift(-1)
     df["next_close"] = df.groupby("symbol")["close"].shift(-1)
     return df
 
+
 def load_holidays_csv(path: str) -> Set[pd.Timestamp]:
-    """Read holiday CSV with a 'date' column (case-insens.), return set of Timestamps (date only)."""
+    """Read holiday CSV with a 'date' column (case-insens.),
+    return set of Timestamps (date only)."""
     h = pd.read_csv(path)
     cols = {c.lower(): c for c in h.columns}
     c_date = cols.get("date") or list(h.columns)[0]
     h[c_date] = pd.to_datetime(h[c_date]).dt.normalize()
     return set(h[c_date].unique())
 
+
 def is_weekend(ts: pd.Timestamp) -> bool:
     return ts.weekday() >= 5  # 5=Sat,6=Sun
 
-def build_trading_days(df: pd.DataFrame, holidays: Optional[Iterable[pd.Timestamp]] = None) -> pd.DatetimeIndex:
-    """Build calendar trading days from min..max of df, excluding weekends and holidays."""
+
+def build_trading_days(
+    df: pd.DataFrame, holidays: Optional[Iterable[pd.Timestamp]] = None
+) -> pd.DatetimeIndex:
+    """Build calendar trading days from min..max of df, excluding weekends
+    and holidays."""
     if df.empty:
         return pd.DatetimeIndex([])
     start = pd.to_datetime(df["date"]).min()
@@ -32,20 +41,28 @@ def build_trading_days(df: pd.DataFrame, holidays: Optional[Iterable[pd.Timestam
     trade = [d for d in all_days if (not is_weekend(d)) and (d.normalize() not in hol)]
     return pd.DatetimeIndex(trade)
 
-def add_next_close_calendar(df: pd.DataFrame, trading_days: pd.DatetimeIndex) -> pd.DataFrame:
+
+def add_next_close_calendar(
+    df: pd.DataFrame, trading_days: pd.DatetimeIndex
+) -> pd.DataFrame:
     """Calendar-driven next business day: next_date = next trading day (global).
-    next_close is taken from symbol's close at that date; if missing, remains NaN (no trade possible)."""
-    df = df.copy().sort_values(["symbol","date"])
+    next_close is taken from symbol's close at that date; if missing,
+    remains NaN (no trade possible).
+    """
+    df = df.copy().sort_values(["symbol", "date"])
     # map current date -> next trading day
     td = pd.Series(trading_days[1:].values, index=trading_days[:-1]).to_dict()
     dates = pd.to_datetime(df["date"])
     next_dates = dates.apply(lambda d: td.get(pd.Timestamp(d).normalize(), pd.NaT))
     df["next_date"] = next_dates.dt.date
     # merge to get next_close for same symbol & next_date
-    base = df[["symbol","date","close"]].copy()
-    base.columns = ["symbol","date","close_curr"]
+    base = df[["symbol", "date", "close"]].copy()
+    base.columns = ["symbol", "date", "close_curr"]
     # align df next_date with base date to pick next_close
-    m = df.merge(base.rename(columns={"date":"next_date","close_curr":"next_close"}),
-                 on=["symbol","next_date"], how="left")
+    m = df.merge(
+        base.rename(columns={"date": "next_date", "close_curr": "next_close"}),
+        on=["symbol", "next_date"],
+        how="left",
+    )
     df["next_close"] = m["next_close"].values
     return df

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -1,10 +1,19 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-import click, os, pandas as pd
+import os
+
+import click
+import pandas as pd
 from .config import load_config
 from .data_loader import read_excels_long
 from .normalizer import normalize
-from .calendars import add_next_close, add_next_close_calendar, build_trading_days, load_holidays_csv
+from .calendars import (
+    add_next_close,
+    add_next_close_calendar,
+    build_trading_days,
+    load_holidays_csv,
+)
 from .indicators import compute_indicators
 from .screener import run_screener
 from .backtester import run_1g_returns
@@ -13,9 +22,11 @@ from .reporter import write_reports
 from .utils import info
 from .validator import dataset_summary, quality_warnings
 
+
 @click.group()
 def cli():
     pass
+
 
 @cli.command("scan-range")
 @click.option("--config", "config_path", required=True, help="YAML config yolu")
@@ -23,8 +34,10 @@ def cli():
 @click.option("--end", "end_date", required=False, default=None, help="YYYY-MM-DD")
 def scan_range(config_path, start_date, end_date):
     cfg = load_config(config_path)
-    if start_date: cfg.project.start_date = start_date
-    if end_date: cfg.project.end_date = end_date
+    if start_date:
+        cfg.project.start_date = start_date
+    if end_date:
+        cfg.project.end_date = end_date
     info("Excelleri okuyor...")
     df = read_excels_long(cfg)
     df = normalize(df)
@@ -40,12 +53,22 @@ def scan_range(config_path, start_date, end_date):
     df_ind = compute_indicators(df, cfg.indicators.params)
     info("Filtre CSV okunuyor...")
     filters_df = pd.read_csv(cfg.data.filters_csv)
-    req = {"FilterCode","PythonQuery"}
+    req = {"FilterCode", "PythonQuery"}
     if not req.issubset(set(filters_df.columns)):
-        raise RuntimeError("filters CSV: 'FilterCode' ve 'PythonQuery' kolonlarını içermeli")
+        raise RuntimeError(
+            "filters CSV: 'FilterCode' ve 'PythonQuery' kolonlarını içermeli"
+        )
     all_days = sorted(pd.to_datetime(df_ind["date"]).dt.date.unique())
-    start = pd.to_datetime(cfg.project.start_date).date() if cfg.project.start_date else all_days[0]
-    end = pd.to_datetime(cfg.project.end_date).date() if cfg.project.end_date else all_days[-1]
+    start = (
+        pd.to_datetime(cfg.project.start_date).date()
+        if cfg.project.start_date
+        else all_days[0]
+    )
+    end = (
+        pd.to_datetime(cfg.project.end_date).date()
+        if cfg.project.end_date
+        else all_days[-1]
+    )
     days = [d for d in all_days if start <= d <= end]
     all_trades = []
     info(f"{len(days)} gün taranacak...")
@@ -53,18 +76,42 @@ def scan_range(config_path, start_date, end_date):
         sigs = run_screener(df_ind, filters_df, d)
         trades = run_1g_returns(df_ind, sigs)
         all_trades.append(trades)
-    trades_all = pd.concat(all_trades, ignore_index=True) if all_trades else pd.DataFrame(columns=["FilterCode","Symbol","Date","EntryClose","ExitClose","ReturnPct","Win"])
+    trades_all = (
+        pd.concat(all_trades, ignore_index=True)
+        if all_trades
+        else pd.DataFrame(
+            columns=[
+                "FilterCode",
+                "Symbol",
+                "Date",
+                "EntryClose",
+                "ExitClose",
+                "ReturnPct",
+                "Win",
+            ]
+        )
+    )
     if not trades_all.empty:
-        pivot = trades_all.groupby(["FilterCode","Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+        pivot = (
+            trades_all.groupby(["FilterCode", "Date"])["ReturnPct"]
+            .mean()
+            .unstack(fill_value=float("nan"))
+        )
         pivot["Ortalama"] = pivot.mean(axis=1)
-        winrate = trades_all.groupby(["FilterCode","Date"])["Win"].mean().unstack(fill_value=float("nan"))
+        winrate = (
+            trades_all.groupby(["FilterCode", "Date"])["Win"]
+            .mean()
+            .unstack(fill_value=float("nan"))
+        )
         winrate["Ortalama"] = winrate.mean(axis=1)
     else:
         pivot = pd.DataFrame()
     xu100_pct = None
     if cfg.benchmark.xu100_source == "csv" and cfg.benchmark.xu100_csv_path:
         s = load_xu100_pct(cfg.benchmark.xu100_csv_path)
-        xu100_pct = {d: float(s.get(d, float("nan"))) for d in pivot.columns if d != "Ortalama"}
+        xu100_pct = {
+            d: float(s.get(d, float("nan"))) for d in pivot.columns if d != "Ortalama"
+        }
     out_dir = cfg.project.out_dir
     os.makedirs(out_dir, exist_ok=True)
     out_xlsx = os.path.join(out_dir, f"{start}_{end}_1G_BIST100.xlsx")
@@ -72,11 +119,22 @@ def scan_range(config_path, start_date, end_date):
     info("Raporlar yazılıyor...")
     val_sum = dataset_summary(df)
     val_iss = quality_warnings(df)
-    write_reports(trades_all, days, pivot, xu100_pct, out_xlsx=out_xlsx, out_csv_dir=out_csv_dir,
-                  validation_summary=val_sum, validation_issues=val_iss, summary_winrate=winrate,
-                  daily_sheet_prefix=cfg.report.daily_sheet_prefix, summary_sheet_name=cfg.report.summary_sheet_name,
-                  percent_fmt=cfg.report.percent_format)
+    write_reports(
+        trades_all,
+        days,
+        pivot,
+        xu100_pct,
+        out_xlsx=out_xlsx,
+        out_csv_dir=out_csv_dir,
+        validation_summary=val_sum,
+        validation_issues=val_iss,
+        summary_winrate=winrate,
+        daily_sheet_prefix=cfg.report.daily_sheet_prefix,
+        summary_sheet_name=cfg.report.summary_sheet_name,
+        percent_fmt=cfg.report.percent_format,
+    )
     info(f"Bitti. Çıktı: {out_xlsx}")
+
 
 @cli.command("scan-day")
 @click.option("--config", "config_path", required=True)
@@ -100,9 +158,11 @@ def scan_day(config_path, date_str):
     df_ind = compute_indicators(df, cfg.indicators.params)
     info("Filtre CSV okunuyor...")
     filters_df = pd.read_csv(cfg.data.filters_csv)
-    req = {"FilterCode","PythonQuery"}
+    req = {"FilterCode", "PythonQuery"}
     if not req.issubset(set(filters_df.columns)):
-        raise RuntimeError("filters CSV: 'FilterCode' ve 'PythonQuery' kolonlarını içermeli")
+        raise RuntimeError(
+            "filters CSV: 'FilterCode' ve 'PythonQuery' kolonlarını içermeli"
+        )
     day = pd.to_datetime(date_str).date()
     sigs = run_screener(df_ind, filters_df, day)
     trades = run_1g_returns(df_ind, sigs)
@@ -111,23 +171,42 @@ def scan_day(config_path, date_str):
         s = load_xu100_pct(cfg.benchmark.xu100_csv_path)
         xu100_pct = {day: float(s.get(day, float("nan")))}
     if not trades.empty:
-        pivot = trades.groupby(["FilterCode","Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+        pivot = (
+            trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+            .mean()
+            .unstack(fill_value=float("nan"))
+        )
         pivot["Ortalama"] = pivot.mean(axis=1)
-        winrate = trades.groupby(["FilterCode","Date"])["Win"].mean().unstack(fill_value=float("nan"))
+        winrate = (
+            trades.groupby(["FilterCode", "Date"])["Win"]
+            .mean()
+            .unstack(fill_value=float("nan"))
+        )
         winrate["Ortalama"] = winrate.mean(axis=1)
     else:
-        pivot = pd.DataFrame(columns=[day,"Ortalama"])
+        pivot = pd.DataFrame(columns=[day, "Ortalama"])
     out_dir = cfg.project.out_dir
     os.makedirs(out_dir, exist_ok=True)
     out_xlsx = os.path.join(out_dir, f"SCAN_{day}.xlsx")
     info("Raporlar yazılıyor...")
     val_sum = dataset_summary(df)
     val_iss = quality_warnings(df)
-    write_reports(trades, [day], pivot, xu100_pct, out_xlsx=out_xlsx, out_csv_dir=None,
-                  validation_summary=val_sum, validation_issues=val_iss, summary_winrate=winrate,
-                  daily_sheet_prefix=cfg.report.daily_sheet_prefix, summary_sheet_name=cfg.report.summary_sheet_name,
-                  percent_fmt=cfg.report.percent_format)
+    write_reports(
+        trades,
+        [day],
+        pivot,
+        xu100_pct,
+        out_xlsx=out_xlsx,
+        out_csv_dir=None,
+        validation_summary=val_sum,
+        validation_issues=val_iss,
+        summary_winrate=winrate,
+        daily_sheet_prefix=cfg.report.daily_sheet_prefix,
+        summary_sheet_name=cfg.report.summary_sheet_name,
+        percent_fmt=cfg.report.percent_format,
+    )
     info(f"Bitti. Çıktı: {out_xlsx}")
+
 
 if __name__ == "__main__":
     cli()

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -1,8 +1,10 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional
-import yaml, os
+import yaml
+
 
 class ProjectCfg(BaseModel):
     out_dir: str = "raporlar"
@@ -11,36 +13,41 @@ class ProjectCfg(BaseModel):
     end_date: Optional[str] = None
     single_date: Optional[str] = None
 
+
 class DataCfg(BaseModel):
     excel_dir: str
     filters_csv: str
     enable_cache: bool = False
     cache_parquet_path: Optional[str] = None
-    price_schema: Dict[str, List[str]] = Field(default_factory=lambda: {
-        "date": ["Tarih","Date","tarih"],
-        "open": ["Açılış","Acılıs","Open","Acilis"],
-        "high": ["Yüksek","Yuksek","High"],
-        "low": ["Düşük","Dusuk","Low"],
-        "close": ["Kapanış","Close"],
-        "volume": ["Hacim","Volume","Adet"],
-    })
+    price_schema: Dict[str, List[str]] = Field(
+        default_factory=lambda: {
+            "date": ["Tarih", "Date", "tarih"],
+            "open": ["Açılış", "Acılıs", "Open", "Acilis"],
+            "high": ["Yüksek", "Yuksek", "High"],
+            "low": ["Düşük", "Dusuk", "Low"],
+            "close": ["Kapanış", "Close"],
+            "volume": ["Hacim", "Volume", "Adet"],
+        }
+    )
+
 
 class CalendarCfg(BaseModel):
     tplus1_mode: str = "price"  # price | calendar
     holidays_source: str = "none"  # none | csv
     holidays_csv_path: Optional[str] = None
 
+
 class IndicatorsCfg(BaseModel):
     engine: str = "pandas_ta"  # pandas_ta | ta_lib
-    params: Dict[str, List[int]] = Field(default_factory=lambda: {
-        "rsi":[14],
-        "ema":[10,20,50],
-        "macd":[12,26,9]
-    })
+    params: Dict[str, List[int]] = Field(
+        default_factory=lambda: {"rsi": [14], "ema": [10, 20, 50], "macd": [12, 26, 9]}
+    )
+
 
 class BenchmarkCfg(BaseModel):
-    xu100_source: str = "none"   # csv | none
+    xu100_source: str = "none"  # csv | none
     xu100_csv_path: Optional[str] = None
+
 
 class ReportCfg(BaseModel):
     excel: bool = True
@@ -49,6 +56,7 @@ class ReportCfg(BaseModel):
     daily_sheet_prefix: str = "SCAN_"
     summary_sheet_name: str = "SUMMARY"
 
+
 class RootCfg(BaseModel):
     project: ProjectCfg
     data: DataCfg
@@ -56,6 +64,7 @@ class RootCfg(BaseModel):
     indicators: IndicatorsCfg = IndicatorsCfg()
     benchmark: BenchmarkCfg = BenchmarkCfg()
     report: ReportCfg = ReportCfg()
+
 
 def load_config(path: str) -> RootCfg:
     with open(path, "r", encoding="utf-8") as f:

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -1,22 +1,35 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-import re
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
-_TR_MAP = str.maketrans({
-    "İ": "I", "I": "I",
-    "ı": "i", "Ş": "S", "ş": "s",
-    "Ğ": "G", "ğ": "g", "Ü": "U", "ü": "u",
-    "Ö": "O", "ö": "o", "Ç": "C", "ç": "c",
-})
+_TR_MAP = str.maketrans(
+    {
+        "İ": "I",
+        "I": "I",
+        "ı": "i",
+        "Ş": "S",
+        "ş": "s",
+        "Ğ": "G",
+        "ğ": "g",
+        "Ü": "U",
+        "ü": "u",
+        "Ö": "O",
+        "ö": "o",
+        "Ç": "C",
+        "ç": "c",
+    }
+)
+
 
 def re_sub(pat: str, repl: str, s: str) -> str:
     import re
+
     return re.sub(pat, repl, s)
+
 
 def normalize_key(s: str) -> str:
     if s is None:
@@ -28,6 +41,7 @@ def normalize_key(s: str) -> str:
     s = re_sub(r"_{2,}", "_", s).strip("_")
     return s
 
+
 def _first_existing(*paths: Union[str, Path]) -> Optional[Path]:
     for p in paths:
         if not p:
@@ -37,13 +51,14 @@ def _first_existing(*paths: Union[str, Path]) -> Optional[Path]:
             return p
     return None
 
+
 def _guess_excel_dir_from_cfg(cfg: Any) -> Optional[Path]:
     if cfg is None:
         return None
     try:
         cand = _first_existing(
             getattr(getattr(cfg, "data", None), "excel_dir", None),
-            getattr(getattr(cfg, "data", None), "path",       None),
+            getattr(getattr(cfg, "data", None), "path", None),
             getattr(cfg, "data_path", None),
         )
         if cand:
@@ -59,16 +74,38 @@ def _guess_excel_dir_from_cfg(cfg: Any) -> Optional[Path]:
         pass
     return None
 
+
 COL_ALIASES: Dict[str, str] = {
-    "date": "date", "tarih": "date", "tarihi": "date",
-    "open": "open", "acilis": "open", "açilis": "open", "açilis_fiyati": "open", "açilis_fiyati_": "open",
-    "high": "high", "yuksek": "high", "yüksek": "high",
-    "low" : "low" , "dusuk" : "low" , "düşük" : "low" ,
-    "close":"close","kapanis":"close","kapanış":"close","son":"close","son_fiyat":"close","adj_close":"close",
-    "volume":"volume","hacim":"volume","islem_hacmi":"volume","işlem_hacmi":"volume",
-    "adet":"volume", "lot":"volume",
-    "kapanis_fiyati":"close","kapanis_fiyat":"close",
+    "date": "date",
+    "tarih": "date",
+    "tarihi": "date",
+    "open": "open",
+    "acilis": "open",
+    "açilis": "open",
+    "açilis_fiyati": "open",
+    "açilis_fiyati_": "open",
+    "high": "high",
+    "yuksek": "high",
+    "yüksek": "high",
+    "low": "low",
+    "dusuk": "low",
+    "düşük": "low",
+    "close": "close",
+    "kapanis": "close",
+    "kapanış": "close",
+    "son": "close",
+    "son_fiyat": "close",
+    "adj_close": "close",
+    "volume": "volume",
+    "hacim": "volume",
+    "islem_hacmi": "volume",
+    "işlem_hacmi": "volume",
+    "adet": "volume",
+    "lot": "volume",
+    "kapanis_fiyati": "close",
+    "kapanis_fiyat": "close",
 }
+
 
 def normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
     rename_map = {}
@@ -78,10 +115,13 @@ def normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
         rename_map[c] = std
     return df.rename(columns=rename_map)
 
-def read_excels_long(cfg_or_path: Union[str, Path, Any],
-                     dayfirst: bool = True,
-                     engine: str = "openpyxl",
-                     verbose: bool = False) -> pd.DataFrame:
+
+def read_excels_long(
+    cfg_or_path: Union[str, Path, Any],
+    dayfirst: bool = True,
+    engine: str = "openpyxl",
+    verbose: bool = False,
+) -> pd.DataFrame:
     if isinstance(cfg_or_path, (str, Path)):
         excel_dir = Path(cfg_or_path)
     else:
@@ -115,10 +155,16 @@ def read_excels_long(cfg_or_path: Union[str, Path, Any],
                         print(f"[SKIP] {fpath}:{sheet} 'date' bulunamadı.")
                     continue
 
-                df["date"] = pd.to_datetime(df["date"], errors="coerce", dayfirst=dayfirst)
+                df["date"] = pd.to_datetime(
+                    df["date"], errors="coerce", dayfirst=dayfirst
+                )
                 df = df.dropna(subset=["date"])
 
-                keep = [c for c in ["open","high","low","close","volume"] if c in df.columns]
+                keep = [
+                    c
+                    for c in ["open", "high", "low", "close", "volume"]
+                    if c in df.columns
+                ]
                 df = df[["date", *keep]].copy()
                 for c in keep:
                     df[c] = pd.to_numeric(df[c], errors="coerce")
@@ -138,5 +184,6 @@ def read_excels_long(cfg_or_path: Union[str, Path, Any],
     if "close" in full.columns:
         full = full.dropna(subset=["close"])
     return full
+
 
 __all__ = ["read_excels_long", "normalize_key", "normalize_columns"]

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -1,22 +1,24 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 from typing import Dict, List
 import pandas_ta as ta
 
-def compute_indicators(df: pd.DataFrame, params: Dict[str,List[int]]) -> pd.DataFrame:
+
+def compute_indicators(df: pd.DataFrame, params: Dict[str, List[int]]) -> pd.DataFrame:
     df = df.copy()
-    df = df.sort_values(["symbol","date"])
+    df = df.sort_values(["symbol", "date"])
     out_frames = []
     for sym, g in df.groupby("symbol", group_keys=False):
         g = g.copy()
-        for p in params.get("ema", [10,20,50]):
+        for p in params.get("ema", [10, 20, 50]):
             col = f"EMA_{p}"
             g[col] = ta.ema(g["close"], length=int(p))
         for p in params.get("rsi", [14]):
             col = f"RSI_{p}"
             g[col] = ta.rsi(g["close"], length=int(p))
-        macd_params = params.get("macd", [12,26,9])
+        macd_params = params.get("macd", [12, 26, 9])
         if len(macd_params) >= 3:
             fast, slow, sig = map(int, macd_params[:3])
             macd = ta.macd(g["close"], fast=fast, slow=slow, signal=sig)
@@ -35,19 +37,19 @@ def compute_indicators(df: pd.DataFrame, params: Dict[str,List[int]]) -> pd.Data
         if low not in df2.columns:
             df2[low] = df2[c]
     alias_map = {
-        "rsi_14":"RSI_14",
-        "ema_10":"EMA_10",
-        "ema_20":"EMA_20",
-        "ema_50":"EMA_50",
-        "macd_12_26_9_hist":"MACD_12_26_9_HIST",
-        "change_1d_percent":"CHANGE_1D_PERCENT",
-        "change_1w_percent":"CHANGE_5D_PERCENT",
-        "relative_volume":"RELATIVE_VOLUME",
+        "rsi_14": "RSI_14",
+        "ema_10": "EMA_10",
+        "ema_20": "EMA_20",
+        "ema_50": "EMA_50",
+        "macd_12_26_9_hist": "MACD_12_26_9_HIST",
+        "change_1d_percent": "CHANGE_1D_PERCENT",
+        "change_1w_percent": "CHANGE_5D_PERCENT",
+        "relative_volume": "RELATIVE_VOLUME",
     }
     alias_map_extra = {
-        "degisim_1g_yuzde":"CHANGE_1D_PERCENT",
-        "degisim_5g_yuzde":"CHANGE_5D_PERCENT",
-        "hacim_goreli":"RELATIVE_VOLUME",
+        "degisim_1g_yuzde": "CHANGE_1D_PERCENT",
+        "degisim_5g_yuzde": "CHANGE_5D_PERCENT",
+        "hacim_goreli": "RELATIVE_VOLUME",
     }
     alias_map.update(alias_map_extra)
     for low, up in alias_map.items():

--- a/backtest/normalizer.py
+++ b/backtest/normalizer.py
@@ -1,16 +1,22 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 
+
 def normalize(df: pd.DataFrame) -> pd.DataFrame:
-    need = ["symbol","date","open","high","low","close","volume"]
+    need = ["symbol", "date", "open", "high", "low", "close", "volume"]
     for n in need:
         if n not in df.columns:
             raise RuntimeError(f"Eksik zorunlu kolon: {n}")
     df = df.copy()
     df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
     df["date"] = pd.to_datetime(df["date"]).dt.date
-    for c in ["open","high","low","close","volume"]:
+    for c in ["open", "high", "low", "close", "volume"]:
         df[c] = pd.to_numeric(df[c], errors="coerce")
-    df = df.dropna(subset=["close"]).sort_values(["symbol","date"]).drop_duplicates(["symbol","date"])
+    df = (
+        df.dropna(subset=["close"])
+        .sort_values(["symbol", "date"])
+        .drop_duplicates(["symbol", "date"])
+    )
     return df.reset_index(drop=True)

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -1,17 +1,30 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-import os, pandas as pd
-from typing import List, Dict, Optional
+import os
+from typing import Dict, List, Optional
+
+import pandas as pd
+
 
 def _ensure_dir(path: str):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
-def write_reports(trades_all: pd.DataFrame, dates: List, summary_wide: pd.DataFrame,
-                  xu100_pct: Dict = None, out_xlsx: str = None, out_csv_dir: str = None,
-                  daily_sheet_prefix: str = "SCAN_", summary_sheet_name: str = "SUMMARY",
-                  percent_fmt: str = "0.00%", summary_winrate: Optional[pd.DataFrame] = None,
-                  validation_summary: Optional[pd.DataFrame] = None,
-                  validation_issues: Optional[pd.DataFrame] = None):
+
+def write_reports(
+    trades_all: pd.DataFrame,
+    dates: List,
+    summary_wide: pd.DataFrame,
+    xu100_pct: Dict = None,
+    out_xlsx: str = None,
+    out_csv_dir: str = None,
+    daily_sheet_prefix: str = "SCAN_",
+    summary_sheet_name: str = "SUMMARY",
+    percent_fmt: str = "0.00%",
+    summary_winrate: Optional[pd.DataFrame] = None,
+    validation_summary: Optional[pd.DataFrame] = None,
+    validation_issues: Optional[pd.DataFrame] = None,
+):
     """Write daily/summary and optional sheets.
     - SUMMARY: ReturnPct ortalamaları (sayısal 0.00 -> yüzde puan)
     - SUMMARY_WINRATE: Win-rate (0..1) (% format)
@@ -23,14 +36,16 @@ def write_reports(trades_all: pd.DataFrame, dates: List, summary_wide: pd.DataFr
         with pd.ExcelWriter(out_xlsx, engine="xlsxwriter") as writer:
             for d in dates:
                 day_df = trades_all[trades_all["Date"] == d].copy()
-                day_df = day_df.sort_values(["FilterCode","Symbol"])
+                day_df = day_df.sort_values(["FilterCode", "Symbol"])
                 sheet = f"{daily_sheet_prefix}{d}"
                 day_df.to_excel(writer, sheet_name=sheet, index=False)
 
             summary_wide.to_excel(writer, sheet_name=summary_sheet_name)
 
             if summary_winrate is not None and not summary_winrate.empty:
-                summary_winrate.to_excel(writer, sheet_name=f"{summary_sheet_name}_WINRATE")
+                summary_winrate.to_excel(
+                    writer, sheet_name=f"{summary_sheet_name}_WINRATE"
+                )
 
             if xu100_pct:
                 cols = [c for c in summary_wide.columns if c != "Ortalama"]
@@ -40,20 +55,34 @@ def write_reports(trades_all: pd.DataFrame, dates: List, summary_wide: pd.DataFr
                         diff[c] = diff[c] - float(xu100_pct[c])
                     diff["Ortalama"] = diff[cols].mean(axis=1)
                     diff.to_excel(writer, sheet_name=f"{summary_sheet_name}_DIFF")
-                bist = pd.DataFrame([ [xu100_pct.get(c, float('nan')) for c in cols] + [pd.Series(list(xu100_pct.values())).mean()] ],
-                                    index=["BIST"], columns=cols+["Ortalama"]) if cols else pd.DataFrame()
+                bist = (
+                    pd.DataFrame(
+                        [
+                            [xu100_pct.get(c, float("nan")) for c in cols]
+                            + [pd.Series(list(xu100_pct.values())).mean()]
+                        ],
+                        index=["BIST"],
+                        columns=cols + ["Ortalama"],
+                    )
+                    if cols
+                    else pd.DataFrame()
+                )
                 if not bist.empty:
                     bist.to_excel(writer, sheet_name="BIST")
 
             # Optional validation
             if validation_summary is not None and not validation_summary.empty:
-                validation_summary.to_excel(writer, sheet_name="VALIDATION_SUMMARY", index=False)
+                validation_summary.to_excel(
+                    writer, sheet_name="VALIDATION_SUMMARY", index=False
+                )
             if validation_issues is not None and not validation_issues.empty:
-                validation_issues.to_excel(writer, sheet_name="VALIDATION_ISSUES", index=False)
+                validation_issues.to_excel(
+                    writer, sheet_name="VALIDATION_ISSUES", index=False
+                )
 
             wb = writer.book
-            num_fmt = wb.add_format({'num_format': '0.00'})
-            pct_fmt = wb.add_format({'num_format': percent_fmt})
+            num_fmt = wb.add_format({"num_format": "0.00"})
+            pct_fmt = wb.add_format({"num_format": percent_fmt})
 
             for d in dates:
                 sheet = f"{daily_sheet_prefix}{d}"
@@ -62,7 +91,7 @@ def write_reports(trades_all: pd.DataFrame, dates: List, summary_wide: pd.DataFr
                 ws.set_column(3, 4, 12)
                 ws.set_column(5, 5, 10, num_fmt)
                 ws.set_column(6, 6, 8)
-                ws.autofilter(0, 0, len(trades_all[trades_all["Date"]==d]), 6)
+                ws.autofilter(0, 0, len(trades_all[trades_all["Date"] == d]), 6)
 
             if summary_sheet_name in writer.sheets:
                 ws = writer.sheets[summary_sheet_name]
@@ -85,6 +114,10 @@ def write_reports(trades_all: pd.DataFrame, dates: List, summary_wide: pd.DataFr
         if summary_winrate is not None and not summary_winrate.empty:
             summary_winrate.to_csv(os.path.join(out_csv_dir, "summary_winrate.csv"))
         if validation_summary is not None and not validation_summary.empty:
-            validation_summary.to_csv(os.path.join(out_csv_dir, "validation_summary.csv"), index=False)
+            validation_summary.to_csv(
+                os.path.join(out_csv_dir, "validation_summary.csv"), index=False
+            )
         if validation_issues is not None and not validation_issues.empty:
-            validation_issues.to_csv(os.path.join(out_csv_dir, "validation_issues.csv"), index=False)
+            validation_issues.to_csv(
+                os.path.join(out_csv_dir, "validation_issues.csv"), index=False
+            )

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -1,7 +1,9 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 import re
+
 
 def _to_pandas_ops(expr: str) -> str:
     expr = re.sub(r"\bAND\b", "&", expr, flags=re.I)
@@ -9,32 +11,39 @@ def _to_pandas_ops(expr: str) -> str:
     expr = re.sub(r"\bNOT\b", "~", expr, flags=re.I)
     return expr
 
+
 def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.DataFrame:
     day = pd.to_datetime(date).date()
     d = df_ind[df_ind["date"] == day].copy()
     if d.empty:
-        return pd.DataFrame(columns=["FilterCode","Symbol","Date","mask"])
+        return pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "mask"])
     d = d.reset_index(drop=True)
     local_vars = {c: d[c] for c in d.columns}
-    local_vars.update({
-        "close": d["close"],
-        "open": d["open"],
-        "high": d["high"],
-        "low": d["low"],
-        "volume": d["volume"],
-    })
+    local_vars.update(
+        {
+            "close": d["close"],
+            "open": d["open"],
+            "high": d["high"],
+            "low": d["low"],
+            "volume": d["volume"],
+        }
+    )
     out_rows = []
     for _, row in filters_df.iterrows():
         code = str(row["FilterCode"]).strip()
         expr = str(row["PythonQuery"])
         expr = _to_pandas_ops(expr)
         try:
-            mask = pd.eval(expr, local_dict=local_vars, engine="python", parser="pandas")
+            mask = pd.eval(
+                expr, local_dict=local_vars, engine="python", parser="pandas"
+            )
             mask = mask.fillna(False)
             hits = d[mask].copy()
             if not hits.empty:
                 for sym in hits["symbol"]:
-                    out_rows.append({"FilterCode": code, "Symbol": sym, "Date": day, "mask": True})
-        except Exception as e:
+                    out_rows.append(
+                        {"FilterCode": code, "Symbol": sym, "Date": day, "mask": True}
+                    )
+        except Exception:
             continue
     return pd.DataFrame(out_rows)

--- a/backtest/utils.py
+++ b/backtest/utils.py
@@ -1,30 +1,43 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from loguru import logger
 from pathlib import Path
+import re
+import unicodedata
+
+from loguru import logger
+
 
 def ensure_dir(path: str):
     Path(path).parent.mkdir(parents=True, exist_ok=True)
 
+
 def info(msg: str):
     logger.info(msg)
 
-
-import unicodedata, re
 
 def normalize_key(s: str) -> str:
     if s is None:
         return ""
     s = str(s).strip()
     # Map Turkish specific chars to ASCII-ish
-    table = str.maketrans({
-        "İ": "I", "I": "I", "ı": "i",
-        "Ş": "S", "ş": "s",
-        "Ğ": "G", "ğ": "g",
-        "Ü": "U", "ü": "u",
-        "Ö": "O", "ö": "o",
-        "Ç": "C", "ç": "c",
-    })
+    table = str.maketrans(
+        {
+            "İ": "I",
+            "I": "I",
+            "ı": "i",
+            "Ş": "S",
+            "ş": "s",
+            "Ğ": "G",
+            "ğ": "g",
+            "Ü": "U",
+            "ü": "u",
+            "Ö": "O",
+            "ö": "o",
+            "Ç": "C",
+            "ç": "c",
+        }
+    )
     s = s.translate(table)
     s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
     s = s.lower()

--- a/backtest/validator.py
+++ b/backtest/validator.py
@@ -1,33 +1,61 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 
+
 def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:
-    """Return simple stats per symbol: first/last date, rows, NA close count, dup count."""
+    """Return simple stats per symbol: first/last date, rows, NA close
+    count, dup count."""
     if df.empty:
-        return pd.DataFrame(columns=["symbol","rows","first_date","last_date","na_close","dup_symbol_date"])
-    dup = df.duplicated(["symbol","date"]).groupby(df["symbol"]).sum()
+        return pd.DataFrame(
+            columns=[
+                "symbol",
+                "rows",
+                "first_date",
+                "last_date",
+                "na_close",
+                "dup_symbol_date",
+            ]
+        )
+    dup = df.duplicated(["symbol", "date"]).groupby(df["symbol"]).sum()
     na_close = df["close"].isna().groupby(df["symbol"]).sum()
     grp = df.groupby("symbol")
-    out = grp.agg(rows=("date","size"),
-                  first_date=("date","min"),
-                  last_date=("date","max")).reset_index()
+    out = grp.agg(
+        rows=("date", "size"), first_date=("date", "min"), last_date=("date", "max")
+    ).reset_index()
     out["na_close"] = out["symbol"].map(na_close).fillna(0).astype(int)
     out["dup_symbol_date"] = out["symbol"].map(dup).fillna(0).astype(int)
     return out.sort_values("symbol").reset_index(drop=True)
 
+
 def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
-    """Return row-level issues for quick inspection (date order, negative prices, etc.)."""
+    """Return row-level issues for quick inspection (date order, negative
+    prices, etc.)."""
     issues = []
     if df.empty:
-        return pd.DataFrame(columns=["symbol","date","issue","value"])
-    g = df.sort_values(["symbol","date"]).groupby("symbol")
+        return pd.DataFrame(columns=["symbol", "date", "issue", "value"])
+    g = df.sort_values(["symbol", "date"]).groupby("symbol")
     for sym, x in g:
         # non-monotonic date
         if not x["date"].is_monotonic_increasing:
-            issues.append({"symbol": sym, "date": None, "issue": "non_monotonic_dates", "value": ""})
+            issues.append(
+                {
+                    "symbol": sym,
+                    "date": None,
+                    "issue": "non_monotonic_dates",
+                    "value": "",
+                }
+            )
         # negative/zero close
         bad = x[x["close"] <= 0]
         for _, r in bad.iterrows():
-            issues.append({"symbol": sym, "date": r["date"], "issue": "non_positive_close", "value": r["close"]})
+            issues.append(
+                {
+                    "symbol": sym,
+                    "date": r["date"],
+                    "issue": "non_positive_close",
+                    "value": r["close"],
+                }
+            )
     return pd.DataFrame(issues)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import sys

--- a/tests/test_backtest_imports.py
+++ b/tests/test_backtest_imports.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import importlib

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,16 +1,26 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 from backtest.backtester import run_1g_returns
 
+
 def test_backtester_basic():
-    df = pd.DataFrame({
-        "symbol":["AAA","AAA"],
-        "date":pd.to_datetime(["2024-01-05","2024-01-08"]).date,
-        "close":[10.0, 11.0],
-        "next_close":[11.0, None],
-        "next_date":pd.to_datetime(["2024-01-08","2024-01-09"]).date,
-    })
-    sigs = pd.DataFrame({"FilterCode":["T1"],"Symbol":["AAA"],"Date":[pd.to_datetime("2024-01-05").date()]})
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).date,
+            "close": [10.0, 11.0],
+            "next_close": [11.0, None],
+            "next_date": pd.to_datetime(["2024-01-08", "2024-01-09"]).date,
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "Symbol": ["AAA"],
+            "Date": [pd.to_datetime("2024-01-05").date()],
+        }
+    )
     out = run_1g_returns(df, sigs)
-    assert round(out.loc[0,"ReturnPct"],2) == 10.0
+    assert round(out.loc[0, "ReturnPct"], 2) == 10.0

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,18 +1,22 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 from backtest.calendars import add_next_close
 
+
 def test_next_close():
-    df = pd.DataFrame({
-        "symbol":["AAA","AAA","AAA"],
-        "date":pd.to_datetime(["2024-01-05","2024-01-08","2024-01-09"]).date,
-        "close":[10, 11, 11.5],
-        "open":[0,0,0],
-        "high":[0,0,0],
-        "low":[0,0,0],
-        "volume":[1,1,1]
-    })
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08", "2024-01-09"]).date,
+            "close": [10, 11, 11.5],
+            "open": [0, 0, 0],
+            "high": [0, 0, 0],
+            "low": [0, 0, 0],
+            "volume": [1, 1, 1],
+        }
+    )
     out = add_next_close(df)
-    assert out.loc[0,"next_close"] == 11
-    assert pd.isna(out.loc[2,"next_close"])
+    assert out.loc[0, "next_close"] == 11
+    assert pd.isna(out.loc[2, "next_close"])

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import ast
@@ -16,7 +17,9 @@ def _module_info(module_name: str) -> tuple[bool, bool]:
     source = Path(spec.origin).read_text(encoding="utf-8")
     tree = ast.parse(source)
     body = tree.body
-    has_docstring = bool(body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Str))
+    has_docstring = bool(
+        body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Str)
+    )
     idx = 1 if has_docstring else 0
     has_future_annotations = (
         len(body) > idx
@@ -51,5 +54,9 @@ def test_import_all_backtest_modules():
             else:
                 seen_without_doc = True
 
-    assert seen_with_doc, "Expected a module with docstring and from __future__ import annotations"
-    assert seen_without_doc, "Expected a module without docstring but with from __future__ import annotations"
+    assert (
+        seen_with_doc
+    ), "Expected a module with docstring and from __future__ import annotations"
+    assert (
+        seen_without_doc
+    ), "Expected a module without docstring but with from __future__ import annotations"

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,27 +1,33 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 from backtest.screener import run_screener
 from backtest.backtester import run_1g_returns
 
+
 def test_pipeline_smoke():
-    df = pd.DataFrame({
-        "symbol":["AAA","AAA"],
-        "date":pd.to_datetime(["2024-01-05","2024-01-08"]).date,
-        "close":[10.0, 11.0],
-        "next_close":[11.0, None],
-        "next_date":pd.to_datetime(["2024-01-08","2024-01-09"]).date,
-        "open":[10.0,11.0],
-        "high":[10.0,11.0],
-        "low":[10.0,11.0],
-        "volume":[100,120],
-        "rsi_14":[70,65],
-        "relative_volume":[1.2,0.9],
-    })
-    filters = pd.DataFrame({
-        "FilterCode":["T1"],
-        "PythonQuery":["(rsi_14 > 65) and (relative_volume > 1.0)"]
-    })
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).date,
+            "close": [10.0, 11.0],
+            "next_close": [11.0, None],
+            "next_date": pd.to_datetime(["2024-01-08", "2024-01-09"]).date,
+            "open": [10.0, 11.0],
+            "high": [10.0, 11.0],
+            "low": [10.0, 11.0],
+            "volume": [100, 120],
+            "rsi_14": [70, 65],
+            "relative_volume": [1.2, 0.9],
+        }
+    )
+    filters = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "PythonQuery": ["(rsi_14 > 65) and (relative_volume > 1.0)"],
+        }
+    )
     sigs = run_screener(df, filters, "2024-01-05")
     out = run_1g_returns(df, sigs)
     assert not out.empty

--- a/tests/test_summary_diff.py
+++ b/tests/test_summary_diff.py
@@ -1,18 +1,32 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 
+
 def test_summary_and_winrate():
-    trades = pd.DataFrame({
-        "FilterCode":["T1","T1","T1","T2","T2"],
-        "Symbol":["AAA","BBB","AAA","AAA","BBB"],
-        "Date":pd.to_datetime(["2024-01-02","2024-01-02","2024-01-03","2024-01-02","2024-01-03"]).date,
-        "ReturnPct":[ 1.0, -0.5, 2.0, 0.5, 0.0 ],
-        "Win":[ True, False, True, True, False ]
-    })
-    pivot = trades.groupby(["FilterCode","Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+    trades = pd.DataFrame(
+        {
+            "FilterCode": ["T1", "T1", "T1", "T2", "T2"],
+            "Symbol": ["AAA", "BBB", "AAA", "AAA", "BBB"],
+            "Date": pd.to_datetime(
+                ["2024-01-02", "2024-01-02", "2024-01-03", "2024-01-02", "2024-01-03"]
+            ).date,
+            "ReturnPct": [1.0, -0.5, 2.0, 0.5, 0.0],
+            "Win": [True, False, True, True, False],
+        }
+    )
+    pivot = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
+    )
     pivot["Ortalama"] = pivot.mean(axis=1)
-    winrate = trades.groupby(["FilterCode","Date"])["Win"].mean().unstack(fill_value=float("nan"))
+    winrate = (
+        trades.groupby(["FilterCode", "Date"])["Win"]
+        .mean()
+        .unstack(fill_value=float("nan"))
+    )
     winrate["Ortalama"] = winrate.mean(axis=1)
-    assert round(pivot.loc["T1"].mean(), 4) == round(pivot.loc["T1","Ortalama"], 4)
+    assert round(pivot.loc["T1"].mean(), 4) == round(pivot.loc["T1", "Ortalama"], 4)
     assert 0 <= winrate.min().min() <= 1 and 0 <= winrate.max().max() <= 1


### PR DESCRIPTION
## Summary
- tidy up imports, docstrings and spacing across modules
- add flake8 configuration for 88 char lines
- ensure all modules compile and tests pass

## Testing
- `python -m flake8`
- `python -m compileall backtest tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937301e4e08325a53fe7fc97b0897b