### PR TITLE
Fix relative volume denominator handling and add test

### DIFF
--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -132,7 +132,8 @@ def compute_indicators(
                 g[f"MACD_{fast}_{slow}_{sig}_HIST"] = hist
         g["CHANGE_1D_PERCENT"] = g["close"].pct_change(1) * 100.0
         g["CHANGE_5D_PERCENT"] = g["close"].pct_change(5) * 100.0
-        g["RELATIVE_VOLUME"] = g["volume"] / g["volume"].rolling(20).mean()
+        vol_mean = g["volume"].rolling(20, min_periods=1).mean().replace(0, pd.NA)
+        g["RELATIVE_VOLUME"] = (g["volume"] / vol_mean).fillna(0)
         out_frames.append(g)
     df2 = pd.concat(out_frames, ignore_index=True)
     alias_map = {

--- a/tests/test_relative_volume.py
+++ b/tests/test_relative_volume.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from backtest.indicators import compute_indicators
+
+
+def test_relative_volume_no_nan_and_no_div_zero():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"] * 5,
+            "date": pd.date_range("2024-01-01", periods=5, freq="D"),
+            "close": [10, 11, 12, 13, 14],
+            "open": [10, 11, 12, 13, 14],
+            "high": [10, 11, 12, 13, 14],
+            "low": [10, 11, 12, 13, 14],
+            "volume": [0, 100, 110, 120, 130],
+        }
+    )
+    res = compute_indicators(df)
+    rv = res["RELATIVE_VOLUME"]
+    assert rv.notna().all()
+    assert not np.isinf(rv).any()
+    assert rv.iloc[0] == 0
+    assert rv.iloc[1] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- compute relative volume using rolling mean with zero-safe denominator
- cover relative volume edge cases with a regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895daab24c883259b848a212b81a080