### PR TITLE
Defer filter validation to runtime

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from lib.validator import validate_filters
-
-validate_filters("filters.csv")
-
-
 def main() -> None:
     """Entry point."""
-    pass
+    from lib.validator import validate_filters
+
+    try:
+        validate_filters("filters.csv")
+    except FileNotFoundError:
+        print("filters.csv dosyası bulunamadı. Lütfen dosyanın mevcut olduğundan emin olun.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Move filter validation into `main` to avoid running during import
- Gracefully handle missing `filters.csv`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ea4449088325b03ce21e282b9a14