### PR TITLE
Validate corporate action factors

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -160,6 +160,9 @@ def apply_corporate_actions(
     adj = adj.rename(columns=str.lower)
     if not {"symbol", "date", "factor"}.issubset(adj.columns):
         raise ValueError("corporate actions csv missing required columns")
+    adj["factor"] = pd.to_numeric(adj["factor"], errors="coerce")
+    if (adj["factor"] <= 0).any() or adj["factor"].isna().any():
+        raise ValueError("corporate actions csv contains invalid factor")
     adj["date"] = pd.to_datetime(adj["date"]).dt.normalize()
     df = df.copy()
     df["date"] = pd.to_datetime(df["date"]).dt.normalize()

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from backtest.data_loader import apply_corporate_actions
 
@@ -65,3 +66,23 @@ def test_apply_corporate_actions_equivalence(tmp_path):
     vec = apply_corporate_actions(df, csv)
     manual = _apply_loop(df, adj)
     pd.testing.assert_frame_equal(vec, manual, check_dtype=False)
+
+
+@pytest.mark.parametrize("factor", [0, -1, "foo"])
+def test_apply_corporate_actions_invalid_factor(tmp_path, factor):
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]),
+            "open": [10.0],
+            "high": [10.0],
+            "low": [10.0],
+            "close": [10.0],
+        }
+    )
+    csv = tmp_path / "actions.csv"
+    csv.write_text(
+        f"symbol,date,factor\nAAA,2024-01-02,{factor}\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError):
+        apply_corporate_actions(df, csv)


### PR DESCRIPTION
## Summary
- ensure corporate action factors are numeric and positive
- raise ValueError for invalid factors
- add tests for invalid factor scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895d3179978832591cb4a82bac6124b