### PR TITLE
Raise error for missing benchmark CSV

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -12,24 +12,21 @@ def _read_csv_any(path: str | Path) -> pd.DataFrame:
     """Read CSV with fallback separator/decimal handling."""
     p = resolve_path(path)
     if not p.exists():
-        warnings.warn(f"CSV bulunamadı: {p}")
-        return pd.DataFrame()
+        raise FileNotFoundError(f"CSV bulunamadı: {p}")
     try:
         return pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
     except Exception:
         try:
             with p.open("r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
                 sample = f.read(2048)
-        except Exception:
-            warnings.warn(f"CSV okunamadı: {p}")
-            return pd.DataFrame()
+        except Exception as e:  # SPECIFIC EXCEPTIONS
+            raise FileNotFoundError(f"CSV okunamadı: {p}") from e
         sep = ";" if sample.count(";") > sample.count(",") else ","
         dec = "," if sample.count(",") > sample.count(".") and sep == ";" else "."
         try:
             return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
-        except Exception:
-            warnings.warn(f"CSV parse edilemedi: {p}")
-            return pd.DataFrame()
+        except Exception as e:
+            raise RuntimeError(f"CSV parse edilemedi: {p}") from e
 
 
 def load_xu100_pct(csv_path: str | Path) -> pd.Series:

--- a/tests/test_benchmark_paths.py
+++ b/tests/test_benchmark_paths.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import pytest
+
+from backtest.benchmark import load_xu100_pct
+
+
+def test_load_xu100_pct_missing_file(tmp_path):
+    missing = tmp_path / "missing.csv"
+    with pytest.raises(FileNotFoundError):
+        load_xu100_pct(missing)


### PR DESCRIPTION
## Summary
- Raise `FileNotFoundError` when the benchmark CSV is missing or unreadable
- Add regression test for missing benchmark CSV

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f8a3e4f08325a0fae3a497208c87