### PR TITLE
Improve data loading column and date handling

### DIFF
--- a/tests/test_utils_normalize_key.py
+++ b/tests/test_utils_normalize_key.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import warnings
 
 from backtest.utils import normalize_key
 from backtest.data_loader import normalize_columns
@@ -15,3 +16,19 @@ def test_normalize_columns_uses_common_normalize_key():
     df = pd.DataFrame({"Kapanış": [1], "İşlem Hacmi": [100]})
     normalized = normalize_columns(df)
     assert set(normalized.columns) == {"close", "volume"}
+
+
+def test_normalize_columns_drops_duplicate_aliases_without_warning():
+    df = pd.DataFrame(
+        {
+            "close": [1, 2],
+            "kapanis": [3, 4],
+            "kapanış": [5, 6],
+        }
+    )
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("error")
+        normalized = normalize_columns(df)
+    assert normalized.columns.tolist() == ["close"]
+    assert normalized["close"].tolist() == [1, 2]
+    assert record == []


### PR DESCRIPTION
## Summary
- Avoid duplicate columns during normalization without raising warnings
- Parse Excel date columns using ISO format by default
- Add regression test ensuring duplicate alias columns keep only the first occurrence

## Testing
- `pytest -q`
- `python -m backtest.cli scan-day --config /tmp/config.yaml --date 2024-01-02` *(terminated manually after startup due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689549f25b8c8325b726feab9e154871