### PR TITLE
Use pathlib for safer file handling

### DIFF
--- a/README_COLAB.md
+++ b/README_COLAB.md
@@ -17,8 +17,11 @@ tqdm
 click
 pydantic
 """.strip()
-open('/content/requirements_colab.txt','w').write(req)
-!pip install -q --force-reinstall -r /content/requirements_colab.txt
+from pathlib import Path
+p = Path("requirements_colab.txt")  # PATH DÜZENLENDİ
+with p.open("w", encoding="utf-8") as f:  # PATH DÜZENLENDİ
+    f.write(req)
+!pip install -q --force-reinstall -r requirements_colab.txt
 ```
 
 ## 2) Runtime'ı yeniden başlat

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -4,11 +4,14 @@ import pytest
 
 from backtest.config import load_config, RootCfg
 
+
 def _write_cfg(text: str) -> Path:
-    tmp = tempfile.NamedTemporaryFile('w+', delete=False)
-    tmp.write(text)
-    tmp.flush()
-    return Path(tmp.name)
+    with tempfile.NamedTemporaryFile(
+        "w", delete=False, encoding="utf-8"
+    ) as tmp:  # PATH DÜZENLENDİ
+        tmp.write(text)
+        tmp.flush()
+        return Path(tmp.name)
 
 def test_load_config_independent_defaults():
     cfg_text = textwrap.dedent(


### PR DESCRIPTION
## Summary
- Use `NamedTemporaryFile` with UTF-8 encoding and context manager in configuration test
- Replace hard-coded Colab requirements path with `pathlib.Path` and safe `open`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893d445ab9483259719551beedb26cf