### PR TITLE
Handle missing Excel data with clear errors

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -37,7 +37,11 @@ def scan_range(config_path, start_date, end_date):
     if end_date:
         cfg.project.end_date = end_date
     info("Excelleri okuyor...")
-    df = read_excels_long(cfg)
+    try:
+        df = read_excels_long(cfg)
+    except (FileNotFoundError, RuntimeError) as exc:
+        info(str(exc))
+        return
     df = normalize(df)
     if cfg.calendar.tplus1_mode == "calendar":
         holidays = None
@@ -149,7 +153,11 @@ def scan_day(config_path, date_str):
     cfg.project.single_date = date_str
     cfg.project.run_mode = "single"
     info("Excelleri okuyor...")
-    df = read_excels_long(cfg)
+    try:
+        df = read_excels_long(cfg)
+    except (FileNotFoundError, RuntimeError) as exc:
+        info(str(exc))
+        return
     df = normalize(df)
     if cfg.calendar.tplus1_mode == "calendar":
         holidays = None

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -158,14 +158,12 @@ def read_excels_long(
                 print(f"[WARN] Önbellek okunamadı: {cache_path} -> {e}")
 
     if not excel_dir or not excel_dir.exists():
-        warnings.warn(f"Excel klasörü bulunamadı: {excel_dir}")
-        return pd.DataFrame()
+        raise FileNotFoundError(f"Excel klasörü bulunamadı: {excel_dir}")
 
     records: List[pd.DataFrame] = []
     excel_files = sorted(p for p in excel_dir.glob("*.xlsx"))
     if not excel_files:
-        warnings.warn(f"'{excel_dir}' altında .xlsx bulunamadı.")
-        return pd.DataFrame()
+        raise RuntimeError(f"'{excel_dir}' altında .xlsx bulunamadı.")
 
     for fpath in excel_files:
         try:


### PR DESCRIPTION
## Summary
- raise exceptions instead of warnings when Excel data is missing
- handle data loading errors in CLI commands and report to user

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ed18808c83258a5a7caea8e5d05d