### PR TITLE
Handle missing and negative values in data loader

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -303,6 +303,8 @@ def read_excels_long(
                         df = df[["date", *keep]].copy()
                         for c in keep:
                             df[c] = pd.to_numeric(df[c], errors="coerce")
+                        df = df.dropna(subset=keep)
+                        df = df[(df[keep] >= 0).all(axis=1)]
 
                         df["symbol"] = str(sheet).strip().upper()
                         records.append(df)

--- a/tests/test_data_loader_negative_nan.py
+++ b/tests/test_data_loader_negative_nan.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+
+from backtest.data_loader import read_excels_long
+
+
+def test_read_excels_long_negative_and_nan(tmp_path):
+    f = tmp_path / "dummy.xlsx"
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02", "2024-01-03"],
+            "open": [1, None, 3],
+            "high": [2, 3, -4],
+            "low": [1, 2, 3],
+            "close": [1, 2, 3],
+            "volume": [100, 200, 300],
+        }
+    )
+    df.to_excel(f, index=False)
+
+    out = read_excels_long(tmp_path)
+    assert len(out) == 1
+
+    df.loc[2, "high"] = 4
+    df.to_excel(f, index=False)
+
+    out = read_excels_long(tmp_path)
+    assert len(out) == 2
+    assert out[["open", "high", "low", "close", "volume"]].isna().sum().sum() == 0
+    assert not (out[["open", "high", "low", "close", "volume"]] < 0).any().any()


### PR DESCRIPTION
## Summary
- Drop rows with NaN values in price columns when reading Excel files
- Exclude rows containing negative price or volume values
- Add regression test covering NaN and negative inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960481ee408325aedc769e080e1bdd