### PR TITLE
Remove mask column from screener output

### DIFF
--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -32,7 +32,7 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
     day = pd.to_datetime(date).date()
     d = df_ind[df_ind["date"] == day].copy()
     if d.empty:
-        return pd.DataFrame(columns=["FilterCode", "Symbol", "Date", "mask"])
+        return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
     d = d.reset_index(drop=True)
     out_rows = []
     for _, row in filters_df.iterrows():
@@ -47,13 +47,13 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
             if not hits.empty:
                 for sym in hits["symbol"]:
                     out_rows.append(
-                        {"FilterCode": code, "Symbol": sym, "Date": day, "mask": True}
+                        {"FilterCode": code, "Symbol": sym, "Date": day}
                     )
         except Exception as err:
             warnings.warn(f"Filter {code!r} failed: {err}")
             continue
     if not out_rows:
         return pd.DataFrame(
-            columns=["FilterCode", "Symbol", "Date", "mask"]
+            columns=["FilterCode", "Symbol", "Date"]
         )  # TİP DÜZELTİLDİ
     return pd.DataFrame(out_rows)  # TİP DÜZELTİLDİ

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -49,7 +49,7 @@ def test_scan_range_empty(monkeypatch):
         cli,
         "run_screener",
         lambda df, filters, d: pd.DataFrame(
-            columns=["FilterCode", "Symbol", "Date", "mask"]
+            columns=["FilterCode", "Symbol", "Date"]
         ),
     )
     monkeypatch.setattr(
@@ -98,7 +98,7 @@ def test_scan_day_empty(monkeypatch):
         cli,
         "run_screener",
         lambda df, filters, d: pd.DataFrame(
-            columns=["FilterCode", "Symbol", "Date", "mask"]
+            columns=["FilterCode", "Symbol", "Date"]
         ),
     )
     monkeypatch.setattr(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -42,5 +42,5 @@ def test_run_screener_no_hits():
     )  # TİP DÜZELTİLDİ
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 2"]})
     res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
-    assert list(res.columns) == ["FilterCode", "Symbol", "Date", "mask"]
+    assert list(res.columns) == ["FilterCode", "Symbol", "Date"]
     assert res.empty


### PR DESCRIPTION
## Summary
- drop unused `mask` column from screener results
- adjust tests to expect only `FilterCode`, `Symbol`, and `Date`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894f256b6148325978af16e416213da