### PR TITLE
Improve data loading and config path handling

### DIFF
--- a/backtest/config.py
+++ b/backtest/config.py
@@ -90,8 +90,17 @@ def load_config(path: str | Path) -> RootCfg:
         raw = os.path.expandvars(v)
         vp = Path(raw).expanduser()
         if not vp.is_absolute():
-            vp = base / vp
-        return str(vp.resolve())
+            # first try relative to config file
+            candidate = (base / vp).resolve()
+            if not candidate.exists():
+                # fallback to current working directory only if that path exists
+                cwd_candidate = (Path.cwd() / vp).resolve()
+                if cwd_candidate.exists():
+                    candidate = cwd_candidate
+            vp = candidate
+        else:
+            vp = vp.resolve()
+        return str(vp)
 
     proj = cfg.get("project", {}) if isinstance(cfg, dict) else {}
     if isinstance(proj, dict) and proj.get("out_dir"):

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -93,7 +93,11 @@ def normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
     # renaming may cause different original names to map to the same target
     if result.columns.duplicated().any():
         dup = result.columns[result.columns.duplicated()].tolist()
-        raise ValueError(f"Duplicate columns after normalization: {dup}")
+        warnings.warn(
+            f"Normalize sonrası tekrar eden kolonlar bulundu ve ilk değerler tutuldu: {dup}"
+        )
+        # keep first occurrence, drop subsequent duplicates
+        result = result.loc[:, ~result.columns.duplicated()]
     return result
 
 
@@ -231,7 +235,9 @@ def read_excels_long(
 
     if not records:
         warnings.warn("Hiçbir sheet/çalışma sayfasından veri toplanamadı.")
-        return pd.DataFrame()
+        # return an empty DataFrame with expected columns so downstream code doesn't fail
+        cols = ["date", "open", "high", "low", "close", "volume", "symbol"]
+        return pd.DataFrame(columns=cols)
 
     full = pd.concat(records, ignore_index=True)
     full = full.sort_values(["symbol", "date"], kind="mergesort").reset_index(drop=True)

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -18,8 +18,8 @@ data:
     open: ["Açılış","Open"]
     high: ["Yüksek","High"]
     low:  ["Düşük","Low"]
-    close:["Kapanış","Close"]
-    volume:["Hacim","Volume","Adet"]
+    close: ["Kapanış","Close"]
+    volume: ["Hacim","Volume","Adet"]
 
 calendar:
   tplus1_mode: "price"   # price: sembol-bazlı bir sonraki bar; calendar: takvim bazlı T+1

--- a/lib/validator.py
+++ b/lib/validator.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
-import pandera as pa
+import pandera.pandas as pa
 
 
 _SCHEMA = pa.DataFrameSchema(

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -63,8 +63,10 @@ def test_load_config_relative_paths(tmp_path):
     cfg_file.write_text(cfg_text, encoding="utf-8")  # PATH DÜZENLENDİ
     cfg = load_config(cfg_file)
     base = cfg_file.parent
+    cwd = Path.cwd()
     assert cfg.project.out_dir == str(base / "out")
     assert cfg.data.excel_dir == str(base / "data")
-    assert cfg.data.filters_csv == str(base / "filters.csv")
+    # filters.csv exists in working directory, so path falls back there
+    assert cfg.data.filters_csv == str(cwd / "filters.csv")
     assert cfg.calendar.holidays_csv_path == str(base / "hol.csv")
     assert cfg.benchmark.xu100_csv_path == str(base / "xu.csv")

--- a/tests/test_data_loader_empty_records.py
+++ b/tests/test_data_loader_empty_records.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from backtest.data_loader import read_excels_long, apply_corporate_actions
+
+
+def test_read_excels_long_no_valid_sheets(tmp_path):
+    # Create an Excel file with an empty sheet and a sheet without a date column
+    f = tmp_path / "dummy.xlsx"
+    with pd.ExcelWriter(f) as writer:
+        # empty sheet
+        pd.DataFrame().to_excel(writer, sheet_name="Empty", index=False)
+        # sheet missing required 'date' column
+        pd.DataFrame({"close": [1]}).to_excel(writer, sheet_name="NoDate", index=False)
+
+    df = read_excels_long(tmp_path)
+    expected = ["date", "open", "high", "low", "close", "volume", "symbol"]
+    assert df.empty
+    assert list(df.columns) == expected
+
+    # downstream operations should accept the empty dataframe without errors
+    df2 = apply_corporate_actions(df)
+    assert df2.empty
+    assert list(df2.columns) == expected


### PR DESCRIPTION
## Summary
- fix YAML formatting for sample config and ensure relative paths work even when config file is moved
- handle duplicate columns during Excel normalization and return empty dataframes with expected schema
- update pandera import to new namespace
- add regression test for empty Excel sheets and refine config path fallback logic

## Testing
- `pytest -q`
- `python -m backtest.cli scan-day --config examples/example_config.yaml --date 2024-01-02` *(fails: interrupted manually after verifying progress and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68953f7159488325ae122ce1b76c8c4e