### PR TITLE
Validate filter CSV with Pandera

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,6 @@
+"""Utility library."""
+from __future__ import annotations
+
+from .validator import validate_filters
+
+__all__ = ["validate_filters"]

--- a/lib/validator.py
+++ b/lib/validator.py
@@ -1,0 +1,38 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
+"""CSV validation helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pandera as pa
+
+
+_SCHEMA = pa.DataFrameSchema(
+    {
+        "filter_name": pa.Column(pa.String, nullable=False, checks=pa.Check.str_length(min_value=1)),
+        "query": pa.Column(pa.String, nullable=False, checks=pa.Check.str_length(min_value=1)),
+        "group": pa.Column(pa.String, nullable=True),
+    },
+    coerce=True,
+)
+
+
+def validate_filters(path: str | Path) -> pd.DataFrame:
+    """Validate filter definitions CSV against the schema."""
+    p = Path(path)
+    df = pd.read_csv(p)
+    try:
+        _SCHEMA.validate(df, lazy=True)
+    except pa.errors.SchemaErrors as err:
+        fc = err.failure_cases
+        if not fc.empty and fc["index"].notna().any():
+            first = fc[fc["index"].notna()].iloc[0]
+            column = first["column"]
+            row_num = int(first["index"]) + 2
+            raise ValueError(f"{p.name} satır {row_num} – {column} boş olamaz") from None
+        raise ValueError(f"{p.name} şema doğrulaması başarısız") from None
+    return df
+
+
+__all__ = ["validate_filters"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from lib.validator import validate_filters
+
+validate_filters("filters.csv")
+
+
+def main() -> None:
+    """Entry point."""
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic>=2.7
 loguru>=0.7
 PyYAML>=6.0
 pytest>=8.2
+pandera>=0.16


### PR DESCRIPTION
## Summary
- add `validate_filters` using Pandera to enforce filter CSV schema and raise detailed errors
- invoke `validate_filters('filters.csv')` at startup in `main.py`
- declare Pandera dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c951804483259fdd59afb9ce3e29