### PR TITLE
Organize imports

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -1,8 +1,9 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
+from typing import Iterable, Optional, Set
+
 import pandas as pd
-from typing import Optional, Set, Iterable
 
 
 def add_next_close(df: pd.DataFrame) -> pd.DataFrame:

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -5,20 +5,21 @@ import os
 
 import click
 import pandas as pd
-from .config import load_config
-from .data_loader import read_excels_long
-from .normalizer import normalize
+
+from .backtester import run_1g_returns
+from .benchmark import load_xu100_pct
 from .calendars import (
     add_next_close,
     add_next_close_calendar,
     build_trading_days,
     load_holidays_csv,
 )
+from .config import load_config
+from .data_loader import read_excels_long
 from .indicators import compute_indicators
-from .screener import run_screener
-from .backtester import run_1g_returns
-from .benchmark import load_xu100_pct
+from .normalizer import normalize
 from .reporter import write_reports
+from .screener import run_screener
 from .utils import info
 from .validator import dataset_summary, quality_warnings
 

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -1,8 +1,9 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
-from typing import List, Dict, Optional
 import yaml
 
 

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -1,8 +1,9 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-import pandas as pd
 from typing import Dict, List
+
+import pandas as pd
 import pandas_ta as ta
 
 

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -1,8 +1,9 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-import pandas as pd
 import re
+
+import pandas as pd
 
 
 def _to_pandas_ops(expr: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+import sys
 
 # Ensure the project root is on sys.path for imports
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_backtest_imports.py
+++ b/tests/test_backtest_imports.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
+
 import backtest
 
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
+
 from backtest.backtester import run_1g_returns
 
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
+
 from backtest.calendars import add_next_close
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import ast
 import importlib
 import importlib.util
-import pkgutil
 from pathlib import Path
+import pkgutil
 
 import backtest
 

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import pandas as pd
-from backtest.screener import run_screener
+
 from backtest.backtester import run_1g_returns
+from backtest.screener import run_screener
 
 
 def test_pipeline_smoke():


### PR DESCRIPTION
## Summary
- reorder and group imports across modules and tests
- ensure local modules separated from third-party dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689376cf71848325a1c2f17d195f7a11