### PR TITLE
Improve robustness in benchmark and reports

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -37,8 +37,10 @@ def load_xu100_pct(csv_path: str) -> pd.Series:
             close_col = cols[k]
             break
     if close_col is None:
-        # fallback: second column
-        close_col = list(df.columns)[1]
+        # fallback: second column if available
+        close_col = (
+            list(df.columns)[1] if len(df.columns) > 1 else list(df.columns)[0]
+        )  # TİP DÜZELTİLDİ
     # parse date tolerant
     df[c_date] = pd.to_datetime(df[c_date], errors="coerce", dayfirst=True).dt.date
     df[close_col] = pd.to_numeric(df[close_col], errors="coerce")

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -56,11 +56,16 @@ def write_reports(
                         diff[c] = diff[c] - float(xu100_pct[c])
                     diff["Ortalama"] = diff[cols].mean(axis=1)
                     diff.to_excel(writer, sheet_name=f"{summary_sheet_name}_DIFF")
+                avg = (
+                    sum(xu100_pct.values()) / len(xu100_pct)
+                    if xu100_pct
+                    else float("nan")
+                )  # TİP DÜZELTİLDİ
                 bist = (
                     pd.DataFrame(
                         [
                             [xu100_pct.get(c, float("nan")) for c in cols]
-                            + [pd.Series(list(xu100_pct.values())).mean()]
+                            + [avg]
                         ],
                         index=["BIST"],
                         columns=cols + ["Ortalama"],


### PR DESCRIPTION
## Summary
- prevent column access errors in `load_xu100_pct`
- reduce Pandas overhead when building BIST report

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689380b671b08325b1181d75de89e073