### PR TITLE
refactor: centralize normalize_key

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -7,42 +7,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
+from backtest.utils import normalize_key
 from utils.paths import resolve_path
-
-_TR_MAP = str.maketrans(
-    {
-        "İ": "I",
-        "I": "I",
-        "ı": "i",
-        "Ş": "S",
-        "ş": "s",
-        "Ğ": "G",
-        "ğ": "g",
-        "Ü": "U",
-        "ü": "u",
-        "Ö": "O",
-        "ö": "o",
-        "Ç": "C",
-        "ç": "c",
-    }
-)
-
-
-def re_sub(pat: str, repl: str, s: str) -> str:
-    import re
-
-    return re.sub(pat, repl, s)
-
-
-def normalize_key(s: Optional[str]) -> str:  # TİP DÜZELTİLDİ
-    if s is None:
-        return ""
-    s = str(s).strip()
-    s = s.translate(_TR_MAP)
-    s = s.lower()
-    s = re_sub(r"[^\w]+", "_", s)
-    s = re_sub(r"_{2,}", "_", s).strip("_")
-    return s
 
 
 def _first_existing(*paths: Union[str, Path]) -> Optional[Path]:
@@ -228,4 +194,4 @@ def read_excels_long(
     return full
 
 
-__all__ = ["read_excels_long", "normalize_key", "normalize_columns"]
+__all__ = ["read_excels_long", "normalize_columns"]

--- a/tests/test_utils_normalize_key.py
+++ b/tests/test_utils_normalize_key.py
@@ -1,0 +1,17 @@
+# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
+from __future__ import annotations
+
+import pandas as pd
+
+from backtest.utils import normalize_key
+from backtest.data_loader import normalize_columns
+
+
+def test_normalize_key_basic():
+    assert normalize_key("İşlem Hacmi") == "islem_hacmi"
+
+
+def test_normalize_columns_uses_common_normalize_key():
+    df = pd.DataFrame({"Kapanış": [1], "İşlem Hacmi": [100]})
+    normalized = normalize_columns(df)
+    assert set(normalized.columns) == {"close", "volume"}


### PR DESCRIPTION
## Summary
- use `backtest.utils.normalize_key` in data loader and remove local copy
- add tests ensuring `normalize_key` and `normalize_columns` work through shared helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894f07152b8832580777ca0d5f3455e