### PR TITLE
Resolve config-relative paths

### DIFF
--- a/backtest/config.py
+++ b/backtest/config.py
@@ -81,4 +81,26 @@ def load_config(path: str | Path) -> RootCfg:
         cfg = yaml.safe_load(f)
     if not isinstance(cfg, dict):
         raise TypeError("Config içeriği sözlük olmalı")  # TİP DÜZELTİLDİ
+    base = p.parent
+    def _join(v: Optional[str]) -> Optional[str]:
+        if not v:
+            return v
+        vp = Path(v)
+        return str(base / vp) if not vp.is_absolute() else str(vp)
+
+    proj = cfg.get("project", {}) if isinstance(cfg, dict) else {}
+    if isinstance(proj, dict) and proj.get("out_dir"):
+        proj["out_dir"] = _join(proj.get("out_dir"))  # PATH DÜZENLENDİ
+    data = cfg.get("data", {}) if isinstance(cfg, dict) else {}
+    for k in ["excel_dir", "filters_csv", "cache_parquet_path"]:
+        v = data.get(k)
+        if v:
+            data[k] = _join(v)  # PATH DÜZENLENDİ
+    cal = cfg.get("calendar", {}) if isinstance(cfg, dict) else {}
+    if isinstance(cal, dict) and cal.get("holidays_csv_path"):
+        cal["holidays_csv_path"] = _join(cal.get("holidays_csv_path"))  # PATH DÜZENLENDİ
+    bench = cfg.get("benchmark", {}) if isinstance(cfg, dict) else {}
+    if isinstance(bench, dict) and bench.get("xu100_csv_path"):
+        bench["xu100_csv_path"] = _join(bench.get("xu100_csv_path"))  # PATH DÜZENLENDİ
+    cfg["project"], cfg["data"], cfg["calendar"], cfg["benchmark"] = proj, data, cal, bench
     return RootCfg(**cfg)

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -39,3 +39,28 @@ def test_load_config_invalid_yaml():
     path = _write_cfg("- just\n- a\n- list\n")
     with pytest.raises(TypeError):
         load_config(path)
+
+
+def test_load_config_relative_paths(tmp_path):
+    cfg_text = textwrap.dedent(
+        """
+        project:
+          out_dir: out
+        data:
+          excel_dir: data
+          filters_csv: filters.csv
+        calendar:
+          holidays_csv_path: hol.csv
+        benchmark:
+          xu100_csv_path: xu.csv
+        """
+    )
+    cfg_file = tmp_path / "cfg.yaml"  # PATH DÜZENLENDİ
+    cfg_file.write_text(cfg_text, encoding="utf-8")  # PATH DÜZENLENDİ
+    cfg = load_config(cfg_file)
+    base = cfg_file.parent
+    assert cfg.project.out_dir == str(base / "out")
+    assert cfg.data.excel_dir == str(base / "data")
+    assert cfg.data.filters_csv == str(base / "filters.csv")
+    assert cfg.calendar.holidays_csv_path == str(base / "hol.csv")
+    assert cfg.benchmark.xu100_csv_path == str(base / "xu.csv")


### PR DESCRIPTION
## Summary
- Normalize configuration paths relative to the config file directory using `pathlib`
- Add regression test for relative path resolution in configuration loader

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893dd8ba7688325936eea187d9ee0a3