### PR TITLE
Improve signal validation and indicator engine flexibility

### DIFF
--- a/backtest/config.py
+++ b/backtest/config.py
@@ -26,6 +26,7 @@ class DataCfg(BaseModel):
     filters_csv: str
     enable_cache: bool = False
     cache_parquet_path: Optional[str] = None
+    corporate_actions_csv: Optional[str] = None
     price_schema: Dict[str, List[str]] = Field(
         default_factory=lambda: {
             "date": ["Tarih", "Date", "tarih"],
@@ -96,7 +97,7 @@ def load_config(path: str | Path) -> RootCfg:
     if isinstance(proj, dict) and proj.get("out_dir"):
         proj["out_dir"] = _join(proj.get("out_dir"))  # PATH DÜZENLENDİ
     data = cfg.get("data", {}) if isinstance(cfg, dict) else {}
-    for k in ["excel_dir", "filters_csv", "cache_parquet_path"]:
+    for k in ["excel_dir", "filters_csv", "cache_parquet_path", "corporate_actions_csv"]:
         v = data.get(k)
         if v:
             data[k] = _join(v)  # PATH DÜZENLENDİ

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -102,3 +102,28 @@ def test_run_1g_returns_ignores_out_of_bounds_signals():
     out = run_1g_returns(df, sigs)
     assert len(out) == 1
     assert out.loc[0, "Date"] == pd.Timestamp("2024-01-01")
+
+
+def test_run_1g_returns_side_validation():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-06"]),
+            "close": [10.0, 11.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "Symbol": ["AAA"],
+            "Date": [pd.to_datetime("2024-01-05")],
+            "Side": ["short"],
+        }
+    )
+    out = run_1g_returns(df, sigs)
+    assert out.loc[0, "Side"] == "short"
+    assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == -10.0
+    sigs_bad = sigs.copy()
+    sigs_bad["Side"] = ["foo"]
+    with pytest.raises(ValueError):
+        run_1g_returns(df, sigs_bad)

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -17,7 +17,7 @@ def _cfg():
         calendar=SimpleNamespace(
             tplus1_mode="price", holidays_source="none", holidays_csv_path=None
         ),
-        indicators=SimpleNamespace(params={}),
+        indicators=SimpleNamespace(params={}, engine="pandas_ta"),
         benchmark=SimpleNamespace(xu100_source="none", xu100_csv_path=None),
         report=SimpleNamespace(
             daily_sheet_prefix="SCAN_",
@@ -46,7 +46,9 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(cli, "read_excels_long", lambda _: dummy_df)
     monkeypatch.setattr(cli, "normalize", lambda df: df)
     monkeypatch.setattr(cli, "add_next_close", lambda df: df)
-    monkeypatch.setattr(cli, "compute_indicators", lambda df, params: df)
+    monkeypatch.setattr(
+        cli, "compute_indicators", lambda df, params, engine=None: df
+    )
     monkeypatch.setattr(
         cli,
         "run_screener",
@@ -95,7 +97,9 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(cli, "read_excels_long", lambda _: dummy_df)
     monkeypatch.setattr(cli, "normalize", lambda df: df)
     monkeypatch.setattr(cli, "add_next_close", lambda df: df)
-    monkeypatch.setattr(cli, "compute_indicators", lambda df, params: df)
+    monkeypatch.setattr(
+        cli, "compute_indicators", lambda df, params, engine=None: df
+    )
     monkeypatch.setattr(
         cli,
         "run_screener",

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from backtest.data_loader import apply_corporate_actions
+
+
+def test_apply_corporate_actions(tmp_path):
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "open": [10.0, 20.0],
+            "high": [10.0, 20.0],
+            "low": [10.0, 20.0],
+            "close": [10.0, 20.0],
+            "volume": [100, 200],
+        }
+    )
+    csv = tmp_path / "actions.csv"
+    csv.write_text("symbol,date,factor\nAAA,2024-01-02,0.5\n", encoding="utf-8")
+    adj = apply_corporate_actions(df, csv)
+    first = adj.loc[adj["date"] == pd.Timestamp("2024-01-01"), "close"].iloc[0]
+    second = adj.loc[adj["date"] == pd.Timestamp("2024-01-02"), "close"].iloc[0]
+    assert first == 5.0
+    assert second == 20.0

--- a/tests/test_indicators_engine.py
+++ b/tests/test_indicators_engine.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from backtest.indicators import compute_indicators
+
+
+def _sample_df():
+    dates = pd.date_range("2024-01-01", periods=30, freq="D")
+    return pd.DataFrame(
+        {
+            "symbol": ["AAA"] * 30,
+            "date": dates,
+            "close": range(1, 31),
+            "volume": range(1, 31),
+        }
+    )
+
+
+def test_macd_disabled():
+    df = _sample_df()
+    res = compute_indicators(df, params={"macd": []}, engine="builtin")
+    assert not any(col.startswith("MACD") for col in res.columns)
+
+
+def test_builtin_engine_basic():
+    df = _sample_df()
+    res = compute_indicators(df, params={}, engine="builtin")
+    assert "EMA_10" in res.columns
+    assert "RSI_14" in res.columns

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -133,3 +133,30 @@ def test_run_screener_outputs_timestamp_dates():
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 0"]})
     res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert isinstance(res.loc[0, "Date"], pd.Timestamp)
+
+
+def test_run_screener_side_validation():
+    df_ind = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [100],
+        }
+    )
+    filters_df = pd.DataFrame(
+        {
+            "FilterCode": ["F1"],
+            "PythonQuery": ["close > 0"],
+            "Side": ["long"],
+        }
+    )
+    res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
+    assert res.loc[0, "Side"] == "long"
+    bad = filters_df.copy()
+    bad["Side"] = ["foo"]
+    with pytest.raises(ValueError):
+        run_screener(df_ind, bad, pd.Timestamp("2024-01-02"))


### PR DESCRIPTION
## Summary
- validate trade directions with a `TradeSide` enum and enforce side values across screener and backtester
- add optional corporate action adjustments and expose indicator engine selection
- allow disabling MACD via empty params and support builtin indicator calculations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689535f5d46c83259cca3a1397c8654b