### PR TITLE
Expose report output paths for backtests

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -137,7 +137,7 @@ def scan_range(config_path, start_date, end_date, holding_period, transaction_co
     info("Raporlar yazılıyor...")
     val_sum = dataset_summary(df)
     val_iss = quality_warnings(df)
-    write_reports(
+    outputs = write_reports(
         trades_all,
         days,
         pivot,
@@ -151,7 +151,9 @@ def scan_range(config_path, start_date, end_date, holding_period, transaction_co
         summary_sheet_name=cfg.report.summary_sheet_name,
         percent_fmt=cfg.report.percent_format,
     )
-    info(f"Bitti. Çıktı: {out_xlsx}")
+    info(f"Bitti. Çıktı: {outputs.get('excel')}")
+    if outputs.get("csv"):
+        info(f"CSV klasörü: {outputs['csv'][0].parent}")
 
 
 @cli.command("scan-day")
@@ -224,7 +226,7 @@ def scan_day(config_path, date_str, holding_period, transaction_cost):
     info("Raporlar yazılıyor...")
     val_sum = dataset_summary(df)
     val_iss = quality_warnings(df)
-    write_reports(
+    outputs = write_reports(
         trades,
         [day],
         pivot,
@@ -238,7 +240,7 @@ def scan_day(config_path, date_str, holding_period, transaction_cost):
         summary_sheet_name=cfg.report.summary_sheet_name,
         percent_fmt=cfg.report.percent_format,
     )
-    info(f"Bitti. Çıktı: {out_xlsx}")
+    info(f"Bitti. Çıktı: {outputs.get('excel')}")
 
 
 if __name__ == "__main__":

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -2,10 +2,52 @@ from __future__ import annotations
 
 import pathlib
 
-from backtest.reporter import _ensure_dir
+import pandas as pd
+
+from backtest.reporter import _ensure_dir, write_reports
 
 
 def test_ensure_dir_handles_simple_filename(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _ensure_dir("report.xlsx")  # should not raise
     assert pathlib.Path("report.xlsx").parent.exists()
+
+
+def test_write_reports_returns_paths(tmp_path):
+    trades = pd.DataFrame(
+        {
+            "FilterCode": ["f1"],
+            "Symbol": ["SYM"],
+            "Date": [pd.Timestamp("2024-01-01")],
+            "EntryClose": [10.0],
+            "ExitClose": [11.0],
+            "ReturnPct": [10.0],
+            "Win": [True],
+        }
+    )
+    summary = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
+    )
+    winrate = (
+        trades.groupby(["FilterCode", "Date"])["Win"]
+        .mean()
+        .unstack(fill_value=float("nan"))
+    )
+    out_xlsx = tmp_path / "out.xlsx"
+    out_csv_dir = tmp_path / "csv"
+    outputs = write_reports(
+        trades,
+        [pd.Timestamp("2024-01-01")],
+        summary,
+        out_xlsx=out_xlsx,
+        out_csv_dir=out_csv_dir,
+        summary_winrate=winrate,
+    )
+    assert outputs["excel"] == out_xlsx.resolve()
+    assert out_xlsx.exists()
+    csv_names = {p.name for p in outputs.get("csv", [])}
+    assert {"daily_trades.csv", "summary.csv", "summary_winrate.csv"}.issubset(csv_names)
+    for p in outputs.get("csv", []):
+        assert p.exists()


### PR DESCRIPTION
## Summary
- return the file paths from `write_reports` so callers can easily locate generated results
- log returned paths in CLI commands for backtest runs
- test that report writing exposes the created files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689520a918c08325b06566659639864b