### PR TITLE
Improve robustness and date handling

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -68,7 +68,7 @@ def load_xu100_pct(csv_path: str | Path) -> pd.Series:
         # fallback: second column (df has >=2 columns here)
         close_col = list(df.columns)[1]
     # parse date tolerant
-    df[c_date] = pd.to_datetime(df[c_date], errors="coerce", dayfirst=True).dt.date
+    df[c_date] = pd.to_datetime(df[c_date], errors="coerce", dayfirst=True).dt.normalize()
     df[close_col] = pd.to_numeric(df[close_col], errors="coerce")
     df = df.dropna(subset=[c_date, close_col]).sort_values(c_date)
     pct = df[close_col].pct_change(1) * 100.0

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -106,7 +106,7 @@ def add_next_close_calendar(
     td = dict(zip(trading_days[:-1], trading_days[1:]))  # TİP DÜZELTİLDİ
     dates = pd.to_datetime(df["date"])
     next_dates = dates.apply(lambda d: td.get(pd.Timestamp(d).normalize(), pd.NaT))
-    df["next_date"] = next_dates.dt.date
+    df["next_date"] = next_dates.dt.normalize()
     # merge to get next_close for same symbol & next_date
     base = df[["symbol", "date", "close"]].copy()
     base.columns = ["symbol", "date", "close_curr"]

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -18,6 +18,10 @@ def compute_indicators(
         params = {}  # TİP DÜZELTİLDİ
     if df.empty:
         return df.copy()  # TİP DÜZELTİLDİ
+    req = {"symbol", "date", "close", "volume"}
+    missing = req.difference(df.columns)
+    if missing:
+        raise ValueError(f"Eksik kolon(lar): {', '.join(sorted(missing))}")
     df = df.copy()
     df = df.sort_values(["symbol", "date"])
     out_frames = []

--- a/backtest/normalizer.py
+++ b/backtest/normalizer.py
@@ -13,7 +13,7 @@ def normalize(df: pd.DataFrame) -> pd.DataFrame:
             raise ValueError(f"Eksik zorunlu kolon: {n}")  # TİP DÜZELTİLDİ
     df = df.copy()
     df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
-    df["date"] = pd.to_datetime(df["date"]).dt.date
+    df["date"] = pd.to_datetime(df["date"]).dt.normalize()
     for c in ["open", "high", "low", "close", "volume"]:
         df[c] = pd.to_numeric(df[c], errors="coerce")
     df = (

--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -17,14 +17,15 @@ class SafeQuery:
         The query expression to validate. Validation checks for
         disallowed characters and AST nodes that may lead to unsafe
         execution. The expression is considered safe if it only contains
-        allowed characters and does not include :class:`ast.Call` or
-        :class:`ast.Attribute` nodes.
+        allowed characters and does not include unapproved function
+        calls or attribute access.
     """
 
     # characters permitted inside a query expression
-    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.% ") | set(
+    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.%[], ") | set(
         string.ascii_letters + string.digits + "_"
     )
+    _ALLOWED_FUNCS: Set[str] = {"isin", "notna"}
 
     def __init__(self, expr: str):
         self.expr = expr
@@ -40,10 +41,20 @@ class SafeQuery:
             tree = ast.parse(expr, mode="eval")
         except SyntaxError:
             return False
-        # disallow function calls and attribute access
         for node in ast.walk(tree):
-            if isinstance(node, (ast.Call, ast.Attribute)):
-                return False
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Attribute):
+                    if func.attr not in cls._ALLOWED_FUNCS:
+                        return False
+                elif isinstance(func, ast.Name):
+                    if func.id not in cls._ALLOWED_FUNCS:
+                        return False
+                else:
+                    return False
+            elif isinstance(node, ast.Attribute):
+                if node.attr not in cls._ALLOWED_FUNCS:
+                    return False
         return True
 
     def filter(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -94,9 +94,10 @@ def write_reports(
         else:
             with writer:
                 for d in dates:
-                    day_df = trades_all[trades_all["Date"] == d].copy()
+                    day_ts = pd.to_datetime(d).normalize()
+                    day_df = trades_all[trades_all["Date"] == day_ts].copy()
                     day_df = day_df.sort_values(["FilterCode", "Symbol"])
-                    sheet = f"{daily_sheet_prefix}{d}"
+                    sheet = f"{daily_sheet_prefix}{day_ts.date()}"
                     day_df.to_excel(writer, sheet_name=sheet, index=False)
 
                 summary_wide.to_excel(writer, sheet_name=summary_sheet_name)
@@ -156,13 +157,14 @@ def write_reports(
                 pct_fmt = wb.add_format({"num_format": percent_fmt})
 
                 for d in dates:
-                    sheet = f"{daily_sheet_prefix}{d}"
+                    day_ts = pd.to_datetime(d).normalize()
+                    sheet = f"{daily_sheet_prefix}{day_ts.date()}"
                     ws = writer.sheets[sheet]
                     ws.set_column(0, 2, 12)
                     ws.set_column(3, 4, 12)
                     ws.set_column(5, 5, 10, num_fmt)
                     ws.set_column(6, 6, 8)
-                    rows = len(trades_all[trades_all["Date"] == d])
+                    rows = len(trades_all[trades_all["Date"] == day_ts])
                     last_row = rows if rows > 0 else 0  # LOJİK HATASI DÜZELTİLDİ
                     ws.autofilter(0, 0, last_row, 6)
 

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -50,7 +50,7 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
         logger.error(msg)
         raise ValueError(msg)
 
-    day = pd.to_datetime(date).date()
+    day = pd.to_datetime(date).normalize()
     d = df_ind[df_ind["date"] == day].copy()
     if d.empty:
         logger.warning("No data for date {day}", day=day)
@@ -63,6 +63,9 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
         expr = _to_pandas_ops(expr)
         safe = SafeQuery(expr)
         if not safe.is_safe:
+            logger.warning(
+                "Filter skipped due to unsafe expression", code=code, expr=expr
+            )
             continue
         try:
             hits = safe.filter(d)

--- a/tests/test_backtester_validation.py
+++ b/tests/test_backtester_validation.py
@@ -44,20 +44,20 @@ def test_run_1g_returns_missing_columns():
 
 
 def test_run_1g_returns_empty_signals():
-    with pytest.raises(ValueError):
-        run_1g_returns(
-            _base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
-        )
+    out = run_1g_returns(
+        _base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
+    )
+    assert out.empty
 
 
 def test_run_1g_returns_logs_empty_signals(caplog):
     from loguru import logger
 
-    logger.add(caplog.handler, level="ERROR")
-    with pytest.raises(ValueError):
-        run_1g_returns(
-            _base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
-        )
+    logger.add(caplog.handler, level="WARNING")
+    out = run_1g_returns(
+        _base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
+    )
+    assert out.empty
     assert "signals DataFrame is empty" in caplog.text
 
 

--- a/tests/test_backtester_validation.py
+++ b/tests/test_backtester_validation.py
@@ -9,9 +9,9 @@ def _base_df():
     return pd.DataFrame(
         {
             "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-01"]).date,
+            "date": pd.to_datetime(["2024-01-01"]).normalize(),
             "close": [1.0],
-            "next_date": pd.to_datetime(["2024-01-02"]).date,
+            "next_date": pd.to_datetime(["2024-01-02"]).normalize(),
             "next_close": [1.1],
         }
     )
@@ -22,7 +22,7 @@ def _signals_df():
         {
             "FilterCode": ["F"],
             "Symbol": ["AAA"],
-            "Date": pd.to_datetime(["2024-01-01"]).date,
+            "Date": pd.to_datetime(["2024-01-01"]).normalize(),
         }
     )
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -11,7 +11,7 @@ def test_next_close():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA", "AAA"],
-            "date": pd.to_datetime(["2024-01-05", "2024-01-08", "2024-01-09"]).date,
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08", "2024-01-09"]).normalize(),
             "close": [10, 11, 11.5],
             "open": [0, 0, 0],
             "high": [0, 0, 0],
@@ -25,7 +25,7 @@ def test_next_close():
 
 
 def test_build_trading_days_single_holiday():
-    df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).date})
+    df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).normalize()})
     tdays = build_trading_days(df, pd.Timestamp("2024-01-02"))
     assert pd.Timestamp("2024-01-02") not in tdays
 
@@ -34,11 +34,11 @@ def test_add_next_close_calendar():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA"],
-            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).normalize(),
             "close": [10.0, 11.0],
         }
     )
     tdays = build_trading_days(df)
     out = add_next_close_calendar(df, tdays)
     assert out.loc[0, "next_close"] == 11.0
-    assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-02").date()
+    assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-02")

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -20,6 +20,7 @@ def test_next_close():
         }
     )
     out = add_next_close(df)
+    assert isinstance(out.loc[0, "date"], pd.Timestamp)
     assert out.loc[0, "next_close"] == 11
     assert pd.isna(out.loc[2, "next_close"])
 
@@ -28,6 +29,7 @@ def test_build_trading_days_single_holiday():
     df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).normalize()})
     tdays = build_trading_days(df, pd.Timestamp("2024-01-02"))
     assert pd.Timestamp("2024-01-02") not in tdays
+    assert isinstance(tdays[0], pd.Timestamp)
 
 
 def test_add_next_close_calendar():
@@ -40,5 +42,7 @@ def test_add_next_close_calendar():
     )
     tdays = build_trading_days(df)
     out = add_next_close_calendar(df, tdays)
+    assert isinstance(out.loc[0, "date"], pd.Timestamp)
     assert out.loc[0, "next_close"] == 11.0
     assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-02")
+    assert isinstance(out.loc[0, "next_date"], pd.Timestamp)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -24,6 +24,7 @@ def test_quality_warnings_no_issues():
         }
     )
     res = quality_warnings(df)
+    assert isinstance(df.loc[0, "date"], pd.Timestamp)
     assert list(res.columns) == ["symbol", "date", "issue", "value"]
     assert res.empty
 
@@ -42,5 +43,6 @@ def test_run_screener_no_hits():
     )  # TİP DÜZELTİLDİ
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 2"]})
     res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
+    assert isinstance(df_ind.loc[0, "date"], pd.Timestamp)
     assert list(res.columns) == ["FilterCode", "Symbol", "Date"]
     assert res.empty

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -19,7 +19,7 @@ def test_quality_warnings_no_issues():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA"],
-            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).normalize(),
             "close": [1.0, 2.0],
         }
     )
@@ -32,7 +32,7 @@ def test_run_screener_no_hits():
     df_ind = pd.DataFrame(
         {
             "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
             "open": [1.0],
             "high": [1.0],
             "low": [1.0],

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -23,6 +23,8 @@ def test_pipeline_smoke():
             "relative_volume": [1.2, 0.9],
         }
     )
+    assert isinstance(df.loc[0, "date"], pd.Timestamp)
+    assert isinstance(df.loc[0, "next_date"], pd.Timestamp)
     filters = pd.DataFrame(
         {
             "FilterCode": ["T1"],
@@ -30,8 +32,10 @@ def test_pipeline_smoke():
         }
     )
     sigs = run_screener(df, filters, "2024-01-05")
+    assert isinstance(sigs.loc[0, "Date"], pd.Timestamp)
     out = run_1g_returns(df, sigs)
     assert not out.empty
+    assert isinstance(out.loc[0, "Date"], pd.Timestamp)
 
 
 def test_pipeline_no_signals():
@@ -50,6 +54,8 @@ def test_pipeline_no_signals():
             "relative_volume": [0.9],
         }
     )
+    assert isinstance(df.loc[0, "date"], pd.Timestamp)
+    assert isinstance(df.loc[0, "next_date"], pd.Timestamp)
     filters = pd.DataFrame(
         {
             "FilterCode": ["T1"],

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -11,10 +11,10 @@ def test_pipeline_smoke():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA"],
-            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).date,
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).normalize(),
             "close": [10.0, 11.0],
             "next_close": [11.0, None],
-            "next_date": pd.to_datetime(["2024-01-08", "2024-01-09"]).date,
+            "next_date": pd.to_datetime(["2024-01-08", "2024-01-09"]).normalize(),
             "open": [10.0, 11.0],
             "high": [10.0, 11.0],
             "low": [10.0, 11.0],
@@ -32,3 +32,39 @@ def test_pipeline_smoke():
     sigs = run_screener(df, filters, "2024-01-05")
     out = run_1g_returns(df, sigs)
     assert not out.empty
+
+
+def test_pipeline_no_signals():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-05"]).normalize(),
+            "close": [10.0],
+            "next_close": [11.0],
+            "next_date": pd.to_datetime(["2024-01-08"]).normalize(),
+            "open": [10.0],
+            "high": [10.0],
+            "low": [10.0],
+            "volume": [100],
+            "rsi_14": [60],
+            "relative_volume": [0.9],
+        }
+    )
+    filters = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "PythonQuery": ["(rsi_14 > 65) and (relative_volume > 1.0)"],
+        }
+    )
+    sigs = run_screener(df, filters, "2024-01-05")
+    out = run_1g_returns(df, sigs)
+    assert out.empty
+    assert list(out.columns) == [
+        "FilterCode",
+        "Symbol",
+        "Date",
+        "EntryClose",
+        "ExitClose",
+        "ReturnPct",
+        "Win",
+    ]

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -38,6 +38,7 @@ def test_run_screener_skips_unsafe(caplog):
     logger.add(caplog.handler, level="WARNING")
     res = run_screener(df_ind, filters, pd.Timestamp("2024-01-02"))
     assert res["FilterCode"].tolist() == ["SAFE"]
+    assert isinstance(res.loc[0, "Date"], pd.Timestamp)
     assert "unsafe expression" in caplog.text
 
 
@@ -62,6 +63,7 @@ def test_run_screener_warns_on_error():
     with pytest.warns(UserWarning) as w:
         res = run_screener(df_ind, filters, pd.Timestamp("2024-01-02"))
     assert res["FilterCode"].tolist() == ["GOOD"]
+    assert isinstance(res.loc[0, "Date"], pd.Timestamp)
     assert any("BAD" in str(msg.message) for msg in w)
 
 

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -116,3 +116,20 @@ def test_run_screener_logs_missing_filters_columns(caplog):
         run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert caplog.records[0].levelname == "ERROR"
     assert "filters_df missing required columns" in caplog.text
+
+
+def test_run_screener_outputs_timestamp_dates():
+    df_ind = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [100],
+        }
+    )
+    filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 0"]})
+    res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
+    assert isinstance(res.loc[0, "Date"], pd.Timestamp)

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -28,7 +28,7 @@ def test_run_screener_invalid_inputs():
     df_ok = pd.DataFrame(
         {
             "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
             "open": [1.0],
             "high": [1.0],
             "low": [1.0],
@@ -60,7 +60,7 @@ def test_run_screener_empty_filters_logs(caplog):
     df_ind = pd.DataFrame(
         {
             "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
             "open": [1.0],
             "high": [1.0],
             "low": [1.0],
@@ -81,7 +81,7 @@ def test_run_screener_logs_missing_df_columns(caplog):
     df_ind = pd.DataFrame(
         {
             "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
             "open": [1.0],
             "high": [1.0],
             "low": [1.0],
@@ -102,7 +102,7 @@ def test_run_screener_logs_missing_filters_columns(caplog):
     df_ind = pd.DataFrame(
         {
             "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-02"]).date,
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
             "open": [1.0],
             "high": [1.0],
             "low": [1.0],


### PR DESCRIPTION
## Summary
- Handle empty signals and zero or missing entry prices without crashing
- Exit CLI early when filter CSV is missing or empty and standardize dates to `Timestamp`
- Validate indicator prerequisites, log unsafe screener filters, and whitelist safe functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950076b70083258d4bbd003f5938f2