### PR TITLE
Add robust type checks to calendar utilities

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -1,6 +1,7 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Iterable, Optional, Set
 
 import pandas as pd
@@ -8,18 +9,32 @@ import pandas as pd
 
 def add_next_close(df: pd.DataFrame) -> pd.DataFrame:
     """Price-driven next bar (symbol-based)."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+    req = {"symbol", "date", "close"}
+    missing = req.difference(df.columns)
+    if missing:
+        raise ValueError(
+            f"Eksik kolon(lar): {', '.join(sorted(missing))}"
+        )  # TİP DÜZELTİLDİ
     df = df.copy().sort_values(["symbol", "date"])
     df["next_date"] = df.groupby("symbol")["date"].shift(-1)
     df["next_close"] = df.groupby("symbol")["close"].shift(-1)
     return df
 
 
-def load_holidays_csv(path: str) -> Set[pd.Timestamp]:
+def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
     """Read holiday CSV with a 'date' column (case-insens.),
     return set of Timestamps (date only)."""
+    if not isinstance(path, (str, bytes, Path)):
+        raise TypeError("path must be a string or Path")  # TİP DÜZELTİLDİ
     h = pd.read_csv(path)
+    if h.empty:
+        return set()
     cols = {c.lower(): c for c in h.columns}
-    c_date = cols.get("date") or list(h.columns)[0]
+    c_date = cols.get("date")
+    if c_date is None:
+        raise ValueError("CSV must contain a 'date' column")  # TİP DÜZELTİLDİ
     h[c_date] = pd.to_datetime(h[c_date]).dt.normalize()
     return set(h[c_date].unique())
 
@@ -33,17 +48,24 @@ def build_trading_days(
 ) -> pd.DatetimeIndex:
     """Build calendar trading days from min..max of df, excluding weekends
     and holidays."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
     if df.empty:
         return pd.DatetimeIndex([])
     start = pd.to_datetime(df["date"]).min()
     end = pd.to_datetime(df["date"]).max()
     all_days = pd.date_range(start=start, end=end, freq="D")
     if holidays is not None:
-        if isinstance(holidays, (str, bytes)):
-            hol_iter = [holidays]
+        if isinstance(holidays, (int, float)):
+            raise TypeError("holidays must be iterable or date-like")  # TİP DÜZELTİLDİ
+        if isinstance(holidays, Iterable) and not isinstance(holidays, (str, bytes, pd.Timestamp)):
+            hol_iter = list(holidays)
         else:
-            hol_iter = holidays if isinstance(holidays, Iterable) else [holidays]
-        hol = set(pd.to_datetime(list(hol_iter)))  # TİP DÜZELTİLDİ
+            hol_iter = [holidays]
+        try:
+            hol = set(pd.to_datetime(hol_iter).normalize())  # TİP DÜZELTİLDİ
+        except Exception as e:  # pragma: no cover - defensive
+            raise ValueError("holidays contains non-date values") from e  # TİP DÜZELTİLDİ
     else:
         hol = set()
     trade = [d for d in all_days if (not is_weekend(d)) and (d.normalize() not in hol)]
@@ -57,6 +79,16 @@ def add_next_close_calendar(
     next_close is taken from symbol's close at that date; if missing,
     remains NaN (no trade possible).
     """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+    req = {"symbol", "date", "close"}
+    missing = req.difference(df.columns)
+    if missing:
+        raise ValueError(
+            f"Eksik kolon(lar): {', '.join(sorted(missing))}"
+        )  # TİP DÜZELTİLDİ
+    if not isinstance(trading_days, pd.DatetimeIndex):
+        raise TypeError("trading_days must be a DatetimeIndex")  # TİP DÜZELTİLDİ
     df = df.copy().sort_values(["symbol", "date"])
     # map current date -> next trading day
     td = dict(zip(trading_days[:-1], trading_days[1:]))  # TİP DÜZELTİLDİ

--- a/tests/test_calendars_validation.py
+++ b/tests/test_calendars_validation.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from backtest.calendars import (
+    add_next_close,
+    add_next_close_calendar,
+    build_trading_days,
+    load_holidays_csv,
+)
+
+
+def test_add_next_close_invalid_inputs():
+    with pytest.raises(TypeError):
+        add_next_close([])
+    df_missing = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")]} )
+    with pytest.raises(ValueError):
+        add_next_close(df_missing)
+
+
+def test_add_next_close_calendar_invalid_inputs():
+    df = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")], "close": [1.0]})
+    with pytest.raises(TypeError):
+        add_next_close_calendar([], pd.DatetimeIndex([]))
+    with pytest.raises(TypeError):
+        add_next_close_calendar(df, ["2020-01-02"])
+    with pytest.raises(ValueError):
+        add_next_close_calendar(df.drop(columns=["close"]), pd.DatetimeIndex([]))
+
+
+def test_build_trading_days_invalid_holidays():
+    df = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")]})
+    with pytest.raises(TypeError):
+        build_trading_days(df, holidays=123)
+
+
+def test_load_holidays_csv_validation(tmp_path):
+    with pytest.raises(TypeError):
+        load_holidays_csv(123)
+    csv_file = tmp_path / "hol.csv"
+    csv_file.write_text("col\n1\n")
+    with pytest.raises(ValueError):
+        load_holidays_csv(csv_file)


### PR DESCRIPTION
## Summary
- validate DataFrame inputs and required columns for `add_next_close`
- add safe path and holiday parsing in calendar helpers
- include tests for invalid calendar inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b9bfa6108325904f04979e56335e