### PR TITLE
Fix data type handling and add robust validations

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,6 +1,7 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
+from pathlib import Path
 import pandas as pd
 
 
@@ -16,13 +17,15 @@ def _read_csv_any(path: str) -> pd.DataFrame:
         return pd.read_csv(path, sep=sep, decimal=dec)
 
 
-def load_xu100_pct(csv_path: str) -> pd.Series:
-    df = _read_csv_any(csv_path)
+def load_xu100_pct(csv_path: str | Path) -> pd.Series:
+    if not isinstance(csv_path, (str, Path)):
+        raise TypeError("csv_path must be str or Path")  # TİP DÜZELTİLDİ
+    df = _read_csv_any(str(csv_path))
     cols = {c.lower().strip(): c for c in df.columns}
     # date column
     c_date = cols.get("date") or cols.get("tarih") or list(df.columns)[0]
     # close-like column
-    cand = [
+    cand = (
         "close",
         "kapanış",
         "kapanis",
@@ -30,7 +33,7 @@ def load_xu100_pct(csv_path: str) -> pd.Series:
         "adj_close",
         "kapanis_tl",
         "fiyat",
-    ]
+    )  # TİP DÜZELTİLDİ
     close_col = None
     for k in cand:
         if k in cols:

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -36,6 +36,31 @@ def write_reports(
     - SUMMARY_DIFF: Filtre − BIST
     - VALIDATION_SUMMARY / VALIDATION_ISSUES: veri kalite raporu
     """
+    if not isinstance(trades_all, pd.DataFrame):
+        raise TypeError("trades_all must be a DataFrame")  # TİP DÜZELTİLDİ
+    req_cols = {
+        "FilterCode",
+        "Symbol",
+        "Date",
+        "EntryClose",
+        "ExitClose",
+        "ReturnPct",
+        "Win",
+    }
+    missing = req_cols.difference(trades_all.columns)
+    if missing:
+        raise ValueError(
+            f"trades_all missing columns: {', '.join(sorted(missing))}"  # TİP DÜZELTİLDİ
+        )
+    if summary_wide is not None and not isinstance(summary_wide, pd.DataFrame):
+        raise TypeError("summary_wide must be a DataFrame or None")  # TİP DÜZELTİLDİ
+    if summary_winrate is not None and not isinstance(summary_winrate, pd.DataFrame):
+        raise TypeError("summary_winrate must be a DataFrame or None")  # TİP DÜZELTİLDİ
+    if validation_summary is not None and not isinstance(validation_summary, pd.DataFrame):
+        raise TypeError("validation_summary must be a DataFrame or None")  # TİP DÜZELTİLDİ
+    if validation_issues is not None and not isinstance(validation_issues, pd.DataFrame):
+        raise TypeError("validation_issues must be a DataFrame or None")  # TİP DÜZELTİLDİ
+
     if dates is None:
         dates = tuple()  # TİP DÜZELTİLDİ
     elif isinstance(dates, (str, bytes, pd.Timestamp)):


### PR DESCRIPTION
## Summary
- validate input type for `load_xu100_pct` and use tuple for constant column candidates
- add rigorous DataFrame type/column checks in `write_reports`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c506c64483259b7ee1fd431edfb9