### PR TITLE
Improve validation helpers

### DIFF
--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -57,7 +57,11 @@ def write_reports(
                 )
 
             if xu100_pct is not None:
-                xu100_series = pd.Series(xu100_pct, dtype=float)  # TİP DÜZELTİLDİ
+                if not isinstance(xu100_pct, Mapping):
+                    raise TypeError(
+                        "xu100_pct must be a mapping of dates to returns"
+                    )  # TİP DÜZELTİLDİ
+                xu100_series = pd.Series(dict(xu100_pct), dtype=float)  # TİP DÜZELTİLDİ
                 cols = [c for c in summary_wide.columns if c != "Ortalama"]
                 if set(cols).issubset(set(xu100_series.index)):
                     diff = summary_wide.copy()

--- a/backtest/validator.py
+++ b/backtest/validator.py
@@ -7,6 +7,12 @@ import pandas as pd
 def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:
     """Return simple stats per symbol: first/last date, rows, NA close
     count, dup count."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+    req = {"symbol", "date", "close"}
+    missing = req.difference(df.columns)
+    if missing:
+        raise ValueError(f"Eksik kolon(lar): {', '.join(sorted(missing))}")  # TİP DÜZELTİLDİ
     if df.empty:
         return pd.DataFrame(
             columns=[
@@ -32,6 +38,12 @@ def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:
 def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
     """Return row-level issues for quick inspection (date order, negative
     prices, etc.)."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+    req = {"symbol", "date", "close"}
+    missing = req.difference(df.columns)
+    if missing:
+        raise ValueError(f"Eksik kolon(lar): {', '.join(sorted(missing))}")  # TİP DÜZELTİLDİ
     issues = []
     if df.empty:
         return pd.DataFrame(columns=["symbol", "date", "issue", "value"])

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import pandas as pd
+import pytest
+
+from backtest.validator import dataset_summary, quality_warnings
+
+
+def test_dataset_summary_invalid_type():
+    with pytest.raises(TypeError):
+        dataset_summary([])  # not a DataFrame
+
+
+def test_dataset_summary_missing_columns():
+    df = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
+    with pytest.raises(ValueError):
+        dataset_summary(df)
+
+
+def test_quality_warnings_missing_columns():
+    df = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
+    with pytest.raises(ValueError):
+        quality_warnings(df)
+from types import SimpleNamespace
+from backtest.reporter import write_reports
+
+
+class _DummyWriter:
+    def __init__(self, *args, **kwargs):
+        self.book = SimpleNamespace(add_format=lambda *a, **k: None)
+        self.sheets = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_write_reports_xu100_pct_type(monkeypatch):
+    monkeypatch.setattr(pd, "ExcelWriter", _DummyWriter)
+    monkeypatch.setattr(pd.DataFrame, "to_excel", lambda *a, **k: None)
+    trades = pd.DataFrame(
+        columns=[
+            "FilterCode",
+            "Symbol",
+            "Date",
+            "EntryClose",
+            "ExitClose",
+            "ReturnPct",
+            "Win",
+        ]
+    )
+    with pytest.raises(TypeError):
+        write_reports(trades, [], pd.DataFrame(), xu100_pct=[1, 2], out_xlsx="dummy.xlsx")


### PR DESCRIPTION
## Summary
- validate DataFrame input and required columns in validator utilities
- enforce mapping type for xu100 benchmark data in reporter
- add tests covering invalid inputs for validators and reporter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a7b426948325a7d6ae0d76b89e57