### PR TITLE
Handle additional type cases in calendar and reporter utilities

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -39,7 +39,10 @@ def build_trading_days(
     end = pd.to_datetime(df["date"]).max()
     all_days = pd.date_range(start=start, end=end, freq="D")
     if holidays is not None:
-        hol_iter = holidays if isinstance(holidays, Iterable) else [holidays]
+        if isinstance(holidays, (str, bytes)):
+            hol_iter = [holidays]
+        else:
+            hol_iter = holidays if isinstance(holidays, Iterable) else [holidays]
         hol = set(pd.to_datetime(list(hol_iter)))  # TİP DÜZELTİLDİ
     else:
         hol = set()


### PR DESCRIPTION
## Summary
- Expand `build_trading_days` to safely accept holiday strings and byte inputs
- Allow `write_reports` to consume mapping/series `xu100_pct` by normalizing to a Series

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938790e5848325b36aac6dda1df1c4