### PR TITLE
chore: clean up test imports

### DIFF
--- a/tests/test_benchmark_delimiter.py
+++ b/tests/test_benchmark_delimiter.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-import pandas as pd
 import pytest
 
 from backtest.benchmark import load_xu100_pct

--- a/tests/test_benchmark_paths.py
+++ b/tests/test_benchmark_paths.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from backtest.benchmark import load_xu100_pct

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from backtest.config import RootCfg, load_config
+from backtest.config import load_config
 
 
 def _write_cfg(text: str) -> Path:


### PR DESCRIPTION
## Summary
- remove unused imports from benchmarking and config tests
- tidy import grouping for tests

## Testing
- `ruff check . --select F401,F403,F404,F405,F811 --statistics`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68940c166b608325ad361f22f85a3d75