### PR TITLE
Add comprehensive test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ python -m backtest.cli scan-day --config examples/example_config.yaml --date 202
 ```
 SCAN 2024-01-02: 24 satır, ort. %1.2
 ```
+## Test Çalıştırma
+```bash
+pytest -q
+```
+
 
 ## Sürüm Notları
 - 1.1.0: Colab desteği ve yeni README.

--- a/config/filters_config.py
+++ b/config/filters_config.py
@@ -8,14 +8,24 @@ _FILTERS_CSV = Path(__file__).resolve().parent.parent / "filters.csv"
 
 
 def _load_filter_codes() -> list[str]:
-    """Return list of filter codes from ``filters.csv`` if available."""
+    """Return list of filter codes from ``filters.csv`` if available.
+
+    Raises
+    ------
+    ValueError
+        If ``filters.csv`` lacks the required ``FilterCode`` column.
+    """
     if not _FILTERS_CSV.exists():
         return []
     with _FILTERS_CSV.open(encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
+        if "FilterCode" not in (reader.fieldnames or []):
+            raise ValueError("filters.csv missing 'FilterCode' column")
         return [row["FilterCode"] for row in reader if row.get("FilterCode")]
 
 
 FILTER_LIST: list[str] = _load_filter_codes()
+if not isinstance(FILTER_LIST, list):  # pragma: no cover - defensive
+    raise TypeError("FILTER_LIST must be a list of strings")
 
 __all__ = ["FILTER_LIST"]

--- a/tests/data/filters_empty.csv
+++ b/tests/data/filters_empty.csv
@@ -1,0 +1,2 @@
+filter_name,query,group
+f1,,A

--- a/tests/data/filters_missing_col.csv
+++ b/tests/data/filters_missing_col.csv
@@ -1,0 +1,2 @@
+FilterCode
+F1

--- a/tests/data/filters_valid.csv
+++ b/tests/data/filters_valid.csv
@@ -1,0 +1,3 @@
+filter_name,query,group
+f1,close > 0,A
+f2,volume > 0,B

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+from config import filters_config, paths_config, settings
+
+
+def test_settings_types():
+    assert isinstance(settings.START_DATE, str)
+    assert isinstance(settings.CAPITAL, int)
+
+
+def test_paths_are_paths():
+    assert isinstance(paths_config.DATA_PATH, Path)
+    assert isinstance(paths_config.OUTPUT_PATH, Path)
+    assert isinstance(paths_config.LOG_DIR, Path)
+
+
+def test_filter_list_type():
+    assert isinstance(filters_config.FILTER_LIST, list)
+
+
+def test_invalid_filter_list_raises(monkeypatch, tmp_path):
+    bad_csv = tmp_path / "bad.csv"
+    bad_csv.write_text("Wrong;\n1;\n", encoding="utf-8")
+    monkeypatch.setattr(filters_config, "_FILTERS_CSV", bad_csv)
+    with pytest.raises(ValueError):
+        filters_config._load_filter_codes()
+
+
+def test_filter_list_missing_column_raises(monkeypatch, tmp_path):
+    missing_csv = tmp_path / "missing.csv"
+    missing_csv.write_text("Other\n1\n", encoding="utf-8")
+    monkeypatch.setattr(filters_config, "_FILTERS_CSV", missing_csv)
+    with pytest.raises(ValueError):
+        filters_config._load_filter_codes()

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -1,0 +1,19 @@
+import pytest
+from io_filters import load_filters_csv
+from lib.validator import validate_filters
+
+
+def test_validate_filters_ok():
+    df = validate_filters("tests/data/filters_valid.csv")
+    assert list(df.columns) == ["filter_name", "query", "group"]
+    assert len(df) == 2
+
+
+def test_validate_filters_empty_query():
+    with pytest.raises(ValueError):
+        validate_filters("tests/data/filters_empty.csv")
+
+
+def test_load_filters_missing_column():
+    with pytest.raises(RuntimeError):
+        load_filters_csv("tests/data/filters_missing_col.csv")

--- a/tests/test_indicators_consistency.py
+++ b/tests/test_indicators_consistency.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import pandas_ta as ta
+import indicator_calculator as ic
+
+
+def test_rsi_and_adx_match_pandas_ta():
+    close = pd.Series(range(1, 31))
+    high = close + 1
+    low = close - 1
+    expected_rsi = ta.rsi(close, length=14)
+    expected_adx = ta.adx(high, low, close, length=14)["ADX_14"]
+    pd.testing.assert_series_equal(ic.rsi_14(close), expected_rsi, check_names=False)
+    pd.testing.assert_series_equal(
+        ic.adx_14(high, low, close), expected_adx, check_names=False
+    )

--- a/tests/test_query_parser_security.py
+++ b/tests/test_query_parser_security.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import pytest
+
+from backtest.query_parser import SafeQuery
+
+
+def test_filter_returns_subset():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    q = SafeQuery("x > 1")
+    out = q.filter(df)
+    assert out["x"].tolist() == [2, 3]
+
+
+def test_filter_rejects_unsafe_expression():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    q = SafeQuery("__import__('os').system('echo 1')")
+    with pytest.raises(ValueError):
+        q.filter(df)


### PR DESCRIPTION
## Summary
- add configuration type checks for settings and paths
- harden query parser with safe/unsafe filter tests
- validate indicator outputs against pandas_ta and ensure filter CSV schema integrity
- document how to run tests via `pytest -q`
- guard against malformed `FILTER_LIST` structures and missing `FilterCode` columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894de88869c8325af008a447cfcdd86