### PR TITLE
Fix type checks and handle empty outputs

### DIFF
--- a/backtest/normalizer.py
+++ b/backtest/normalizer.py
@@ -5,10 +5,12 @@ import pandas as pd
 
 
 def normalize(df: pd.DataFrame) -> pd.DataFrame:
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
     need = ["symbol", "date", "open", "high", "low", "close", "volume"]
     for n in need:
         if n not in df.columns:
-            raise RuntimeError(f"Eksik zorunlu kolon: {n}")
+            raise ValueError(f"Eksik zorunlu kolon: {n}")  # TİP DÜZELTİLDİ
     df = df.copy()
     df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
     df["date"] = pd.to_datetime(df["date"]).dt.date

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -47,4 +47,8 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
                     )
         except Exception:
             continue
-    return pd.DataFrame(out_rows)
+    if not out_rows:
+        return pd.DataFrame(
+            columns=["FilterCode", "Symbol", "Date", "mask"]
+        )  # TİP DÜZELTİLDİ
+    return pd.DataFrame(out_rows)  # TİP DÜZELTİLDİ

--- a/backtest/validator.py
+++ b/backtest/validator.py
@@ -70,4 +70,8 @@ def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
                     "value": r["close"],
                 }
             )
-    return pd.DataFrame(issues)
+    if not issues:
+        return pd.DataFrame(
+            columns=["symbol", "date", "issue", "value"]
+        )  # TİP DÜZELTİLDİ
+    return pd.DataFrame(issues, columns=["symbol", "date", "issue", "value"])  # TİP DÜZELTİLDİ

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+from backtest.normalizer import normalize
+from backtest.validator import quality_warnings
+from backtest.screener import run_screener
+
+def test_normalize_type_and_missing_columns():
+    with pytest.raises(TypeError):
+        normalize([])  # not a DataFrame
+    df_missing = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
+    with pytest.raises(ValueError):
+        normalize(df_missing)
+
+def test_quality_warnings_no_issues():
+    df = pd.DataFrame({
+        "symbol": ["AAA", "AAA"],
+        "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).date,
+        "close": [1.0, 2.0],
+    })
+    res = quality_warnings(df)
+    assert list(res.columns) == ["symbol", "date", "issue", "value"]
+    assert res.empty
+
+def test_run_screener_no_hits():
+    df_ind = pd.DataFrame({
+        "symbol": ["AAA"],
+        "date": pd.to_datetime(["2024-01-02"]).date,
+        "open": [1.0],
+        "high": [1.0],
+        "low": [1.0],
+        "close": [1.0],
+        "volume": [100],
+    })  # TİP DÜZELTİLDİ
+    filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 2"]})
+    res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
+    assert list(res.columns) == ["FilterCode", "Symbol", "Date", "mask"]
+    assert res.empty


### PR DESCRIPTION
## Summary
- add explicit type/column validation in normalizer
- ensure screener/validator return DataFrames with expected columns even when empty
- cover edge cases with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b71f91f88325993125ebabb04212