### PR TITLE
Add trading calendar support and strengthen data validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ pytest -q
 ```
 
 
+## Backtest Akış Rehberi
+1. **Veri Yükleme:** `backtest.data_loader.read_excels_long` ile Excel fiyat dosyalarını okuyun. Gerekirse `backtest.calendars.add_next_close_calendar` ile işlem günlerine göre `next_date` ve `next_close` alanlarını ekleyin.
+2. **İndikatör Hesabı:** `indicator_calculator.py` veya benzeri bir araçla göstergeleri hesaplayın ve veri ile birleştirin.
+3. **Filtreleme:** `backtest.screener.run_screener` fonksiyonunu kullanarak `filters.csv` içindeki sorguları çalıştırın.
+4. **Getiri Hesabı:** Filtre sonuçlarını `backtest.backtester.run_1g_returns` fonksiyonuna vererek T+N getirilerini hesaplayın. Tatil ve hafta sonu hatalarını önlemek için `trading_days` parametresine işlem günlerini geçin.
+5. **Raporlama:** Çıktıları `backtest.reporter.write_reports` veya `backtest.report.write_report` aracılığıyla Excel/CSV olarak kaydedin.
+
 ## Sürüm Notları
 - 1.1.0: Colab desteği ve yeni README.
 - 1.0.0: İlk yayımlanan sürüm.

--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import ast
 import string
-from typing import Set
+from typing import Set, Tuple
 
 import pandas as pd
 
@@ -38,33 +38,40 @@ class SafeQuery:
 
     def __init__(self, expr: str):
         self.expr = expr
-        self.is_safe = self._validate(expr)
+        ok, names, err = self._validate(expr)
+        self.is_safe = ok
+        self.names = names
+        self.error = err
 
     @classmethod
-    def _validate(cls, expr: str) -> bool:
-        """Return ``True`` if *expr* is safe to evaluate."""
+    def _validate(cls, expr: str) -> Tuple[bool, Set[str], str | None]:
+        """Return (is_safe, names, error_message) for *expr*."""
+        names: Set[str] = set()
         # quick character check
-        if any(ch not in cls._ALLOWED_CHARS for ch in expr):
-            return False
+        invalid = next((ch for ch in expr if ch not in cls._ALLOWED_CHARS), None)
+        if invalid is not None:
+            return False, names, f"invalid character {invalid!r}"
         try:
             tree = ast.parse(expr, mode="eval")
         except SyntaxError:
-            return False
+            return False, names, "syntax error"
         for node in ast.walk(tree):
+            if isinstance(node, ast.Name):
+                names.add(node.id)
             if isinstance(node, ast.Call):
                 func = node.func
                 if isinstance(func, ast.Attribute):
                     if func.attr not in cls._ALLOWED_FUNCS:
-                        return False
+                        return False, names, f"function '{func.attr}' not allowed"
                 elif isinstance(func, ast.Name):
                     if func.id not in cls._ALLOWED_FUNCS:
-                        return False
+                        return False, names, f"function '{func.id}' not allowed"
                 else:
-                    return False
+                    return False, names, "invalid function call"
             elif isinstance(node, ast.Attribute):
                 if node.attr not in cls._ALLOWED_FUNCS:
-                    return False
-        return True
+                    return False, names, f"attribute '{node.attr}' not allowed"
+        return True, names, None
 
     def filter(self, df: pd.DataFrame) -> pd.DataFrame:
         """Return rows from *df* matching the query expression.
@@ -75,5 +82,5 @@ class SafeQuery:
             If the stored expression is unsafe.
         """
         if not self.is_safe:
-            raise ValueError("Unsafe query expression")
+            raise ValueError(f"Unsafe query expression: {self.error}")
         return df.query(self.expr)

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -64,8 +64,14 @@ def run_screener(df_ind: pd.DataFrame, filters_df: pd.DataFrame, date) -> pd.Dat
         sq = SafeQuery(expr)
         if not sq.is_safe:
             logger.warning(
-                "Filter skipped due to unsafe expression", code=code, expr=expr
+                "Filter skipped due to unsafe expression", code=code, expr=expr, reason=sq.error
             )
+            continue
+        missing_cols = sq.names.difference(d.columns)
+        if missing_cols:
+            msg = f"Filter {code!r} skipped; missing columns: {sorted(missing_cols)}"
+            logger.warning("Filter skipped due to missing columns", code=code, missing=sorted(missing_cols))
+            warnings.warn(msg)
             continue
         valids.append((code, sq))
     out_frames = []


### PR DESCRIPTION
## Summary
- Validate and drop invalid entry/exit prices in `run_1g_returns` and support trading-day exit calculation
- Guard against duplicate or conflicting columns when loading Excel data
- Expose query parser errors with column validation and clearer warnings in the screener
- Document end-to-end backtest workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951c4212088325bde4c0a01f68055c