### PR TITLE
Fix input validation and date handling

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -108,7 +108,9 @@ COL_ALIASES: Dict[str, str] = {
 
 
 def normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
-    rename_map = {}
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+    rename_map: Dict[str, str] = {}
     for c in df.columns:
         key = normalize_key(c).strip("_")
         std = COL_ALIASES.get(key, key)

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -38,6 +38,8 @@ def write_reports(
     """
     if dates is None:
         dates = tuple()  # TİP DÜZELTİLDİ
+    elif isinstance(dates, (str, bytes, pd.Timestamp)):
+        dates = (dates,)  # TİP DÜZELTİLDİ
     else:
         dates = tuple(dates)  # TİP DÜZELTİLDİ
     if summary_wide is None:


### PR DESCRIPTION
## Summary
- validate DataFrame input in `normalize_columns`
- handle single string timestamps in `write_reports`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c22d6eb08325bccbd1b63649b6b6