### PR TITLE
Improve backtest accuracy, reporting, and data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ python -m backtest.cli scan-day --config examples/example_config.yaml --date 202
 !python -m backtest.cli scan-day --config examples/example_config.yaml --date 2024-01-02
 ```
 
+> Not: Filtre CSV doğrulaması için [Pandera](https://pandera.readthedocs.io/) gereklidir. 
+> `pip install pandera` komutuyla kurulabilir.
+
 ## Örnek Çalıştırma
 - `examples/example_config.yaml` içindeki `excel_dir` ve `filters_csv` yollarını düzenleyin.
 - Tek gün tarama:

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -61,6 +61,8 @@ def write_reports(
         raise ValueError(
             f"trades_all missing columns: {', '.join(sorted(missing))}"
         )  # TİP DÜZELTİLDİ
+    if "Reason" not in trades_all.columns:
+        trades_all["Reason"] = pd.NA
     if summary_wide is not None and not isinstance(summary_wide, pd.DataFrame):
         raise TypeError("summary_wide must be a DataFrame or None")  # TİP DÜZELTİLDİ
     if summary_winrate is not None and not isinstance(summary_winrate, pd.DataFrame):
@@ -173,7 +175,7 @@ def write_reports(
                     ws.set_column(6, 6, 8)
                     rows = len(trades_all[trades_all["Date"] == day_ts])
                     last_row = rows if rows > 0 else 0  # LOJİK HATASI DÜZELTİLDİ
-                    ws.autofilter(0, 0, last_row, 6)
+                    ws.autofilter(0, 0, last_row, day_df.shape[1] - 1)
 
                 if summary_sheet_name in writer.sheets:
                     ws = writer.sheets[summary_sheet_name]

--- a/lib/validator.py
+++ b/lib/validator.py
@@ -13,7 +13,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
-import pandera.pandas as pa
+
+try:  # Pandera import may vary by version
+    import pandera as pa
+except Exception as exc:  # pragma: no cover - import error path
+    raise ImportError(
+        "Pandera is required for filter validation. Install with 'pip install pandera'."
+    ) from exc
 
 
 _SCHEMA = pa.DataFrameSchema(

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -72,6 +72,7 @@ def test_scan_range_empty(monkeypatch):
                 "ExitClose",
                 "ReturnPct",
                 "Win",
+                "Reason",
             ]
         ),
     )
@@ -125,6 +126,7 @@ def test_scan_day_empty(monkeypatch):
                 "ExitClose",
                 "ReturnPct",
                 "Win",
+                "Reason",
             ]
         ),
     )

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+from click.testing import CliRunner
+
+from backtest import cli
+
+
+def test_cli_scan_range_integration(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Tarih": ["2024-01-02", "2024-01-03"],
+            "Açılış": [10, 11],
+            "Yüksek": [10, 11],
+            "Düşük": [10, 11],
+            "Kapanış": [10, 11],
+            "Hacim": [100, 110],
+        }
+    )
+    df.to_excel(tmp_path / "AAA.xlsx", index=False)
+    filters_csv = tmp_path / "filters.csv"
+    filters_csv.write_text("FilterCode;PythonQuery\nF1;close > 0\n", encoding="utf-8")
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        (
+            """
+project:
+  out_dir: "{out_dir}"
+  run_mode: "range"
+  start_date: "2024-01-02"
+  end_date: "2024-01-02"
+  holding_period: 1
+  transaction_cost: 0.0
+
+data:
+  excel_dir: "{out_dir}"
+  filters_csv: "{filters}"
+  enable_cache: false
+  cache_parquet_path: "{out_dir}/cache.parquet"
+  price_schema:
+    date: ["Tarih"]
+    open: ["Açılış"]
+    high: ["Yüksek"]
+    low: ["Düşük"]
+    close: ["Kapanış"]
+    volume: ["Hacim"]
+
+calendar:
+  tplus1_mode: "price"
+  holidays_source: "none"
+  holidays_csv_path: ""
+
+indicators:
+  engine: "builtin"
+  params: {{}}
+
+benchmark:
+  xu100_source: "none"
+  xu100_csv_path: ""
+
+report:
+  excel: true
+  csv: false
+  percent_format: "0.00%"
+  daily_sheet_prefix: "SCAN_"
+  summary_sheet_name: "SUMMARY"
+"""
+        ).format(out_dir=tmp_path, filters=filters_csv),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli.scan_range, ["--config", str(cfg_path)])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "SCAN_2024-01-02.xlsx").exists()

--- a/tests/test_group_short.py
+++ b/tests/test_group_short.py
@@ -47,6 +47,7 @@ def test_run_1g_returns_handles_short_and_group():
     )
     out = run_1g_returns(df, signals, trading_days=tdays)
     assert set(["Group", "Side"]).issubset(out.columns)
+    assert out["Reason"].isna().all()
     long_ret = (11.0 / 10.0 - 1.0) * 100.0
     short_ret = ((10.0 - 11.0) / 10.0) * 100.0
     assert pytest.approx(out[out["Side"] == "long"]["ReturnPct"].iloc[0], 0.01) == long_ret

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -36,5 +36,7 @@ def test_pipeline_end_to_end():
         "Side",
         "ReturnPct",
         "Win",
+        "Reason",
     ]
+    assert out["Reason"].isna().all()
     assert out.loc[0, "ReturnPct"] == pytest.approx((12.0 / 11.0 - 1) * 100)

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -67,4 +67,5 @@ def test_pipeline_no_signals():
         "ExitClose",
         "ReturnPct",
         "Win",
+        "Reason",
     ]

--- a/tests/test_price_schema.py
+++ b/tests/test_price_schema.py
@@ -1,0 +1,82 @@
+import pandas as pd
+from types import SimpleNamespace
+
+from backtest.data_loader import read_excels_long
+
+
+class _DummyExcelFile:
+    def __init__(self, *args, **kwargs):
+        self.sheet_names = ["S1"]
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+
+    def parse(self, sheet_name, header=0):
+        return pd.DataFrame(
+            {
+                "Tarih": ["2024-01-01"],
+                "Açılış": [1],
+                "Yüksek": [2],
+                "Düşük": [0.5],
+                "Fiyat": [1.5],
+                "Adet": [100],
+            }
+        )
+
+
+class _StdExcelFile(_DummyExcelFile):
+    def parse(self, sheet_name, header=0):  # type: ignore[override]
+        return pd.DataFrame(
+            {
+                "date": ["2024-01-01"],
+                "open": [1],
+                "high": [2],
+                "low": [0.5],
+                "close": [1.5],
+                "volume": [100],
+            }
+        )
+
+
+def test_read_excels_long_price_schema(tmp_path, monkeypatch):
+    (tmp_path / "a.xlsx").write_text("dummy")
+    cfg = SimpleNamespace(
+        data=SimpleNamespace(
+            excel_dir=tmp_path,
+            price_schema={
+                "date": ["Tarih"],
+                "open": ["Açılış"],
+                "high": ["Yüksek"],
+                "low": ["Düşük"],
+                "close": ["Fiyat"],
+                "volume": ["Adet"],
+            },
+        )
+    )
+    monkeypatch.setattr(pd, "ExcelFile", _DummyExcelFile)
+    out = read_excels_long(cfg)
+    assert "close" in out.columns and out.loc[0, "close"] == 1.5
+
+
+def test_read_excels_long_closes_files(tmp_path, monkeypatch):
+    (tmp_path / "a.xlsx").write_text("dummy")
+    instances = []
+
+    def _factory(*args, **kwargs):
+        inst = _DummyExcelFile(*args, **kwargs)
+        instances.append(inst)
+        return inst
+
+    def _factory(*args, **kwargs):
+        inst = _StdExcelFile(*args, **kwargs)
+        instances.append(inst)
+        return inst
+
+    monkeypatch.setattr(pd, "ExcelFile", _factory)
+    cfg = SimpleNamespace(data=SimpleNamespace(excel_dir=tmp_path))
+    read_excels_long(cfg)
+    assert instances and all(inst.closed for inst in instances)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -24,6 +24,7 @@ def test_write_reports_returns_paths(tmp_path):
             "ExitClose": [11.0],
             "ReturnPct": [10.0],
             "Win": [True],
+            "Reason": [pd.NA],
         }
     )
     summary = (
@@ -64,6 +65,7 @@ def test_write_reports_raises_on_excel_error(monkeypatch, tmp_path):
             "ExitClose": [11.0],
             "ReturnPct": [10.0],
             "Win": [True],
+            "Reason": [pd.NA],
         }
     )
     summary = trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack()
@@ -86,6 +88,7 @@ def test_write_reports_warns_if_file_missing(monkeypatch, tmp_path):
             "ExitClose": [11.0],
             "ReturnPct": [10.0],
             "Win": [True],
+            "Reason": [pd.NA],
         }
     )
     summary = trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack()

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -25,6 +25,35 @@ def test_quality_warnings_missing_columns():
         quality_warnings(df)
 
 
+def test_quality_warnings_extra_checks():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"] * 5,
+            "date": pd.to_datetime(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-04",
+                    "2024-01-05",
+                ]
+            ),
+            "open": [1.0, 1.0, 1.0, None, 1.0],
+            "high": [2.0, 2.0, 0.5, 2.0, 2.0],
+            "low": [1.0, 1.0, 1.0, 1.0, 3.0],
+            "close": [1.0, 1.0, 1.0, 1.0, float("nan")],
+            "volume": [100, 0, 100, 100, -5],
+        }
+    )
+    issues = quality_warnings(df)
+    assert set(issues["issue"]) == {
+        "non_positive_volume",
+        "high_lt_low",
+        "na_open",
+        "na_close",
+    }
+
+
 class _DummyWriter:
     def __init__(self, *args, **kwargs):
         self.book = SimpleNamespace(add_format=lambda *a, **k: None)
@@ -49,6 +78,7 @@ def test_write_reports_xu100_pct_type(monkeypatch):
             "ExitClose",
             "ReturnPct",
             "Win",
+            "Reason",
         ]
     )
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary
- Fix multi-day exit calculations and log reasons for invalid trades
- Adjust corporate actions to scale volume and honor custom price schemas
- Harden validator imports, quality checks, and reporting for richer diagnostics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a435b6608325af47083ad28dd13b