### PR TITLE
Ensure screener output is unique

### DIFF
--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -24,7 +24,8 @@ def run_screener(
     strict: bool = True,
 ) -> pd.DataFrame:
     logger.debug(
-        "run_screener start - data rows: {rows_df}, filter rows: {rows_filters}, date: {day}",
+        "run_screener start - data rows: {rows_df}, "
+        "filter rows: {rows_filters}, date: {day}",
         rows_df=len(df_ind) if isinstance(df_ind, pd.DataFrame) else "?",
         rows_filters=len(filters_df) if isinstance(filters_df, pd.DataFrame) else "?",
         day=date,
@@ -82,17 +83,26 @@ def run_screener(
         sq = SafeQuery(expr)
         if not sq.is_safe:
             logger.warning(
-                "Filter skipped due to unsafe expression", code=code, expr=expr, reason=sq.error
+                "Filter skipped due to unsafe expression",
+                code=code,
+                expr=expr,
+                reason=sq.error,
             )
             continue
         missing_cols = sq.names.difference(d.columns)
         if missing_cols:
             msg = f"Filter {code!r} missing columns: {sorted(missing_cols)}"
             if strict:
-                logger.error("Filter missing columns", code=code, missing=sorted(missing_cols))
+                logger.error(
+                    "Filter missing columns",
+                    code=code,
+                    missing=sorted(missing_cols),
+                )
                 raise ValueError(msg)
             logger.warning(
-                "Filter skipped due to missing columns", code=code, missing=sorted(missing_cols)
+                "Filter skipped due to missing columns",
+                code=code,
+                missing=sorted(missing_cols),
             )
             warnings.warn(msg)
             continue
@@ -120,6 +130,7 @@ def run_screener(
         return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
     out = pd.concat(out_frames, ignore_index=True)
     out = out.rename(columns={"symbol": "Symbol"})
+    out.drop_duplicates(["FilterCode", "Symbol", "Date"], inplace=True)
     cols = ["FilterCode"]
     if "Group" in out.columns:
         cols.append("Group")

--- a/tests/test_screener_duplicates.py
+++ b/tests/test_screener_duplicates.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from backtest.screener import run_screener
+
+
+def test_run_screener_deduplicates():
+    df_ind = pd.DataFrame(
+        {
+            "symbol": ["AAA", "AAA"],
+            "date": pd.to_datetime(["2024-01-02", "2024-01-02"]).normalize(),
+            "open": [1.0, 1.0],
+            "high": [1.0, 1.0],
+            "low": [1.0, 1.0],
+            "close": [1.0, 1.0],
+            "volume": [100, 100],
+        }
+    )
+    filters = pd.DataFrame(
+        {
+            "FilterCode": ["F1"],
+            "PythonQuery": ["close > 0"],
+        }
+    )
+    res = run_screener(df_ind, filters, pd.Timestamp("2024-01-02"))
+    assert len(res) == 1
+    assert res["Symbol"].tolist() == ["AAA"]


### PR DESCRIPTION
## Summary
- Drop duplicate FilterCode/Symbol/Date rows after concatenating screener results
- Test screener against duplicate input rows

## Testing
- `flake8 backtest/screener.py tests/test_screener_duplicates.py`
- `pytest tests/test_screener_duplicates.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ffd81b5c8325a5c389db1b698223