### PR TITLE
Refactor reporter autofilter and verify Excel output

### DIFF
--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -63,6 +63,7 @@ def write_reports(
         )  # TİP DÜZELTİLDİ
     if "Reason" not in trades_all.columns:
         trades_all["Reason"] = pd.NA
+    n_cols = trades_all.shape[1]
     if summary_wide is not None and not isinstance(summary_wide, pd.DataFrame):
         raise TypeError("summary_wide must be a DataFrame or None")  # TİP DÜZELTİLDİ
     if summary_winrate is not None and not isinstance(summary_winrate, pd.DataFrame):
@@ -175,7 +176,7 @@ def write_reports(
                     ws.set_column(6, 6, 8)
                     rows = len(trades_all[trades_all["Date"] == day_ts])
                     last_row = rows if rows > 0 else 0  # LOJİK HATASI DÜZELTİLDİ
-                    ws.autofilter(0, 0, last_row, day_df.shape[1] - 1)
+                    ws.autofilter(0, 0, last_row, n_cols - 1)
 
                 if summary_sheet_name in writer.sheets:
                     ws = writer.sheets[summary_sheet_name]

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -55,6 +55,35 @@ def test_write_reports_returns_paths(tmp_path):
         assert p.exists()
 
 
+def test_write_reports_preserves_excel_columns(tmp_path):
+    trades = pd.DataFrame(
+        {
+            "FilterCode": ["f1"],
+            "Symbol": ["SYM"],
+            "Date": [pd.Timestamp("2024-01-01")],
+            "EntryClose": [10.0],
+            "ExitClose": [11.0],
+            "ReturnPct": [10.0],
+            "Win": [True],
+            "Reason": [pd.NA],
+        }
+    )
+    summary = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
+    )
+    out_xlsx = tmp_path / "out.xlsx"
+    write_reports(
+        trades,
+        [pd.Timestamp("2024-01-01")],
+        summary,
+        out_xlsx=out_xlsx,
+    )
+    df = pd.read_excel(out_xlsx, sheet_name="SCAN_2024-01-01")
+    assert list(df.columns) == list(trades.columns)
+
+
 def test_write_reports_raises_on_excel_error(monkeypatch, tmp_path):
     trades = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- Compute column count once before loops and reuse in Excel autofilter
- Extend reporter tests to confirm generated Excel retains all columns

## Testing
- `pytest tests/test_reporter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895d9621bc88325a9592351eb527c30