### PR TITLE
Refactor backtester and extend screener/query features

### DIFF
--- a/backtest/config.py
+++ b/backtest/config.py
@@ -17,6 +17,8 @@ class ProjectCfg(BaseModel):
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     single_date: Optional[str] = None
+    holding_period: int = 1
+    transaction_cost: float = 0.0
 
 
 class DataCfg(BaseModel):

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -59,10 +59,6 @@ def compute_indicators(
         g["RELATIVE_VOLUME"] = g["volume"] / g["volume"].rolling(20).mean()
         out_frames.append(g)
     df2 = pd.concat(out_frames, ignore_index=True)
-    for c in df2.columns:
-        low = c.lower()
-        if low not in df2.columns:
-            df2[low] = df2[c]
     alias_map = {
         "rsi_14": "RSI_14",
         "ema_10": "EMA_10",

--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -22,10 +22,19 @@ class SafeQuery:
     """
 
     # characters permitted inside a query expression
-    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.%[], ") | set(
-        string.ascii_letters + string.digits + "_"
+    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.%[], '") | set(
+        string.ascii_letters + string.digits + "_\""
     )
-    _ALLOWED_FUNCS: Set[str] = {"isin", "notna"}
+    _ALLOWED_FUNCS: Set[str] = {
+        "isin",
+        "notna",
+        "str",
+        "contains",
+        "abs",
+        "rolling",
+        "shift",
+        "mean",
+    }
 
     def __init__(self, expr: str):
         self.expr = expr

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -5,6 +5,8 @@ project:
   start_date: "2024-01-01"
   end_date: "2024-12-31"
   single_date: null
+  holding_period: 1
+  transaction_cost: 0.0
 
 data:
   excel_dir: "Veri"

--- a/io_filters.py
+++ b/io_filters.py
@@ -32,7 +32,7 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     if not p.exists():
         raise FileNotFoundError(f"Filters CSV bulunamadı: {p}")
     try:
-        df = pd.read_csv(p, encoding="utf-8")
+        df = pd.read_csv(p, encoding="utf-8", sep=None, engine="python")
     except Exception as exc:
         raise FileNotFoundError(f"Filters CSV okunamadı: {p}") from exc
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from backtest.backtester import run_1g_returns
 
@@ -10,18 +11,94 @@ def test_backtester_basic():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA"],
-            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).date,
+            "date": pd.to_datetime(["2024-01-05", "2024-01-06"]),
             "close": [10.0, 11.0],
-            "next_close": [11.0, None],
-            "next_date": pd.to_datetime(["2024-01-08", "2024-01-09"]).date,
         }
     )
     sigs = pd.DataFrame(
         {
             "FilterCode": ["T1"],
             "Symbol": ["AAA"],
-            "Date": [pd.to_datetime("2024-01-05").date()],
+            "Date": [pd.to_datetime("2024-01-05")],
         }
     )
     out = run_1g_returns(df, sigs)
-    assert round(out.loc[0, "ReturnPct"], 2) == 10.0
+    assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == 10.0
+
+
+def test_run_1g_returns_drops_duplicates():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-05", "2024-01-06"]),
+            "close": [10.0, 10.0, 11.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1", "T1"],
+            "Symbol": ["AAA", "AAA"],
+            "Date": [pd.to_datetime("2024-01-05"), pd.to_datetime("2024-01-05")],
+        }
+    )
+    out = run_1g_returns(df, sigs)
+    assert len(out) == 1
+
+
+def test_run_1g_returns_holding_period_and_cost():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+            "close": [10.0, 11.0, 12.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "Symbol": ["AAA"],
+            "Date": [pd.to_datetime("2024-01-01")],
+        }
+    )
+    out = run_1g_returns(df, sigs, holding_period=2, transaction_cost=1.0)
+    expected = ((12.0 / 10.0 - 1.0) * 100.0) - 1.0
+    assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == expected
+
+
+def test_run_1g_returns_exit_date_out_of_bounds_returns_empty():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "close": [10.0, 11.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "Symbol": ["AAA"],
+            "Date": [pd.to_datetime("2024-01-02")],
+        }
+    )
+    out = run_1g_returns(df, sigs)
+    assert out.empty
+
+
+def test_run_1g_returns_ignores_out_of_bounds_signals():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+            "close": [10.0, 11.0, 12.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1", "T1"],
+            "Symbol": ["AAA", "AAA"],
+            "Date": [pd.to_datetime("2024-01-01"), pd.to_datetime("2024-01-03")],
+        }
+    )
+    out = run_1g_returns(df, sigs)
+    assert len(out) == 1
+    assert out.loc[0, "Date"] == pd.Timestamp("2024-01-01")

--- a/tests/test_backtester_validation.py
+++ b/tests/test_backtester_validation.py
@@ -8,11 +8,11 @@ from backtest.backtester import run_1g_returns
 def _base_df():
     return pd.DataFrame(
         {
-            "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-01"]).normalize(),
-            "close": [1.0],
-            "next_date": pd.to_datetime(["2024-01-02"]).normalize(),
-            "next_close": [1.1],
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]).normalize(),
+            "close": [1.0, 1.1],
+            "next_date": pd.to_datetime(["2024-01-02", "2024-01-03"]).normalize(),
+            "next_close": [1.1, 1.2],
         }
     )
 

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -10,7 +10,9 @@ from backtest import cli
 
 def _cfg():
     return SimpleNamespace(
-        project=SimpleNamespace(out_dir="out", start_date=None, end_date=None),
+        project=SimpleNamespace(
+            out_dir="out", start_date=None, end_date=None, holding_period=1, transaction_cost=0.0
+        ),
         data=SimpleNamespace(filters_csv="dummy.csv"),
         calendar=SimpleNamespace(
             tplus1_mode="price", holidays_source="none", holidays_csv_path=None
@@ -55,7 +57,7 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
-        lambda df, sigs: pd.DataFrame(
+        lambda df, sigs, holding_period, transaction_cost: pd.DataFrame(
             columns=[
                 "FilterCode",
                 "Symbol",
@@ -71,7 +73,7 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "info", lambda msg: None)
-    cli.scan_range.callback("cfg.yml", None, None)
+    cli.scan_range.callback("cfg.yml", None, None, None, None)
 
 
 def test_scan_day_empty(monkeypatch):
@@ -104,7 +106,7 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
-        lambda df, sigs: pd.DataFrame(
+        lambda df, sigs, holding_period, transaction_cost: pd.DataFrame(
             columns=[
                 "FilterCode",
                 "Symbol",
@@ -120,4 +122,4 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "info", lambda msg: None)
-    cli.scan_day.callback("cfg.yml", "2024-01-02")
+    cli.scan_day.callback("cfg.yml", "2024-01-02", None, None)

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -17,3 +17,10 @@ def test_validate_filters_empty_query():
 def test_load_filters_missing_column():
     with pytest.raises(RuntimeError):
         load_filters_csv("tests/data/filters_missing_col.csv")
+
+
+def test_load_filters_semicolon(tmp_path):
+    csv_file = tmp_path / "filters.csv"
+    csv_file.write_text("FilterCode;PythonQuery\nF1;close>0\n", encoding="utf-8")
+    df = load_filters_csv(csv_file)
+    assert df.loc[0, "FilterCode"] == "F1"

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -11,10 +11,8 @@ def test_pipeline_smoke():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA"],
-            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).normalize(),
+            "date": pd.to_datetime(["2024-01-05", "2024-01-06"]).normalize(),
             "close": [10.0, 11.0],
-            "next_close": [11.0, None],
-            "next_date": pd.to_datetime(["2024-01-08", "2024-01-09"]).normalize(),
             "open": [10.0, 11.0],
             "high": [10.0, 11.0],
             "low": [10.0, 11.0],
@@ -24,7 +22,6 @@ def test_pipeline_smoke():
         }
     )
     assert isinstance(df.loc[0, "date"], pd.Timestamp)
-    assert isinstance(df.loc[0, "next_date"], pd.Timestamp)
     filters = pd.DataFrame(
         {
             "FilterCode": ["T1"],
@@ -41,21 +38,18 @@ def test_pipeline_smoke():
 def test_pipeline_no_signals():
     df = pd.DataFrame(
         {
-            "symbol": ["AAA"],
-            "date": pd.to_datetime(["2024-01-05"]).normalize(),
-            "close": [10.0],
-            "next_close": [11.0],
-            "next_date": pd.to_datetime(["2024-01-08"]).normalize(),
-            "open": [10.0],
-            "high": [10.0],
-            "low": [10.0],
-            "volume": [100],
-            "rsi_14": [60],
-            "relative_volume": [0.9],
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-06"]).normalize(),
+            "close": [10.0, 11.0],
+            "open": [10.0, 11.0],
+            "high": [10.0, 11.0],
+            "low": [10.0, 11.0],
+            "volume": [100, 100],
+            "rsi_14": [60, 60],
+            "relative_volume": [0.9, 0.9],
         }
     )
     assert isinstance(df.loc[0, "date"], pd.Timestamp)
-    assert isinstance(df.loc[0, "next_date"], pd.Timestamp)
     filters = pd.DataFrame(
         {
             "FilterCode": ["T1"],

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -73,3 +73,19 @@ def test_safequery_allows_whitelist_functions():
     assert q.is_safe
     out = q.filter(df)
     assert out["x"].tolist() == [1, 2]
+
+
+def test_safequery_allows_strings_and_methods():
+    df = pd.DataFrame({"symbol": ["AAA", "BBB"], "close": [1, 2]})
+    q = SafeQuery("symbol == 'AAA' & close.abs() > 0")
+    assert q.is_safe
+    out = q.filter(df)
+    assert out["symbol"].tolist() == ["AAA"]
+
+
+def test_safequery_allows_str_contains():
+    df = pd.DataFrame({"symbol": ["AAA", "BBB"]})
+    q = SafeQuery("symbol.str.contains('A')")
+    assert q.is_safe
+    out = q.filter(df)
+    assert out["symbol"].tolist() == ["AAA"]


### PR DESCRIPTION
## Summary
- handle semicolon-delimited filter CSVs
- add holding period and transaction cost support with duplicate-safe returns
- broaden SafeQuery syntax and vectorize screener for better performance
- drop redundant indicator columns and expose new options in config/CLI
- add tests for exit dates falling outside available price history

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950b62ab3083259fecc85b0ca51784