### PR TITLE
Refactor configuration into modular package

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .filters_config import FILTER_LIST
+from .paths_config import DATA_PATH, OUTPUT_PATH, LOG_DIR
+from .settings import START_DATE, CAPITAL
+from .crossovers_config import (
+    SERIES_SERIES_CROSSOVERS,
+    SERIES_VALUE_CROSSOVERS,
+)
+
+__all__ = [
+    "FILTER_LIST",
+    "DATA_PATH",
+    "OUTPUT_PATH",
+    "LOG_DIR",
+    "START_DATE",
+    "CAPITAL",
+    "SERIES_SERIES_CROSSOVERS",
+    "SERIES_VALUE_CROSSOVERS",
+]

--- a/config/crossovers_config.py
+++ b/config/crossovers_config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+# Example crossover definitions
+SERIES_SERIES_CROSSOVERS: List[Tuple[str, str]] = [
+    ("sma_20", "sma_50"),
+    ("sma_50", "sma_200"),
+]
+
+SERIES_VALUE_CROSSOVERS: List[Tuple[str, float]] = [
+    ("rsi_14", 50.0),
+]
+
+__all__ = ["SERIES_SERIES_CROSSOVERS", "SERIES_VALUE_CROSSOVERS"]

--- a/config/filters_config.py
+++ b/config/filters_config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+
+# Path to the filters definition file relative to the repository root
+_FILTERS_CSV = Path(__file__).resolve().parent.parent / "filters.csv"
+
+
+def _load_filter_codes() -> list[str]:
+    """Return list of filter codes from ``filters.csv`` if available."""
+    if not _FILTERS_CSV.exists():
+        return []
+    with _FILTERS_CSV.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        return [row["FilterCode"] for row in reader if row.get("FilterCode")]
+
+
+FILTER_LIST: list[str] = _load_filter_codes()
+
+__all__ = ["FILTER_LIST"]

--- a/config/paths_config.py
+++ b/config/paths_config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+# Repository root
+_ROOT = Path(__file__).resolve().parent.parent
+
+# Commonly used directories
+DATA_PATH = (_ROOT / "Veri").resolve()
+OUTPUT_PATH = (_ROOT / "output").resolve()
+LOG_DIR = (_ROOT / "logs").resolve()
+
+__all__ = ["DATA_PATH", "OUTPUT_PATH", "LOG_DIR"]

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+# General configurable parameters
+START_DATE = "2024-01-01"
+CAPITAL = 100_000
+
+__all__ = ["START_DATE", "CAPITAL"]


### PR DESCRIPTION
## Summary
- modularize configuration into `config` package
- expose filter codes, common paths, settings and crossover definitions via dedicated modules
- re-export legacy names through `config.__init__`

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894bd0fdea08325941f55b51c13dfe4