### PR TITLE
Refactor path resolution and filter CSV loading

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -5,11 +5,13 @@ from pathlib import Path
 import warnings
 import pandas as pd
 
+from utils.paths import resolve_path
+
 
 def _read_csv_any(path: str | Path) -> pd.DataFrame:
     """Read CSV with fallback separator/decimal handling."""
-    p = Path(path)
-    if not p.exists():  # PATH DÜZENLENDİ
+    p = resolve_path(path)
+    if not p.exists():
         warnings.warn(f"CSV bulunamadı: {p}")
         return pd.DataFrame()
     try:
@@ -19,14 +21,14 @@ def _read_csv_any(path: str | Path) -> pd.DataFrame:
             with p.open("r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
                 sample = f.read(2048)
         except Exception:
-            warnings.warn(f"CSV okunamadı: {p}")  # PATH DÜZENLENDİ
+            warnings.warn(f"CSV okunamadı: {p}")
             return pd.DataFrame()
         sep = ";" if sample.count(";") > sample.count(",") else ","
         dec = "," if sample.count(",") > sample.count(".") and sep == ";" else "."
         try:
             return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
         except Exception:
-            warnings.warn(f"CSV parse edilemedi: {p}")  # PATH DÜZENLENDİ
+            warnings.warn(f"CSV parse edilemedi: {p}")
             return pd.DataFrame()
 
 
@@ -36,7 +38,7 @@ def load_xu100_pct(csv_path: str | Path) -> pd.Series:
     df = _read_csv_any(csv_path)  # PATH DÜZENLENDİ
     # En az iki kolon yoksa tarih ve fiyat ayrılamaz
     if df.empty or df.shape[1] < 2:  # LOJİK HATASI DÜZELTİLDİ
-        warnings.warn(f"Boş CSV: {csv_path}")  # PATH DÜZENLENDİ
+        warnings.warn(f"Boş CSV: {csv_path}")
         return pd.Series(dtype=float)
     cols = {c.lower().strip(): c for c in df.columns}
     # date column

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -6,6 +6,7 @@ from typing import Iterable, Optional, Set
 import warnings
 
 import pandas as pd
+from utils.paths import resolve_path
 
 
 def add_next_close(df: pd.DataFrame) -> pd.DataFrame:
@@ -28,15 +29,15 @@ def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
     """Read holiday CSV with a 'date' column (case-insens.),
     return set of Timestamps (date only)."""
     if not isinstance(path, (str, bytes, Path)):
-        raise TypeError("path must be a string or Path")  # TİP DÜZELTİLDİ
-    p = Path(path)
-    if not p.exists():  # PATH DÜZENLENDİ
+        raise TypeError("path must be a string or Path")
+    p = resolve_path(path)
+    if not p.exists():
         warnings.warn(f"Tatil CSV bulunamadı: {p}")
         return set()
     try:
-        h = pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
+        h = pd.read_csv(p, encoding="utf-8")
     except Exception:
-        warnings.warn(f"Tatil CSV okunamadı: {p}")  # PATH DÜZENLENDİ
+        warnings.warn(f"Tatil CSV okunamadı: {p}")
         return set()
     if h.empty:
         return set()

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -8,13 +8,15 @@ from typing import Iterable, Optional, Mapping  # TİP DÜZELTİLDİ
 import warnings
 import pandas as pd
 
+from utils.paths import resolve_path
 
-def _ensure_dir(path: Optional[str]):
+
+def _ensure_dir(path: Optional[str | Path]):
     if not path:
         return
-    p = Path(path)
+    p = resolve_path(path)
     target = p if not p.suffix else p.parent
-    target.mkdir(parents=True, exist_ok=True)  # TİP DÜZELTİLDİ
+    target.mkdir(parents=True, exist_ok=True)
 
 
 def write_reports(
@@ -73,7 +75,7 @@ def write_reports(
     if summary_wide is None:
         summary_wide = pd.DataFrame()  # TİP DÜZELTİLDİ
     if out_xlsx:
-        out_xlsx_path = Path(out_xlsx)
+        out_xlsx_path = resolve_path(out_xlsx)
         _ensure_dir(out_xlsx_path)
         try:
             writer = pd.ExcelWriter(out_xlsx_path, engine="xlsxwriter")  # PATH DÜZENLENDİ
@@ -167,8 +169,8 @@ def write_reports(
                     ws.set_column(1, 100, 12, num_fmt)
     
     if out_csv_dir:
-        out_csv_path = Path(out_csv_dir)
-        out_csv_path.mkdir(parents=True, exist_ok=True)  # PATH DÜZENLENDİ
+        out_csv_path = resolve_path(out_csv_dir)
+        out_csv_path.mkdir(parents=True, exist_ok=True)
         try:
             trades_all.to_csv(
                 out_csv_path / "daily_trades.csv",

--- a/backtest/utils.py
+++ b/backtest/utils.py
@@ -8,11 +8,13 @@ import unicodedata
 
 from loguru import logger
 
+from utils.paths import resolve_path
+
 
 def ensure_dir(path: str | Path):
-    p = Path(path)
+    p = resolve_path(path)
     target = p if not p.suffix else p.parent
-    target.mkdir(parents=True, exist_ok=True)  # TİP DÜZELTİLDİ
+    target.mkdir(parents=True, exist_ok=True)
 
 
 def info(msg: str):

--- a/io_filters.py
+++ b/io_filters.py
@@ -1,0 +1,55 @@
+"""Helpers for reading filter CSV files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import warnings
+
+import pandas as pd
+
+from utils.paths import resolve_path
+
+
+REQUIRED_COLUMNS = {"FilterCode", "PythonQuery"}
+
+
+def load_filters_csv(path: str | Path) -> pd.DataFrame:
+    """Load filters from CSV with validation and basic normalization.
+
+    Parameters
+    ----------
+    path:
+        Location of the CSV file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the filter definitions. If the file is missing
+        or cannot be parsed, an empty DataFrame is returned and a warning is
+        issued. Missing required columns raise ``RuntimeError``.
+    """
+
+    p = resolve_path(path)
+    if not p.exists():
+        warnings.warn(f"Filters CSV bulunamadı: {p}")
+        return pd.DataFrame()
+    try:
+        df = pd.read_csv(p, encoding="utf-8")
+    except Exception:
+        warnings.warn(f"Filters CSV okunamadı: {p}")
+        return pd.DataFrame()
+
+    missing = REQUIRED_COLUMNS.difference(df.columns)
+    if missing:
+        raise RuntimeError(
+            "Eksik kolon(lar): " + ", ".join(sorted(missing))
+        )
+
+    # basic normalization
+    df["FilterCode"] = df["FilterCode"].astype(str).str.strip()
+    df["PythonQuery"] = df["PythonQuery"].astype(str)
+    return df
+
+
+__all__ = ["load_filters_csv"]
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility package for shared helpers."""
+
+from .paths import resolve_path
+
+__all__ = ["resolve_path"]
+

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,0 +1,34 @@
+"""Path utilities."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+
+def resolve_path(path: Union[str, os.PathLike]) -> Path:
+    """Expand user home (``~``) and environment variables safely.
+
+    Parameters
+    ----------
+    path:
+        Raw path as string or ``os.PathLike``.
+
+    Returns
+    -------
+    pathlib.Path
+        Normalized path with user and environment variables expanded.
+    """
+
+    if not isinstance(path, (str, os.PathLike)):
+        raise TypeError("path must be str or Path-like")
+
+    # ``expandvars`` must operate on string before converting to ``Path``
+    expanded = os.path.expandvars(str(path))
+    expanded = os.path.expanduser(expanded)
+    return Path(expanded).resolve()
+
+
+__all__ = ["resolve_path"]
+


### PR DESCRIPTION
## Summary
- add `resolve_path` helper to expand user and env vars and return `Path`
- centralize filter CSV parsing via `load_filters_csv`
- refactor modules to use pathlib paths consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893f3ecf6fc8325a0d17c94eb41550e