### PR TITLE
Handle scalar masks in screener

### DIFF
--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -50,6 +50,8 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
             mask = pd.eval(
                 expr, local_dict=local_vars, engine="python", parser="pandas"
             )
+            if not isinstance(mask, pd.Series):
+                mask = pd.Series(mask, index=d.index)
             mask = mask.fillna(False)
             hits = d[mask].copy()
             if not hits.empty:


### PR DESCRIPTION
## Summary
- fix screener to handle scalar filter expressions by converting them to boolean Series

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ff4c918883259665e6ba6547d56e