### PR TITLE
Improve backtesting accuracy and flexibility

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -46,6 +46,7 @@ def _run_scan(cfg) -> None:
         tdays = build_trading_days(df, holidays)
         df = add_next_close_calendar(df, tdays)
     else:
+        tdays = None
         df = add_next_close(df)
     info("Göstergeler hesaplanıyor...")
     df_ind = compute_indicators(df, cfg.indicators.params)
@@ -86,7 +87,11 @@ def _run_scan(cfg) -> None:
     for d in days:
         sigs = run_screener(df_ind, filters_df, d)
         trades = run_1g_returns(
-            df_ind, sigs, cfg.project.holding_period, cfg.project.transaction_cost
+            df_ind,
+            sigs,
+            cfg.project.holding_period,
+            cfg.project.transaction_cost,
+            trading_days=tdays,
         )
         all_trades.append(trades)
     trades_all = (
@@ -95,10 +100,12 @@ def _run_scan(cfg) -> None:
         else pd.DataFrame(
             columns=[
                 "FilterCode",
+                "Group",
                 "Symbol",
                 "Date",
                 "EntryClose",
                 "ExitClose",
+                "Side",
                 "ReturnPct",
                 "Win",
             ]

--- a/io_filters.py
+++ b/io_filters.py
@@ -30,9 +30,9 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     Returns
     -------
     pandas.DataFrame
-        DataFrame containing the filter definitions. If the file is missing
-        or cannot be parsed, ``FileNotFoundError`` is raised. Missing required
-        columns raise ``RuntimeError``.
+        DataFrame containing the filter definitions. If the file is missing,
+        ``FileNotFoundError`` is raised. CSV parse issues raise
+        ``RuntimeError``. Missing required columns raise ``RuntimeError``.
     """
 
     p = resolve_path(path)
@@ -41,7 +41,7 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     try:
         df = pd.read_csv(p, encoding="utf-8", sep=None, engine="python")
     except Exception as exc:
-        raise FileNotFoundError(f"Filters CSV okunamadı: {p}") from exc
+        raise RuntimeError(f"Filters CSV parse edilemedi: {p}") from exc
 
     missing = REQUIRED_COLUMNS.difference(df.columns)
     if missing:

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -46,3 +46,17 @@ def test_add_next_close_calendar():
     assert out.loc[0, "next_close"] == 11.0
     assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-02")
     assert isinstance(out.loc[0, "next_date"], pd.Timestamp)
+
+
+def test_add_next_close_calendar_skips_weekend():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).normalize(),
+            "close": [10.0, 11.0],
+        }
+    )
+    tdays = build_trading_days(df)
+    out = add_next_close_calendar(df, tdays)
+    assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-08")
+    assert out.loc[0, "next_close"] == 11.0

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -57,7 +57,7 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
-        lambda df, sigs, holding_period, transaction_cost: pd.DataFrame(
+        lambda df, sigs, holding_period, transaction_cost, **kwargs: pd.DataFrame(
             columns=[
                 "FilterCode",
                 "Symbol",
@@ -106,7 +106,7 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
-        lambda df, sigs, holding_period, transaction_cost: pd.DataFrame(
+        lambda df, sigs, holding_period, transaction_cost, **kwargs: pd.DataFrame(
             columns=[
                 "FilterCode",
                 "Symbol",

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -24,3 +24,10 @@ def test_load_filters_semicolon(tmp_path):
     csv_file.write_text("FilterCode;PythonQuery\nF1;close>0\n", encoding="utf-8")
     df = load_filters_csv(csv_file)
     assert df.loc[0, "FilterCode"] == "F1"
+
+
+def test_load_filters_parse_error(tmp_path):
+    csv_file = tmp_path / "filters.csv"
+    csv_file.write_text("FilterCode,PythonQuery\n\"unclosed", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        load_filters_csv(csv_file)

--- a/tests/test_group_short.py
+++ b/tests/test_group_short.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import pytest
+
+from backtest.calendars import add_next_close_calendar, build_trading_days
+from backtest.backtester import run_1g_returns
+from backtest.screener import run_screener
+
+
+def test_run_screener_includes_group():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [100],
+        }
+    )
+    filters_df = pd.DataFrame(
+        {"FilterCode": ["F1"], "PythonQuery": ["close > 0"], "Group": ["G1"]}
+    )
+    res = run_screener(df, filters_df, pd.Timestamp("2024-01-02"))
+    assert "Group" in res.columns
+    assert res.loc[0, "Group"] == "G1"
+
+
+def test_run_1g_returns_handles_short_and_group():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08"]).normalize(),
+            "close": [10.0, 11.0],
+        }
+    )
+    tdays = build_trading_days(df)
+    df = add_next_close_calendar(df, tdays)
+    signals = pd.DataFrame(
+        {
+            "FilterCode": ["F1", "F1"],
+            "Group": ["G1", "G1"],
+            "Symbol": ["AAA", "AAA"],
+            "Date": [pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-05")],
+            "Side": ["long", "short"],
+        }
+    )
+    out = run_1g_returns(df, signals, trading_days=tdays)
+    assert set(["Group", "Side"]).issubset(out.columns)
+    long_ret = (11.0 / 10.0 - 1.0) * 100.0
+    short_ret = ((10.0 - 11.0) / 10.0) * 100.0
+    assert pytest.approx(out[out["Side"] == "long"]["ReturnPct"].iloc[0], 0.01) == long_ret
+    assert pytest.approx(out[out["Side"] == "short"]["ReturnPct"].iloc[0], 0.01) == short_ret


### PR DESCRIPTION
## Summary
- Pass trading-day calendars through CLI and leverage precomputed `next_close` in backtester
- Preserve filter groups, support short trades, and expose optional side info
- Vectorize calendar lookups and harden filter CSV parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689530782f20832592df579d16da8028