### PR TITLE
Add type checks for indicators and screener

### DIFF
--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -10,6 +10,10 @@ import pandas_ta as ta
 def compute_indicators(
     df: pd.DataFrame, params: Optional[Dict[str, List[int]]] = None
 ) -> pd.DataFrame:
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+    if params is not None and not isinstance(params, dict):
+        raise TypeError("params must be a dict or None")  # TİP DÜZELTİLDİ
     if params is None:
         params = {}  # TİP DÜZELTİLDİ
     if df.empty:

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -14,6 +14,18 @@ def _to_pandas_ops(expr: str) -> str:
 
 
 def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.DataFrame:
+    if not isinstance(df_ind, pd.DataFrame):
+        raise TypeError("df_ind must be a DataFrame")  # TİP DÜZELTİLDİ
+    if not isinstance(filters_df, pd.DataFrame):
+        raise TypeError("filters_df must be a DataFrame")  # TİP DÜZELTİLDİ
+    req_df = {"symbol", "date", "open", "high", "low", "close", "volume"}
+    missing_df = req_df.difference(df_ind.columns)
+    if missing_df:
+        raise ValueError(
+            f"df_ind missing columns: {', '.join(sorted(missing_df))}"
+        )  # TİP DÜZELTİLDİ
+    if not {"FilterCode", "PythonQuery"}.issubset(filters_df.columns):
+        raise ValueError("filters_df missing required columns")  # TİP DÜZELTİLDİ
     day = pd.to_datetime(date).date()
     d = df_ind[df_ind["date"] == day].copy()
     if d.empty:

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+
+from backtest.indicators import compute_indicators
+from backtest.screener import run_screener
+
+
+def test_compute_indicators_invalid_inputs():
+    with pytest.raises(TypeError):
+        compute_indicators([])
+    df = pd.DataFrame()
+    with pytest.raises(TypeError):
+        compute_indicators(df, params=[])
+
+
+def test_run_screener_invalid_inputs():
+    filters_df = pd.DataFrame({"FilterCode": [], "PythonQuery": []})
+    df_ind = pd.DataFrame({"symbol": [], "open": [], "high": [], "low": [], "close": [], "volume": []})
+    with pytest.raises(TypeError):
+        run_screener([], filters_df, pd.Timestamp("2024-01-02"))
+    with pytest.raises(TypeError):
+        run_screener(df_ind, [], pd.Timestamp("2024-01-02"))
+    with pytest.raises(ValueError):
+        run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
+    df_ok = df_ind.assign(date=pd.to_datetime([]))
+    bad_filters = pd.DataFrame({"FilterCode": []})
+    with pytest.raises(ValueError):
+        run_screener(df_ok, bad_filters, pd.Timestamp("2024-01-02"))


### PR DESCRIPTION
## Summary
- validate DataFrame and params types in compute_indicators
- ensure run_screener receives proper DataFrames and necessary columns
- add tests covering new validation behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bea1bcd08325adc248b330570d03