### PR TITLE
fix: validate config and avoid mutable defaults

### DIFF
--- a/backtest/config.py
+++ b/backtest/config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Dict, List, Optional
+from pathlib import Path  # TİP DÜZELTİLDİ
 
 from pydantic import BaseModel, Field
 import yaml
@@ -61,13 +62,15 @@ class ReportCfg(BaseModel):
 class RootCfg(BaseModel):
     project: ProjectCfg
     data: DataCfg
-    calendar: CalendarCfg = CalendarCfg()
-    indicators: IndicatorsCfg = IndicatorsCfg()
-    benchmark: BenchmarkCfg = BenchmarkCfg()
-    report: ReportCfg = ReportCfg()
+    calendar: CalendarCfg = Field(default_factory=CalendarCfg)  # TİP DÜZELTİLDİ
+    indicators: IndicatorsCfg = Field(default_factory=IndicatorsCfg)  # TİP DÜZELTİLDİ
+    benchmark: BenchmarkCfg = Field(default_factory=BenchmarkCfg)  # TİP DÜZELTİLDİ
+    report: ReportCfg = Field(default_factory=ReportCfg)  # TİP DÜZELTİLDİ
 
 
-def load_config(path: str) -> RootCfg:
+def load_config(path: str | Path) -> RootCfg:
     with open(path, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
+    if not isinstance(cfg, dict):
+        raise TypeError("Config içeriği sözlük olmalı")  # TİP DÜZELTİLDİ
     return RootCfg(**cfg)

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -1,0 +1,38 @@
+import tempfile, textwrap
+from pathlib import Path
+import pytest
+
+from backtest.config import load_config, RootCfg
+
+def _write_cfg(text: str) -> Path:
+    tmp = tempfile.NamedTemporaryFile('w+', delete=False)
+    tmp.write(text)
+    tmp.flush()
+    return Path(tmp.name)
+
+def test_load_config_independent_defaults():
+    cfg_text = textwrap.dedent(
+        """
+        project:
+          out_dir: out
+          run_mode: range
+          start_date: '2020-01-01'
+          end_date: '2020-12-31'
+        data:
+          excel_dir: data
+          filters_csv: filters.csv
+        """
+    )
+    path = _write_cfg(cfg_text)
+    cfg1 = load_config(path)
+    cfg1.calendar.holidays_source = 'csv'
+    cfg1.indicators.params['ema'].append(99)
+    cfg2 = load_config(path)
+    assert cfg2.calendar.holidays_source == 'none'
+    assert 99 not in cfg2.indicators.params['ema']
+
+
+def test_load_config_invalid_yaml():
+    path = _write_cfg("- just\n- a\n- list\n")
+    with pytest.raises(TypeError):
+        load_config(path)


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults for config sections using `Field(default_factory=...)`
- improve config loader: accept `Path` objects and validate YAML structure
- add tests for configuration defaults and invalid YAML handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a9acdba0832591fac1b93e679eca