### PR TITLE
Handle missing CSV files gracefully

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -33,7 +33,11 @@ def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
     if not p.exists():  # PATH DÜZENLENDİ
         warnings.warn(f"Tatil CSV bulunamadı: {p}")
         return set()
-    h = pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
+    try:
+        h = pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
+    except Exception:
+        warnings.warn(f"Tatil CSV okunamadı: {p}")  # PATH DÜZENLENDİ
+        return set()
     if h.empty:
         return set()
     cols = {c.lower(): c for c in h.columns}

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -55,7 +55,11 @@ def scan_range(config_path, start_date, end_date):
     info("Filtre CSV okunuyor...")
     p_filters = Path(cfg.data.filters_csv)
     if p_filters.exists():
-        filters_df = pd.read_csv(p_filters, encoding="utf-8")  # PATH DÜZENLENDİ
+        try:
+            filters_df = pd.read_csv(p_filters, encoding="utf-8")  # PATH DÜZENLENDİ
+        except Exception:
+            info(f"Filters CSV okunamadı: {p_filters}")  # PATH DÜZENLENDİ
+            filters_df = pd.DataFrame()
     else:
         info(f"Filters CSV bulunamadı: {p_filters}")  # PATH DÜZENLENDİ
         filters_df = pd.DataFrame()
@@ -168,7 +172,11 @@ def scan_day(config_path, date_str):
     info("Filtre CSV okunuyor...")
     p_filters = Path(cfg.data.filters_csv)
     if p_filters.exists():
-        filters_df = pd.read_csv(p_filters, encoding="utf-8")  # PATH DÜZENLENDİ
+        try:
+            filters_df = pd.read_csv(p_filters, encoding="utf-8")  # PATH DÜZENLENDİ
+        except Exception:
+            info(f"Filters CSV okunamadı: {p_filters}")  # PATH DÜZENLENDİ
+            filters_df = pd.DataFrame()
     else:
         info(f"Filters CSV bulunamadı: {p_filters}")  # PATH DÜZENLENDİ
         filters_df = pd.DataFrame()


### PR DESCRIPTION
## Summary
- Tolerate absent or unreadable filter CSV files in CLI commands
- Guard holiday CSV loading with warnings instead of hard failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d1b350f88325be808bf6339463b7