### PR TITLE
Add SafeQuery for secure screener filtering

### DIFF
--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -1,0 +1,59 @@
+"""Safe evaluation for DataFrame queries."""
+from __future__ import annotations
+
+import ast
+import string
+from typing import Set
+
+import pandas as pd
+
+
+class SafeQuery:
+    """Validate and run pandas ``DataFrame.query`` expressions.
+
+    Parameters
+    ----------
+    expr:
+        The query expression to validate. Validation checks for
+        disallowed characters and AST nodes that may lead to unsafe
+        execution. The expression is considered safe if it only contains
+        allowed characters and does not include :class:`ast.Call` or
+        :class:`ast.Attribute` nodes.
+    """
+
+    # characters permitted inside a query expression
+    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.% ") | set(
+        string.ascii_letters + string.digits + "_"
+    )
+
+    def __init__(self, expr: str):
+        self.expr = expr
+        self.is_safe = self._validate(expr)
+
+    @classmethod
+    def _validate(cls, expr: str) -> bool:
+        """Return ``True`` if *expr* is safe to evaluate."""
+        # quick character check
+        if any(ch not in cls._ALLOWED_CHARS for ch in expr):
+            return False
+        try:
+            tree = ast.parse(expr, mode="eval")
+        except SyntaxError:
+            return False
+        # disallow function calls and attribute access
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Call, ast.Attribute)):
+                return False
+        return True
+
+    def filter(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return rows from *df* matching the query expression.
+
+        Raises
+        ------
+        ValueError
+            If the stored expression is unsafe.
+        """
+        if not self.is_safe:
+            raise ValueError("Unsafe query expression")
+        return df.query(self.expr)

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from backtest.query_parser import SafeQuery
+from backtest.screener import run_screener
+
+
+def test_safequery_basic():
+    q = SafeQuery("rsi_14 > 70 & close>ema_20")
+    assert q.is_safe
+
+
+def test_safequery_rejects_calls_and_attributes():
+    assert not SafeQuery("__import__('os').system('echo 1')").is_safe
+    assert not SafeQuery("df.__class__").is_safe
+
+
+def test_run_screener_skips_unsafe():
+    df_ind = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).date,
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [100],
+        }
+    )
+    filters = pd.DataFrame(
+        {
+            "FilterCode": ["SAFE", "BAD"],
+            "PythonQuery": ["close > 0", "__import__('os').system('echo 1')"],
+        }
+    )
+    res = run_screener(df_ind, filters, pd.Timestamp("2024-01-02"))
+    assert res["FilterCode"].tolist() == ["SAFE"]


### PR DESCRIPTION
## Summary
- Implement SafeQuery class to validate and run DataFrame queries safely
- Replace eval usage in screener with SafeQuery
- Add tests for SafeQuery and screener integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894c4a85fdc83259028fdb672b28551