### PR TITLE
Improve CSV path handling in benchmark

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -15,11 +15,19 @@ def _read_csv_any(path: str | Path) -> pd.DataFrame:
     try:
         return pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
     except Exception:
-        with open(p, "r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
-            sample = f.read(2048)
+        try:
+            with p.open("r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
+                sample = f.read(2048)
+        except Exception:
+            warnings.warn(f"CSV okunamadı: {p}")  # PATH DÜZENLENDİ
+            return pd.DataFrame()
         sep = ";" if sample.count(";") > sample.count(",") else ","
         dec = "," if sample.count(",") > sample.count(".") and sep == ";" else "."
-        return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
+        try:
+            return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
+        except Exception:
+            warnings.warn(f"CSV parse edilemedi: {p}")  # PATH DÜZENLENDİ
+            return pd.DataFrame()
 
 
 def load_xu100_pct(csv_path: str | Path) -> pd.Series:


### PR DESCRIPTION
## Summary
- Safely read benchmark CSVs with Path.open, UTF-8 and warnings when files are missing or malformed.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893dc4ffa948325a201f287735d5307