### PR TITLE
Handle filters with zero trades

### DIFF
--- a/backtest/report.py
+++ b/backtest/report.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+from utils.paths import resolve_path
+
+
+def drop_inactive_filters(df_stats: pd.DataFrame, out_dir: Union[str, Path] = "raporlar") -> pd.DataFrame:
+    """Remove filters with zero trades from stats and log them.
+
+    Parameters
+    ----------
+    df_stats : pd.DataFrame
+        Statistics per filter. Must contain ``FilterCode`` and ``trade_count`` columns.
+    out_dir : str | Path, default "raporlar"
+        Directory where ``inactive_filters.txt`` will be written.
+
+    Returns
+    -------
+    pd.DataFrame
+        ``df_stats`` without rows where ``trade_count`` equals zero.
+    """
+    if not isinstance(df_stats, pd.DataFrame):
+        raise TypeError("df_stats must be a DataFrame")
+
+    required_cols = {"FilterCode", "trade_count"}
+    missing = required_cols.difference(df_stats.columns)
+    if missing:
+        raise ValueError(f"df_stats missing columns: {', '.join(sorted(missing))}")
+
+    mask = df_stats["trade_count"] == 0
+    inactive = df_stats.loc[mask, "FilterCode"].astype(str).tolist()
+
+    if inactive:
+        out_path = resolve_path(out_dir) / "inactive_filters.txt"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fh:
+            fh.write("\n".join(inactive))
+        warnings.warn(
+            f"{len(inactive)} filtre işlem üretmedi: {', '.join(inactive)}",
+            RuntimeWarning,
+        )
+
+    return df_stats.loc[~mask].copy()
+
+
+__all__ = ["drop_inactive_filters"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import warnings
+import pandas as pd
+
+from backtest.report import drop_inactive_filters
+
+
+def test_drop_inactive_filters_writes_file_and_warns(tmp_path):
+    df = pd.DataFrame({
+        "FilterCode": ["t1", "t2", "t3"],
+        "trade_count": [5, 0, 3],
+        "extra": [1, 2, 3],
+    })
+    out_dir = tmp_path / "raporlar"
+    with warnings.catch_warnings(record=True) as w:
+        filtered = drop_inactive_filters(df, out_dir)
+        assert filtered["FilterCode"].tolist() == ["t1", "t3"]
+        inactive_file = out_dir / "inactive_filters.txt"
+        assert inactive_file.exists()
+        assert inactive_file.read_text(encoding="utf-8").strip() == "t2"
+        assert any("t2" in str(wi.message) for wi in w)
+
+
+def test_drop_inactive_filters_no_inactive(tmp_path):
+    df = pd.DataFrame({
+        "FilterCode": ["t1", "t2"],
+        "trade_count": [1, 2],
+    })
+    out_dir = tmp_path / "raporlar"
+    with warnings.catch_warnings(record=True) as w:
+        filtered = drop_inactive_filters(df, out_dir)
+        assert filtered.equals(df)
+        assert not (out_dir / "inactive_filters.txt").exists()
+        assert w == []


### PR DESCRIPTION
## Summary
- Add `drop_inactive_filters` to remove filters with no trades and log them
- Write inactive filter codes to `inactive_filters.txt`
- Test dropping inactive filters and warning behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894cbd84f708325ab84da18c848a7b7