### PR TITLE
Default missing signal side to long

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -114,12 +114,12 @@ def run_1g_returns(
         trading_days = build_trading_days(df_with_next)
 
     if "Side" in signals.columns:
-        sides = signals["Side"].dropna().astype(str).str.lower()
+        sides = signals["Side"].fillna("long").astype(str).str.lower()
         invalid = ~sides.isin([s.value for s in TradeSide])
         if invalid.any():
-            bad_vals = signals["Side"][invalid].unique().tolist()
+            bad_vals = sides[invalid].unique().tolist()
             raise ValueError(f"Geçersiz Side değer(ler)i: {bad_vals}")
-        signals["Side"] = sides.map(lambda s: TradeSide.from_value(s).value)
+        signals["Side"] = sides.map(TradeSide.from_value)
 
     has_next = {"next_date", "next_close"}.issubset(df_with_next.columns)
     base_cols = ["symbol", "date", "close"]
@@ -201,7 +201,7 @@ def run_1g_returns(
 
     valid = ~(invalid_entry | invalid_exit)
     if "Side" in merged.columns:
-        side_enum = merged.loc[valid, "Side"].map(TradeSide.from_value)
+        side_enum = merged.loc[valid, "Side"]
     else:
         side_enum = pd.Series(TradeSide.LONG, index=merged.index)
         side_enum = side_enum.loc[valid]

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -134,6 +134,41 @@ def test_run_1g_returns_side_validation():
         run_1g_returns(df, sigs_bad)
 
 
+def test_run_1g_returns_fills_missing_side_with_long():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA", "BBB", "BBB", "CCC", "CCC"],
+            "date": pd.to_datetime(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-01",
+                    "2024-01-02",
+                ]
+            ),
+            "close": [10.0, 11.0, 20.0, 22.0, 30.0, 33.0],
+        }
+    )
+    sigs = pd.DataFrame(
+        {
+            "FilterCode": ["T1", "T1", "T1"],
+            "Symbol": ["AAA", "BBB", "CCC"],
+            "Date": pd.to_datetime(
+                ["2024-01-01", "2024-01-01", "2024-01-01"]
+            ),
+            "Side": [pd.NA, "short", None],
+        }
+    )
+    out = run_1g_returns(df, sigs).set_index("Symbol")
+    assert out.loc["AAA", "Side"] == "long"
+    assert out.loc["CCC", "Side"] == "long"
+    assert out.loc["BBB", "Side"] == "short"
+    assert pytest.approx(out.loc["AAA", "ReturnPct"], 0.01) == 10.0
+    assert pytest.approx(out.loc["CCC", "ReturnPct"], 0.01) == 10.0
+    assert pytest.approx(out.loc["BBB", "ReturnPct"], 0.01) == -10.0
+
 def test_run_1g_returns_fills_missing_exit_data():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- Fill missing signal sides with `long` and convert to `TradeSide` enums
- Adjust return calculation to use enum sides directly
- Add regression test covering missing side values

## Testing
- `pytest tests/test_backtester.py::test_run_1g_returns_side_validation tests/test_backtester.py::test_run_1g_returns_fills_missing_side_with_long -q`
- `pytest tests/test_backtester.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895d0742e208325b11a4f0475c3bbab