### PR TITLE
Raise FileNotFoundError for missing filters CSV

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -50,8 +50,12 @@ def scan_range(config_path, start_date, end_date):
     info("Göstergeler hesaplanıyor...")
     df_ind = compute_indicators(df, cfg.indicators.params)
     info("Filtre CSV okunuyor...")
-    filters_df = load_filters_csv(cfg.data.filters_csv)
-    if filters_df.empty:
+    try:
+        filters_df = load_filters_csv(cfg.data.filters_csv)
+        if filters_df.empty:
+            filters_df = pd.DataFrame(columns=["FilterCode", "PythonQuery"])
+    except FileNotFoundError as exc:
+        info(str(exc))
         filters_df = pd.DataFrame(columns=["FilterCode", "PythonQuery"])
     all_days = sorted(pd.to_datetime(df_ind["date"]).dt.date.unique())
     if not all_days:
@@ -158,8 +162,12 @@ def scan_day(config_path, date_str):
     info("Göstergeler hesaplanıyor...")
     df_ind = compute_indicators(df, cfg.indicators.params)
     info("Filtre CSV okunuyor...")
-    filters_df = load_filters_csv(cfg.data.filters_csv)
-    if filters_df.empty:
+    try:
+        filters_df = load_filters_csv(cfg.data.filters_csv)
+        if filters_df.empty:
+            filters_df = pd.DataFrame(columns=["FilterCode", "PythonQuery"])
+    except FileNotFoundError as exc:
+        info(str(exc))
         filters_df = pd.DataFrame(columns=["FilterCode", "PythonQuery"])
     day = pd.to_datetime(date_str).date()
     sigs = run_screener(df_ind, filters_df, day)

--- a/io_filters.py
+++ b/io_filters.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -25,19 +24,17 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     -------
     pandas.DataFrame
         DataFrame containing the filter definitions. If the file is missing
-        or cannot be parsed, an empty DataFrame is returned and a warning is
-        issued. Missing required columns raise ``RuntimeError``.
+        or cannot be parsed, ``FileNotFoundError`` is raised. Missing required
+        columns raise ``RuntimeError``.
     """
 
     p = resolve_path(path)
     if not p.exists():
-        warnings.warn(f"Filters CSV bulunamadı: {p}")
-        return pd.DataFrame()
+        raise FileNotFoundError(f"Filters CSV bulunamadı: {p}")
     try:
         df = pd.read_csv(p, encoding="utf-8")
-    except Exception:
-        warnings.warn(f"Filters CSV okunamadı: {p}")
-        return pd.DataFrame()
+    except Exception as exc:
+        raise FileNotFoundError(f"Filters CSV okunamadı: {p}") from exc
 
     missing = REQUIRED_COLUMNS.difference(df.columns)
     if missing:


### PR DESCRIPTION
## Summary
- Raise `FileNotFoundError` when filters CSV is missing or unreadable
- Catch missing filter CSV in CLI commands and fall back to empty filter set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894ebb3478c8325a5f50d53c744bcd2