### PR TITLE
Fix CSV delimiter detection

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -14,19 +14,27 @@ def _read_csv_any(path: str | Path) -> pd.DataFrame:
     if not p.exists():
         raise FileNotFoundError(f"CSV bulunamadı: {p}")
     try:
-        return pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
+        df = pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
+        if df.shape[1] > 1:
+            return df
     except Exception:
-        try:
-            with p.open("r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
-                sample = f.read(2048)
-        except Exception as e:  # SPECIFIC EXCEPTIONS
-            raise FileNotFoundError(f"CSV okunamadı: {p}") from e
-        sep = ";" if sample.count(";") > sample.count(",") else ","
-        dec = "," if sample.count(",") > sample.count(".") and sep == ";" else "."
-        try:
-            return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
-        except Exception as e:
-            raise RuntimeError(f"CSV parse edilemedi: {p}") from e
+        pass
+    try:
+        with p.open("r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
+            sample = f.read(2048)
+    except Exception as e:  # SPECIFIC EXCEPTIONS
+        raise FileNotFoundError(f"CSV okunamadı: {p}") from e
+    import csv
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=";,")
+        sep = dialect.delimiter
+    except Exception:
+        sep = ","
+    dec = "," if sep == ";" else "."
+    try:
+        return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
+    except Exception as e:
+        raise RuntimeError(f"CSV parse edilemedi: {p}") from e
 
 
 def load_xu100_pct(csv_path: str | Path) -> pd.Series:

--- a/tests/test_benchmark_delimiter.py
+++ b/tests/test_benchmark_delimiter.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from backtest.benchmark import load_xu100_pct
+
+
+def test_load_xu100_pct_semicolon_decimal_comma(tmp_path):
+    csv_file = tmp_path / "xu100.csv"
+    csv_file.write_text(
+        "Date;Close\n2020-01-01;100,0\n2020-01-02;110,0\n", encoding="utf-8"
+    )
+    series = load_xu100_pct(csv_file)
+    assert len(series) == 2
+    assert series.iloc[1] == pytest.approx(10.0)


### PR DESCRIPTION
## Summary
- handle semicolon-separated CSVs with decimal commas in benchmark loader
- add regression test for semicolon CSV parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940338962883258cd00f4256e08544