### PR TITLE
style: organize imports

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,8 +1,9 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from pathlib import Path
 import warnings
+from pathlib import Path
+
 import pandas as pd
 
 from utils.paths import resolve_path

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable, Optional, Set
 
 import pandas as pd
+
 from utils.paths import resolve_path
 
 

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -9,12 +9,8 @@ from utils.paths import resolve_path
 
 from .backtester import run_1g_returns
 from .benchmark import load_xu100_pct
-from .calendars import (
-    add_next_close,
-    add_next_close_calendar,
-    build_trading_days,
-    load_holidays_csv,
-)
+from .calendars import (add_next_close, add_next_close_calendar,
+                        build_trading_days, load_holidays_csv)
 from .config import load_config
 from .data_loader import read_excels_long
 from .indicators import compute_indicators
@@ -23,6 +19,8 @@ from .reporter import write_reports
 from .screener import run_screener
 from .utils import info
 from .validator import dataset_summary, quality_warnings
+
+
 @click.group()
 def cli():
     pass

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -1,12 +1,12 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from typing import Dict, List, Optional
-from pathlib import Path  # TİP DÜZELTİLDİ
 import os
+from pathlib import Path  # TİP DÜZELTİLDİ
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
 import yaml
+from pydantic import BaseModel, Field
 
 from utils.paths import resolve_path
 

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -1,9 +1,9 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
-import warnings
 
 import pandas as pd
 

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -1,11 +1,11 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from pathlib import Path
-from datetime import date  # TİP DÜZELTİLDİ
-from typing import Iterable, Optional, Mapping  # TİP DÜZELTİLDİ
-
 import warnings
+from datetime import date  # TİP DÜZELTİLDİ
+from pathlib import Path
+from typing import Iterable, Mapping, Optional  # TİP DÜZELTİLDİ
+
 import pandas as pd
 
 from utils.paths import resolve_path

--- a/backtest/utils.py
+++ b/backtest/utils.py
@@ -1,10 +1,10 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Optional  # TİP DÜZELTİLDİ
 import re
 import unicodedata
+from pathlib import Path
+from typing import Optional  # TİP DÜZELTİLDİ
 
 from loguru import logger
 

--- a/io_filters.py
+++ b/io_filters.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import pandas as pd
 
 from utils.paths import resolve_path
-
 
 REQUIRED_COLUMNS = {"FilterCode", "PythonQuery"}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 # DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 # Ensure the project root is on sys.path for imports
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,11 +3,8 @@ from __future__ import annotations
 
 import pandas as pd
 
-from backtest.calendars import (
-    add_next_close,
-    add_next_close_calendar,
-    build_trading_days,
-)
+from backtest.calendars import (add_next_close, add_next_close_calendar,
+                                build_trading_days)
 
 
 def test_next_close():

--- a/tests/test_calendars_validation.py
+++ b/tests/test_calendars_validation.py
@@ -1,12 +1,8 @@
-import pytest
 import pandas as pd
+import pytest
 
-from backtest.calendars import (
-    add_next_close,
-    add_next_close_calendar,
-    build_trading_days,
-    load_holidays_csv,
-)
+from backtest.calendars import (add_next_close, add_next_close_calendar,
+                                build_trading_days, load_holidays_csv)
 
 
 def test_add_next_close_invalid_inputs():

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -1,8 +1,10 @@
-import tempfile, textwrap
+import tempfile
+import textwrap
 from pathlib import Path
+
 import pytest
 
-from backtest.config import load_config, RootCfg
+from backtest.config import RootCfg, load_config
 
 
 def _write_cfg(text: str) -> Path:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,8 +1,10 @@
 import pandas as pd
 import pytest
+
 from backtest.normalizer import normalize
-from backtest.validator import quality_warnings
 from backtest.screener import run_screener
+from backtest.validator import quality_warnings
+
 
 def test_normalize_type_and_missing_columns():
     with pytest.raises(TypeError):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import ast
 import importlib
 import importlib.util
-from pathlib import Path
 import pkgutil
+from pathlib import Path
 
 import backtest
 

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -1,9 +1,10 @@
-import pandas as pd
-import pytest
 from types import SimpleNamespace
 
-from backtest.validator import dataset_summary, quality_warnings
+import pandas as pd
+import pytest
+
 from backtest.reporter import write_reports
+from backtest.validator import dataset_summary, quality_warnings
 
 
 def test_dataset_summary_invalid_type():


### PR DESCRIPTION
## Summary
- sort and group imports across modules and tests

## Testing
- `isort io_filters.py backtest/*.py utils/*.py tests/*.py --check-only`
- `flake8 --select=F401`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68940a428c588325a12573eae899dfd3