### PR TITLE
Add input validation for run_1g_returns and tests

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -5,6 +5,16 @@ import pandas as pd
 
 
 def run_1g_returns(df_with_next: pd.DataFrame, signals: pd.DataFrame) -> pd.DataFrame:
+    if not isinstance(df_with_next, pd.DataFrame):
+        raise TypeError("df_with_next must be a DataFrame")  # TİP DÜZELTİLDİ
+    if not isinstance(signals, pd.DataFrame):
+        raise TypeError("signals must be a DataFrame")  # TİP DÜZELTİLDİ
+    req_base = {"symbol", "date", "close", "next_date", "next_close"}
+    missing_base = req_base.difference(df_with_next.columns)
+    if missing_base:
+        raise ValueError(
+            f"Eksik kolon(lar): {', '.join(sorted(missing_base))}"
+        )  # TİP DÜZELTİLDİ
     if signals.empty:
         return pd.DataFrame(
             columns=[
@@ -17,6 +27,12 @@ def run_1g_returns(df_with_next: pd.DataFrame, signals: pd.DataFrame) -> pd.Data
                 "Win",
             ]
         )
+    req_sig = {"FilterCode", "Symbol", "Date"}
+    missing_sig = req_sig.difference(signals.columns)
+    if missing_sig:
+        raise ValueError(
+            f"Eksik kolon(lar): {', '.join(sorted(missing_sig))}"
+        )  # TİP DÜZELTİLDİ
     base = df_with_next[["symbol", "date", "close", "next_date", "next_close"]].copy()
     merged = signals.merge(
         base, left_on=["Symbol", "Date"], right_on=["symbol", "date"], how="left"

--- a/tests/test_backtester_validation.py
+++ b/tests/test_backtester_validation.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import pytest
+
+from backtest.backtester import run_1g_returns
+
+
+def _base_df():
+    return pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-01"]).date,
+            "close": [1.0],
+            "next_date": pd.to_datetime(["2024-01-02"]).date,
+            "next_close": [1.1],
+        }
+    )
+
+
+def _signals_df():
+    return pd.DataFrame(
+        {"FilterCode": ["F"], "Symbol": ["AAA"], "Date": pd.to_datetime(["2024-01-01"]).date}
+    )
+
+
+def test_run_1g_returns_type_validation():
+    with pytest.raises(TypeError):
+        run_1g_returns([], pd.DataFrame())  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        run_1g_returns(_base_df(), [])  # type: ignore[arg-type]
+
+
+def test_run_1g_returns_missing_columns():
+    bad_df = pd.DataFrame({"symbol": ["AAA"]})
+    with pytest.raises(ValueError):
+        run_1g_returns(bad_df, _signals_df())
+    bad_sig = pd.DataFrame({"FilterCode": ["F"], "Symbol": ["AAA"]})
+    with pytest.raises(ValueError):
+        run_1g_returns(_base_df(), bad_sig)
+
+
+def test_run_1g_returns_empty_signals():
+    res = run_1g_returns(_base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"]))
+    assert list(res.columns) == [
+        "FilterCode",
+        "Symbol",
+        "Date",
+        "EntryClose",
+        "ExitClose",
+        "ReturnPct",
+        "Win",
+    ]
+    assert res.empty


### PR DESCRIPTION
## Summary
- validate types and required columns in `run_1g_returns`
- test `run_1g_returns` error handling and empty case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bc3d8eac832580482e16e556d13c