### PR TITLE
Improve type handling and test imports

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -31,7 +31,7 @@ def re_sub(pat: str, repl: str, s: str) -> str:
     return re.sub(pat, repl, s)
 
 
-def normalize_key(s: str) -> str:
+def normalize_key(s: Optional[str]) -> str:  # TİP DÜZELTİLDİ
     if s is None:
         return ""
     s = str(s).strip()

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import List, Optional, Mapping
+from typing import Iterable, List, Optional, Mapping  # TİP DÜZELTİLDİ
 
 import pandas as pd
 
@@ -18,7 +18,7 @@ def _ensure_dir(path: Optional[str]):
 
 def write_reports(
     trades_all: pd.DataFrame,
-    dates: Optional[List] = None,
+    dates: Optional[Iterable] = None,  # TİP DÜZELTİLDİ
     summary_wide: Optional[pd.DataFrame] = None,
     xu100_pct: Optional[Mapping] = None,
     out_xlsx: Optional[str] = None,
@@ -38,6 +38,8 @@ def write_reports(
     """
     if dates is None:
         dates = []  # TİP DÜZELTİLDİ
+    elif not isinstance(dates, list):
+        dates = list(dates)  # TİP DÜZELTİLDİ
     if summary_wide is None:
         summary_wide = pd.DataFrame()  # TİP DÜZELTİLDİ
     if out_xlsx:

--- a/backtest/utils.py
+++ b/backtest/utils.py
@@ -2,21 +2,24 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional  # TİP DÜZELTİLDİ
 import re
 import unicodedata
 
 from loguru import logger
 
 
-def ensure_dir(path: str):
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
+def ensure_dir(path: str | Path):
+    p = Path(path)
+    target = p if not p.suffix else p.parent
+    target.mkdir(parents=True, exist_ok=True)  # TİP DÜZELTİLDİ
 
 
 def info(msg: str):
     logger.info(msg)
 
 
-def normalize_key(s: str) -> str:
+def normalize_key(s: Optional[str]) -> str:  # TİP DÜZELTİLDİ
     if s is None:
         return ""
     s = str(s).strip()

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -1,8 +1,9 @@
 import pandas as pd
-import pandas as pd
 import pytest
+from types import SimpleNamespace
 
 from backtest.validator import dataset_summary, quality_warnings
+from backtest.reporter import write_reports
 
 
 def test_dataset_summary_invalid_type():
@@ -20,8 +21,6 @@ def test_quality_warnings_missing_columns():
     df = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
     with pytest.raises(ValueError):
         quality_warnings(df)
-from types import SimpleNamespace
-from backtest.reporter import write_reports
 
 
 class _DummyWriter:


### PR DESCRIPTION
## Summary
- refine directory creation logic and allow optional strings in utility helpers
- accept iterable dates in reports and convert to list
- tidy validator extra tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ad7df74083258c5124dfe1ed8810