### PR TITLE
Fix variable initializations and improve type safety

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -38,7 +38,11 @@ def build_trading_days(
     start = pd.to_datetime(df["date"]).min()
     end = pd.to_datetime(df["date"]).max()
     all_days = pd.date_range(start=start, end=end, freq="D")
-    hol = set(pd.to_datetime(list(holidays))) if holidays is not None else set()
+    if holidays is not None:
+        hol_iter = holidays if isinstance(holidays, Iterable) else [holidays]
+        hol = set(pd.to_datetime(list(hol_iter)))  # TİP DÜZELTİLDİ
+    else:
+        hol = set()
     trade = [d for d in all_days if (not is_weekend(d)) and (d.normalize() not in hol)]
     return pd.DatetimeIndex(trade)
 
@@ -52,7 +56,7 @@ def add_next_close_calendar(
     """
     df = df.copy().sort_values(["symbol", "date"])
     # map current date -> next trading day
-    td = pd.Series(trading_days[1:].values, index=trading_days[:-1]).to_dict()
+    td = dict(zip(trading_days[:-1], trading_days[1:]))  # TİP DÜZELTİLDİ
     dates = pd.to_datetime(df["date"])
     next_dates = dates.apply(lambda d: td.get(pd.Timestamp(d).normalize(), pd.NaT))
     df["next_date"] = next_dates.dt.date

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -107,6 +107,7 @@ def scan_range(config_path, start_date, end_date):
         winrate["Ortalama"] = winrate.mean(axis=1)
     else:
         pivot = pd.DataFrame()
+        winrate = pd.DataFrame()  # TİP DÜZELTİLDİ
     xu100_pct = None
     if cfg.benchmark.xu100_source == "csv" and cfg.benchmark.xu100_csv_path:
         s = load_xu100_pct(cfg.benchmark.xu100_csv_path)
@@ -186,6 +187,7 @@ def scan_day(config_path, date_str):
         winrate["Ortalama"] = winrate.mean(axis=1)
     else:
         pivot = pd.DataFrame(columns=[day, "Ortalama"])
+        winrate = pd.DataFrame()  # TİP DÜZELTİLDİ
     out_dir = cfg.project.out_dir
     os.makedirs(out_dir, exist_ok=True)
     out_xlsx = os.path.join(out_dir, f"SCAN_{day}.xlsx")

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -1,13 +1,17 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pandas as pd
 import pandas_ta as ta
 
 
-def compute_indicators(df: pd.DataFrame, params: Dict[str, List[int]]) -> pd.DataFrame:
+def compute_indicators(
+    df: pd.DataFrame, params: Optional[Dict[str, List[int]]] = None
+) -> pd.DataFrame:
+    if params is None:
+        params = {}  # TİP DÜZELTİLDİ
     df = df.copy()
     df = df.sort_values(["symbol", "date"])
     out_frames = []

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import pandas as pd
 
 
 def _ensure_dir(path: str):
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Path(path).parent.mkdir(parents=True, exist_ok=True)  # TİP DÜZELTİLDİ
 
 
 def write_reports(

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import pandas as pd
 
-from backtest.calendars import add_next_close
+from backtest.calendars import (
+    add_next_close,
+    add_next_close_calendar,
+    build_trading_days,
+)
 
 
 def test_next_close():
@@ -21,3 +25,23 @@ def test_next_close():
     out = add_next_close(df)
     assert out.loc[0, "next_close"] == 11
     assert pd.isna(out.loc[2, "next_close"])
+
+
+def test_build_trading_days_single_holiday():
+    df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).date})
+    tdays = build_trading_days(df, pd.Timestamp("2024-01-02"))
+    assert pd.Timestamp("2024-01-02") not in tdays
+
+
+def test_add_next_close_calendar():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).date,
+            "close": [10.0, 11.0],
+        }
+    )
+    tdays = build_trading_days(df)
+    out = add_next_close_calendar(df, tdays)
+    assert out.loc[0, "next_close"] == 11.0
+    assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-02").date()

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from backtest import cli
+
+
+def _cfg():
+    return SimpleNamespace(
+        project=SimpleNamespace(out_dir="out", start_date=None, end_date=None),
+        data=SimpleNamespace(filters_csv="dummy.csv"),
+        calendar=SimpleNamespace(tplus1_mode="price", holidays_source="none", holidays_csv_path=None),
+        indicators=SimpleNamespace(params={}),
+        benchmark=SimpleNamespace(xu100_source="none", xu100_csv_path=None),
+        report=SimpleNamespace(daily_sheet_prefix="SCAN_", summary_sheet_name="SUMMARY", percent_format="0.00%"),
+    )
+
+
+def test_scan_range_empty(monkeypatch):
+    cfg = _cfg()
+    monkeypatch.setattr(cli, "load_config", lambda _: cfg)
+    dummy_df = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).date,
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [1],
+            "next_close": [1],
+            "next_date": pd.to_datetime(["2024-01-03"]).date,
+        }
+    )
+    monkeypatch.setattr(cli, "read_excels_long", lambda _: dummy_df)
+    monkeypatch.setattr(cli, "normalize", lambda df: df)
+    monkeypatch.setattr(cli, "add_next_close", lambda df: df)
+    monkeypatch.setattr(cli, "compute_indicators", lambda df, params: df)
+    monkeypatch.setattr(pd, "read_csv", lambda path: pd.DataFrame({"FilterCode": [], "PythonQuery": []}))
+    monkeypatch.setattr(cli, "run_screener", lambda df, filters, d: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "mask"]))
+    monkeypatch.setattr(cli, "run_1g_returns", lambda df, sigs: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win"]))
+    monkeypatch.setattr(cli, "write_reports", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
+    monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
+    monkeypatch.setattr(cli, "info", lambda msg: None)
+    monkeypatch.setattr(cli.os, "makedirs", lambda *args, **kwargs: None)
+    cli.scan_range.callback("cfg.yml", None, None)
+
+
+def test_scan_day_empty(monkeypatch):
+    cfg = _cfg()
+    monkeypatch.setattr(cli, "load_config", lambda _: cfg)
+    dummy_df = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).date,
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [1],
+            "next_close": [1],
+            "next_date": pd.to_datetime(["2024-01-03"]).date,
+        }
+    )
+    monkeypatch.setattr(cli, "read_excels_long", lambda _: dummy_df)
+    monkeypatch.setattr(cli, "normalize", lambda df: df)
+    monkeypatch.setattr(cli, "add_next_close", lambda df: df)
+    monkeypatch.setattr(cli, "compute_indicators", lambda df, params: df)
+    monkeypatch.setattr(pd, "read_csv", lambda path: pd.DataFrame({"FilterCode": [], "PythonQuery": []}))
+    monkeypatch.setattr(cli, "run_screener", lambda df, filters, d: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "mask"]))
+    monkeypatch.setattr(cli, "run_1g_returns", lambda df, sigs: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win"]))
+    monkeypatch.setattr(cli, "write_reports", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
+    monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
+    monkeypatch.setattr(cli, "info", lambda msg: None)
+    monkeypatch.setattr(cli.os, "makedirs", lambda *args, **kwargs: None)
+    cli.scan_day.callback("cfg.yml", "2024-01-02")

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from backtest.indicators import compute_indicators
+
+
+def test_compute_indicators_defaults():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-01"]).date,
+            "close": [10.0],
+            "volume": [100],
+        }
+    )
+    out = compute_indicators(df)
+    assert "rsi_14" in out.columns

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pathlib
+
+from backtest.reporter import _ensure_dir
+
+
+def test_ensure_dir_handles_simple_filename(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _ensure_dir("report.xlsx")  # should not raise
+    assert pathlib.Path("report.xlsx").parent.exists()


### PR DESCRIPTION
## Summary
- Avoid NameError in CLI by initializing `winrate` when no trades are generated
- Harden calendar utilities for single-holiday inputs and lighter day mapping
- Guard against mutable defaults and simple path handling in indicators and reporting

## Testing
- `pytest tests/test_indicators.py::test_compute_indicators_defaults -q`
- `pytest tests/test_reporter.py::test_ensure_dir_handles_simple_filename -q`
- `pytest tests/test_calendar.py -q`
- `pytest tests/test_cli_empty.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68937d27601c83259c4836751593efd1