### PR TITLE
Improve indicator calculations and backtest robustness

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -6,6 +6,8 @@ from enum import Enum
 import pandas as pd
 from loguru import logger
 
+from .calendars import add_next_close, add_next_close_calendar, build_trading_days
+
 
 class TradeSide(Enum):
     LONG = "long"
@@ -70,6 +72,17 @@ def run_1g_returns(
         msg = f"Eksik kolon(lar): {', '.join(sorted(missing_sig))}"
         logger.error(msg)
         raise ValueError(msg)
+
+    has_next = {"next_date", "next_close"}.issubset(df_with_next.columns)
+    if not has_next:
+        if trading_days is not None:
+            df_with_next = add_next_close_calendar(df_with_next, trading_days)
+        else:
+            df_with_next = add_next_close(df_with_next)
+        has_next = True
+
+    if trading_days is None:
+        trading_days = build_trading_days(df_with_next)
 
     if "Side" in signals.columns:
         sides = signals["Side"].dropna().astype(str).str.lower()

--- a/io_filters.py
+++ b/io_filters.py
@@ -50,6 +50,10 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     # basic normalization
     df["FilterCode"] = df["FilterCode"].astype(str).str.strip()
     df["PythonQuery"] = df["PythonQuery"].astype(str)
+    dups = df["FilterCode"][df["FilterCode"].duplicated()]
+    if not dups.empty:
+        dup_codes = ", ".join(sorted(dups.unique()))
+        raise RuntimeError(f"Duplicate FilterCode detected: {dup_codes}")
     return df
 
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -127,3 +127,26 @@ def test_run_1g_returns_side_validation():
     sigs_bad["Side"] = ["foo"]
     with pytest.raises(ValueError):
         run_1g_returns(df, sigs_bad)
+
+
+def test_run_1g_returns_fills_missing_exit_data():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-05", "2024-01-08", "2024-01-09"]),
+            "close": [10.0, 11.0, 12.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1"],
+            "Symbol": ["AAA"],
+            "Date": [pd.to_datetime("2024-01-05")],
+        }
+    )
+    out1 = run_1g_returns(df, sigs)
+    assert out1.loc[0, "ExitClose"] == 11.0
+    assert pytest.approx(out1.loc[0, "ReturnPct"], 0.01) == 10.0
+    out2 = run_1g_returns(df, sigs, holding_period=2)
+    assert out2.loc[0, "ExitClose"] == 12.0
+    assert pytest.approx(out2.loc[0, "ReturnPct"], 0.01) == 20.0

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -31,3 +31,12 @@ def test_load_filters_parse_error(tmp_path):
     csv_file.write_text("FilterCode,PythonQuery\n\"unclosed", encoding="utf-8")
     with pytest.raises(RuntimeError):
         load_filters_csv(csv_file)
+
+
+def test_load_filters_duplicate_codes(tmp_path):
+    csv_file = tmp_path / "filters.csv"
+    csv_file.write_text(
+        "FilterCode,PythonQuery\nF1,close>0\nF1,close>1\n", encoding="utf-8"
+    )
+    with pytest.raises(RuntimeError):
+        load_filters_csv(csv_file)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -10,7 +10,6 @@ def test_indicator_calculator_outputs():
 
     sma = ic.sma_5(df['close'])
     ema = ic.ema_13(df['close'])
-    rsi = ic.rsi_14(df['close'])
     adx = ic.adx_14(df['high'], df['low'], df['close'])
 
     expected_sma = pd.Series([np.nan, np.nan, np.nan, np.nan, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0])
@@ -30,11 +29,18 @@ def test_indicator_calculator_outputs():
     ])
     np.testing.assert_allclose(ema.values, expected_ema.values, rtol=1e-6, atol=1e-6)
 
-    assert rsi.isna().all()
+    close = pd.Series([44,47,52,48,44,46,50,49,48,47,49,53,54,56,58,57,55], dtype=float)
+    rsi = ic.rsi_14(close)
+    expected_rsi = pd.Series(
+        [np.nan]*14 + [84.577233, 82.142390, 77.346463]
+    )
+    pd.testing.assert_series_equal(rsi.reset_index(drop=True), expected_rsi, check_names=False)
+
     assert adx.isna().all()
 
 
-def test_adx_raises_without_pandas_ta(monkeypatch):
+def test_adx_without_pandas_ta(monkeypatch):
     monkeypatch.setattr(ic, "ta", None)
-    with pytest.raises(NotImplementedError):
-        ic.adx_14(pd.Series([1, 2]), pd.Series([1, 2]), pd.Series([1, 2]))
+    with pytest.warns(RuntimeWarning):
+        out = ic.adx_14(pd.Series([1, 2]), pd.Series([1, 2]), pd.Series([1, 2]))
+    assert out.isna().all()


### PR DESCRIPTION
## Summary
- implement Wilder-style RSI with division-by-zero guard and safe ADX fallback
- auto-generate exit data and trading day calendar in `run_1g_returns`
- validate unique `FilterCode` in filter CSV loading
- expand tests for indicators, backtester, and filter CSV errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68953a8a18d483259296e1097ff3f76a