### PR TITLE
style: fix syntax and style issues

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -66,14 +66,18 @@ def build_trading_days(
     if holidays is not None:
         if isinstance(holidays, (int, float)):
             raise TypeError("holidays must be iterable or date-like")  # TİP DÜZELTİLDİ
-        if isinstance(holidays, Iterable) and not isinstance(holidays, (str, bytes, pd.Timestamp)):
+        if isinstance(holidays, Iterable) and not isinstance(
+            holidays, (str, bytes, pd.Timestamp)
+        ):
             hol_iter = list(holidays)
         else:
             hol_iter = [holidays]
         try:
             hol = set(pd.to_datetime(hol_iter).normalize())  # TİP DÜZELTİLDİ
         except Exception as e:  # pragma: no cover - defensive
-            raise ValueError("holidays contains non-date values") from e  # TİP DÜZELTİLDİ
+            raise ValueError(
+                "holidays contains non-date values"
+            ) from e  # TİP DÜZELTİLDİ
     else:
         hol = set()
     trade = [d for d in all_days if (not is_weekend(d)) and (d.normalize() not in hol)]

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -100,9 +100,16 @@ def load_config(path: str | Path) -> RootCfg:
             data[k] = _join(v)  # PATH DÜZENLENDİ
     cal = cfg.get("calendar", {}) if isinstance(cfg, dict) else {}
     if isinstance(cal, dict) and cal.get("holidays_csv_path"):
-        cal["holidays_csv_path"] = _join(cal.get("holidays_csv_path"))  # PATH DÜZENLENDİ
+        cal["holidays_csv_path"] = _join(
+            cal.get("holidays_csv_path")
+        )  # PATH DÜZENLENDİ
     bench = cfg.get("benchmark", {}) if isinstance(cfg, dict) else {}
     if isinstance(bench, dict) and bench.get("xu100_csv_path"):
         bench["xu100_csv_path"] = _join(bench.get("xu100_csv_path"))  # PATH DÜZENLENDİ
-    cfg["project"], cfg["data"], cfg["calendar"], cfg["benchmark"] = proj, data, cal, bench
+    cfg["project"], cfg["data"], cfg["calendar"], cfg["benchmark"] = (
+        proj,
+        data,
+        cal,
+        bench,
+    )
     return RootCfg(**cfg)

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -40,7 +40,9 @@ def compute_indicators(
             macd_params = [macd_params]  # TİP DÜZELTİLDİ
         macd_params = list(macd_params)
         if len(macd_params) < 3:
-            raise ValueError("macd params must have at least three values")  # TİP DÜZELTİLDİ
+            raise ValueError(
+                "macd params must have at least three values"
+            )  # TİP DÜZELTİLDİ
         fast, slow, sig = map(int, macd_params[:3])
         macd = ta.macd(g["close"], fast=fast, slow=slow, signal=sig)
         if macd is not None and not macd.empty:

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -53,16 +53,24 @@ def write_reports(
     missing = req_cols.difference(trades_all.columns)
     if missing:
         raise ValueError(
-            f"trades_all missing columns: {', '.join(sorted(missing))}"  # TİP DÜZELTİLDİ
-        )
+            f"trades_all missing columns: {', '.join(sorted(missing))}"
+        )  # TİP DÜZELTİLDİ
     if summary_wide is not None and not isinstance(summary_wide, pd.DataFrame):
         raise TypeError("summary_wide must be a DataFrame or None")  # TİP DÜZELTİLDİ
     if summary_winrate is not None and not isinstance(summary_winrate, pd.DataFrame):
         raise TypeError("summary_winrate must be a DataFrame or None")  # TİP DÜZELTİLDİ
-    if validation_summary is not None and not isinstance(validation_summary, pd.DataFrame):
-        raise TypeError("validation_summary must be a DataFrame or None")  # TİP DÜZELTİLDİ
-    if validation_issues is not None and not isinstance(validation_issues, pd.DataFrame):
-        raise TypeError("validation_issues must be a DataFrame or None")  # TİP DÜZELTİLDİ
+    if validation_summary is not None and not isinstance(
+        validation_summary, pd.DataFrame
+    ):
+        raise TypeError(
+            "validation_summary must be a DataFrame or None"
+        )  # TİP DÜZELTİLDİ
+    if validation_issues is not None and not isinstance(
+        validation_issues, pd.DataFrame
+    ):
+        raise TypeError(
+            "validation_issues must be a DataFrame or None"
+        )  # TİP DÜZELTİLDİ
 
     if dates is None:
         dates = tuple()  # TİP DÜZELTİLDİ
@@ -78,7 +86,9 @@ def write_reports(
         out_xlsx_path = resolve_path(out_xlsx)
         _ensure_dir(out_xlsx_path)
         try:
-            writer = pd.ExcelWriter(out_xlsx_path, engine="xlsxwriter")  # PATH DÜZENLENDİ
+            writer = pd.ExcelWriter(
+                out_xlsx_path, engine="xlsxwriter"
+            )  # PATH DÜZENLENDİ
         except Exception:
             warnings.warn(f"Excel yazılamadı: {out_xlsx_path}")  # PATH DÜZENLENDİ
         else:
@@ -88,19 +98,21 @@ def write_reports(
                     day_df = day_df.sort_values(["FilterCode", "Symbol"])
                     sheet = f"{daily_sheet_prefix}{d}"
                     day_df.to_excel(writer, sheet_name=sheet, index=False)
-    
+
                 summary_wide.to_excel(writer, sheet_name=summary_sheet_name)
-    
+
                 if summary_winrate is not None and not summary_winrate.empty:
                     summary_winrate.to_excel(
                         writer, sheet_name=f"{summary_sheet_name}_WINRATE"
                     )
-    
+
                 if xu100_pct is not None:
                     if isinstance(xu100_pct, pd.Series):
                         xu100_series = xu100_pct.astype(float)  # TİP DÜZELTİLDİ
                     elif isinstance(xu100_pct, Mapping):
-                        xu100_series = pd.Series(dict(xu100_pct), dtype=float)  # TİP DÜZELTİLDİ
+                        xu100_series = pd.Series(
+                            dict(xu100_pct), dtype=float
+                        )  # TİP DÜZELTİLDİ
                     else:
                         raise TypeError(
                             "xu100_pct must be a mapping or Series"
@@ -128,7 +140,7 @@ def write_reports(
                     )
                     if not bist.empty:
                         bist.to_excel(writer, sheet_name="BIST")
-    
+
                 # Optional validation
                 if validation_summary is not None and not validation_summary.empty:
                     validation_summary.to_excel(
@@ -138,11 +150,11 @@ def write_reports(
                     validation_issues.to_excel(
                         writer, sheet_name="VALIDATION_ISSUES", index=False
                     )
-    
+
                 wb = writer.book
                 num_fmt = wb.add_format({"num_format": "0.00"})
                 pct_fmt = wb.add_format({"num_format": percent_fmt})
-    
+
                 for d in dates:
                     sheet = f"{daily_sheet_prefix}{d}"
                     ws = writer.sheets[sheet]
@@ -153,21 +165,21 @@ def write_reports(
                     rows = len(trades_all[trades_all["Date"] == d])
                     last_row = rows if rows > 0 else 0  # LOJİK HATASI DÜZELTİLDİ
                     ws.autofilter(0, 0, last_row, 6)
-    
+
                 if summary_sheet_name in writer.sheets:
                     ws = writer.sheets[summary_sheet_name]
                     ws.set_column(1, 100, 12, num_fmt)
-    
+
                 wr_sheet = f"{summary_sheet_name}_WINRATE"
                 if wr_sheet in writer.sheets:
                     ws = writer.sheets[wr_sheet]
                     ws.set_column(1, 100, 12, pct_fmt)
-    
+
                 diff_sheet = f"{summary_sheet_name}_DIFF"
                 if diff_sheet in writer.sheets:
                     ws = writer.sheets[diff_sheet]
                     ws.set_column(1, 100, 12, num_fmt)
-    
+
     if out_csv_dir:
         out_csv_path = resolve_path(out_csv_dir)
         out_csv_path.mkdir(parents=True, exist_ok=True)

--- a/backtest/validator.py
+++ b/backtest/validator.py
@@ -12,7 +12,9 @@ def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:
     req = {"symbol", "date", "close"}
     missing = req.difference(df.columns)
     if missing:
-        raise ValueError(f"Eksik kolon(lar): {', '.join(sorted(missing))}")  # TİP DÜZELTİLDİ
+        raise ValueError(
+            f"Eksik kolon(lar): {', '.join(sorted(missing))}"
+        )  # TİP DÜZELTİLDİ
     if df.empty:
         return pd.DataFrame(
             columns=[
@@ -43,7 +45,9 @@ def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
     req = {"symbol", "date", "close"}
     missing = req.difference(df.columns)
     if missing:
-        raise ValueError(f"Eksik kolon(lar): {', '.join(sorted(missing))}")  # TİP DÜZELTİLDİ
+        raise ValueError(
+            f"Eksik kolon(lar): {', '.join(sorted(missing))}"
+        )  # TİP DÜZELTİLDİ
     issues = []
     if df.empty:
         return pd.DataFrame(columns=["symbol", "date", "issue", "value"])
@@ -74,4 +78,6 @@ def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame(
             columns=["symbol", "date", "issue", "value"]
         )  # TİP DÜZELTİLDİ
-    return pd.DataFrame(issues, columns=["symbol", "date", "issue", "value"])  # TİP DÜZELTİLDİ
+    return pd.DataFrame(
+        issues, columns=["symbol", "date", "issue", "value"]
+    )  # TİP DÜZELTİLDİ

--- a/io_filters.py
+++ b/io_filters.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Helpers for reading filter CSV files."""
 
 from __future__ import annotations
@@ -40,9 +41,7 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
 
     missing = REQUIRED_COLUMNS.difference(df.columns)
     if missing:
-        raise RuntimeError(
-            "Eksik kolon(lar): " + ", ".join(sorted(missing))
-        )
+        raise RuntimeError("Eksik kolon(lar): " + ", ".join(sorted(missing)))
 
     # basic normalization
     df["FilterCode"] = df["FilterCode"].astype(str).str.strip()
@@ -51,4 +50,3 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
 
 
 __all__ = ["load_filters_csv"]
-

--- a/tests/test_backtester_validation.py
+++ b/tests/test_backtester_validation.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
@@ -18,7 +19,11 @@ def _base_df():
 
 def _signals_df():
     return pd.DataFrame(
-        {"FilterCode": ["F"], "Symbol": ["AAA"], "Date": pd.to_datetime(["2024-01-01"]).date}
+        {
+            "FilterCode": ["F"],
+            "Symbol": ["AAA"],
+            "Date": pd.to_datetime(["2024-01-01"]).date,
+        }
     )
 
 
@@ -39,7 +44,9 @@ def test_run_1g_returns_missing_columns():
 
 
 def test_run_1g_returns_empty_signals():
-    res = run_1g_returns(_base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"]))
+    res = run_1g_returns(
+        _base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
+    )
     assert list(res.columns) == [
         "FilterCode",
         "Symbol",

--- a/tests/test_calendars_validation.py
+++ b/tests/test_calendars_validation.py
@@ -1,20 +1,27 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
-from backtest.calendars import (add_next_close, add_next_close_calendar,
-                                build_trading_days, load_holidays_csv)
+from backtest.calendars import (
+    add_next_close,
+    add_next_close_calendar,
+    build_trading_days,
+    load_holidays_csv,
+)
 
 
 def test_add_next_close_invalid_inputs():
     with pytest.raises(TypeError):
         add_next_close([])
-    df_missing = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")]} )
+    df_missing = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")]})
     with pytest.raises(ValueError):
         add_next_close(df_missing)
 
 
 def test_add_next_close_calendar_invalid_inputs():
-    df = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")], "close": [1.0]})
+    df = pd.DataFrame(
+        {"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")], "close": [1.0]}
+    )
     with pytest.raises(TypeError):
         add_next_close_calendar([], pd.DatetimeIndex([]))
     with pytest.raises(TypeError):

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -11,10 +12,16 @@ def _cfg():
     return SimpleNamespace(
         project=SimpleNamespace(out_dir="out", start_date=None, end_date=None),
         data=SimpleNamespace(filters_csv="dummy.csv"),
-        calendar=SimpleNamespace(tplus1_mode="price", holidays_source="none", holidays_csv_path=None),
+        calendar=SimpleNamespace(
+            tplus1_mode="price", holidays_source="none", holidays_csv_path=None
+        ),
         indicators=SimpleNamespace(params={}),
         benchmark=SimpleNamespace(xu100_source="none", xu100_csv_path=None),
-        report=SimpleNamespace(daily_sheet_prefix="SCAN_", summary_sheet_name="SUMMARY", percent_format="0.00%"),
+        report=SimpleNamespace(
+            daily_sheet_prefix="SCAN_",
+            summary_sheet_name="SUMMARY",
+            percent_format="0.00%",
+        ),
     )
 
 
@@ -38,8 +45,28 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(cli, "normalize", lambda df: df)
     monkeypatch.setattr(cli, "add_next_close", lambda df: df)
     monkeypatch.setattr(cli, "compute_indicators", lambda df, params: df)
-    monkeypatch.setattr(cli, "run_screener", lambda df, filters, d: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "mask"]))
-    monkeypatch.setattr(cli, "run_1g_returns", lambda df, sigs: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win"]))
+    monkeypatch.setattr(
+        cli,
+        "run_screener",
+        lambda df, filters, d: pd.DataFrame(
+            columns=["FilterCode", "Symbol", "Date", "mask"]
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_1g_returns",
+        lambda df, sigs: pd.DataFrame(
+            columns=[
+                "FilterCode",
+                "Symbol",
+                "Date",
+                "EntryClose",
+                "ExitClose",
+                "ReturnPct",
+                "Win",
+            ]
+        ),
+    )
     monkeypatch.setattr(cli, "write_reports", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
@@ -67,8 +94,28 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(cli, "normalize", lambda df: df)
     monkeypatch.setattr(cli, "add_next_close", lambda df: df)
     monkeypatch.setattr(cli, "compute_indicators", lambda df, params: df)
-    monkeypatch.setattr(cli, "run_screener", lambda df, filters, d: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "mask"]))
-    monkeypatch.setattr(cli, "run_1g_returns", lambda df, sigs: pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win"]))
+    monkeypatch.setattr(
+        cli,
+        "run_screener",
+        lambda df, filters, d: pd.DataFrame(
+            columns=["FilterCode", "Symbol", "Date", "mask"]
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_1g_returns",
+        lambda df, sigs: pd.DataFrame(
+            columns=[
+                "FilterCode",
+                "Symbol",
+                "Date",
+                "EntryClose",
+                "ExitClose",
+                "ReturnPct",
+                "Win",
+            ]
+        ),
+    )
     monkeypatch.setattr(cli, "write_reports", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())

--- a/tests/test_config_missing.py
+++ b/tests/test_config_missing.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pytest
 
 from backtest.config import load_config
@@ -7,4 +8,3 @@ def test_load_config_missing_file(tmp_path):
     missing = tmp_path / "nonexistent.yml"
     with pytest.raises(FileNotFoundError):
         load_config(missing)
-

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from pathlib import Path
 import tempfile
 import textwrap
@@ -15,6 +16,7 @@ def _write_cfg(text: str) -> Path:
         tmp.flush()
         return Path(tmp.name)
 
+
 def test_load_config_independent_defaults():
     cfg_text = textwrap.dedent(
         """
@@ -30,11 +32,11 @@ def test_load_config_independent_defaults():
     )
     path = _write_cfg(cfg_text)
     cfg1 = load_config(path)
-    cfg1.calendar.holidays_source = 'csv'
-    cfg1.indicators.params['ema'].append(99)
+    cfg1.calendar.holidays_source = "csv"
+    cfg1.indicators.params["ema"].append(99)
     cfg2 = load_config(path)
-    assert cfg2.calendar.holidays_source == 'none'
-    assert 99 not in cfg2.indicators.params['ema']
+    assert cfg2.calendar.holidays_source == "none"
+    assert 99 not in cfg2.indicators.params["ema"]
 
 
 def test_load_config_invalid_yaml():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
@@ -13,26 +14,32 @@ def test_normalize_type_and_missing_columns():
     with pytest.raises(ValueError):
         normalize(df_missing)
 
+
 def test_quality_warnings_no_issues():
-    df = pd.DataFrame({
-        "symbol": ["AAA", "AAA"],
-        "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).date,
-        "close": [1.0, 2.0],
-    })
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).date,
+            "close": [1.0, 2.0],
+        }
+    )
     res = quality_warnings(df)
     assert list(res.columns) == ["symbol", "date", "issue", "value"]
     assert res.empty
 
+
 def test_run_screener_no_hits():
-    df_ind = pd.DataFrame({
-        "symbol": ["AAA"],
-        "date": pd.to_datetime(["2024-01-02"]).date,
-        "open": [1.0],
-        "high": [1.0],
-        "low": [1.0],
-        "close": [1.0],
-        "volume": [100],
-    })  # TİP DÜZELTİLDİ
+    df_ind = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).date,
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [100],
+        }
+    )  # TİP DÜZELTİLDİ
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 2"]})
     res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert list(res.columns) == ["FilterCode", "Symbol", "Date", "mask"]

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
@@ -15,7 +16,9 @@ def test_compute_indicators_invalid_inputs():
 
 def test_run_screener_invalid_inputs():
     filters_df = pd.DataFrame({"FilterCode": [], "PythonQuery": []})
-    df_ind = pd.DataFrame({"symbol": [], "open": [], "high": [], "low": [], "close": [], "volume": []})
+    df_ind = pd.DataFrame(
+        {"symbol": [], "open": [], "high": [], "low": [], "close": [], "volume": []}
+    )
     with pytest.raises(TypeError):
         run_screener([], filters_df, pd.Timestamp("2024-01-02"))
     with pytest.raises(TypeError):

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from types import SimpleNamespace
 
 import pandas as pd
@@ -51,4 +52,6 @@ def test_write_reports_xu100_pct_type(monkeypatch):
         ]
     )
     with pytest.raises(TypeError):
-        write_reports(trades, [], pd.DataFrame(), xu100_pct=[1, 2], out_xlsx="dummy.xlsx")
+        write_reports(
+            trades, [], pd.DataFrame(), xu100_pct=[1, 2], out_xlsx="dummy.xlsx"
+        )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,6 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Utility package for shared helpers."""
 
 from .paths import resolve_path
 
 __all__ = ["resolve_path"]
-

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,3 +1,4 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Path utilities."""
 
 from __future__ import annotations
@@ -31,4 +32,3 @@ def resolve_path(path: Union[str, os.PathLike]) -> Path:
 
 
 __all__ = ["resolve_path"]
-


### PR DESCRIPTION
## Summary
- format and clean syntax across modules
- ensure consistent headers for syntax cleanup

## Testing
- `flake8`
- `python -m py_compile backtest/calendars.py ... utils/paths.py`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68941096b6e08325b82b684d828bd643