### PR TITLE
Raise error for missing holiday CSV

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, Optional, Set
-import warnings
 
 import pandas as pd
 from utils.paths import resolve_path
@@ -32,13 +31,11 @@ def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
         raise TypeError("path must be a string or Path")
     p = resolve_path(path)
     if not p.exists():
-        warnings.warn(f"Tatil CSV bulunamadı: {p}")
-        return set()
+        raise FileNotFoundError(f"Tatil CSV bulunamadı: {p}")
     try:
         h = pd.read_csv(p, encoding="utf-8")
-    except Exception:
-        warnings.warn(f"Tatil CSV okunamadı: {p}")
-        return set()
+    except Exception as e:
+        raise FileNotFoundError(f"Tatil CSV okunamadı: {p}") from e
     if h.empty:
         return set()
     cols = {c.lower(): c for c in h.columns}

--- a/tests/test_calendars_validation.py
+++ b/tests/test_calendars_validation.py
@@ -36,6 +36,9 @@ def test_build_trading_days_invalid_holidays():
 def test_load_holidays_csv_validation(tmp_path):
     with pytest.raises(TypeError):
         load_holidays_csv(123)
+    missing = tmp_path / "missing.csv"
+    with pytest.raises(FileNotFoundError):
+        load_holidays_csv(missing)
     csv_file = tmp_path / "hol.csv"
     csv_file.write_text("col\n1\n", encoding="utf-8")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Raise FileNotFoundError when holiday CSV is missing or unreadable in `load_holidays_csv`
- Add unit test to verify missing holiday CSV now triggers FileNotFoundError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894067113388325b05f6c0f3a0e2c7c