### PR TITLE
Raise error for duplicate FilterCode

### DIFF
--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -88,6 +88,10 @@ def run_screener(
         return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
     d = d.reset_index(drop=True)
     filters_df = filters_df.copy()
+    dups = filters_df["FilterCode"].duplicated()
+    if dups.any():
+        dup_codes = filters_df.loc[dups, "FilterCode"].tolist()
+        raise ValueError(f"Duplicate FilterCode detected: {dup_codes}")
     filters_df["FilterCode"] = filters_df["FilterCode"].astype(str).str.strip()
     filters_df["expr"] = filters_df["PythonQuery"].astype(str).map(_to_pandas_ops)
     groups = filters_df.get("Group")

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -160,3 +160,25 @@ def test_run_screener_side_validation():
     bad["Side"] = ["foo"]
     with pytest.raises(ValueError):
         run_screener(df_ind, bad, pd.Timestamp("2024-01-02"))
+
+
+def test_run_screener_duplicate_filter_code():
+    df_ind = pd.DataFrame(
+        {
+            "symbol": ["AAA"],
+            "date": pd.to_datetime(["2024-01-02"]).normalize(),
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [100],
+        }
+    )
+    filters_df = pd.DataFrame(
+        {
+            "FilterCode": ["F1", "F1"],
+            "PythonQuery": ["close > 0", "close > 1"],
+        }
+    )
+    with pytest.raises(ValueError, match="Duplicate FilterCode"):
+        run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))


### PR DESCRIPTION
## Summary
- check for duplicate FilterCode entries in run_screener
- add unit test verifying duplicate codes raise ValueError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689611d720a08325a74aafe57782de14