### PR TITLE
Handle NaN side values in screener

### DIFF
--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -105,7 +105,7 @@ def run_screener(
         filters_df["FilterCode"], filters_df["expr"], groups, sides
     ):
         side_norm = None
-        if side is not None and str(side).strip():
+        if pd.notna(side) and str(side).strip():
             side_norm = str(side).strip().lower()
             if side_norm not in {"long", "short"}:
                 raise ValueError(f"Geçersiz Side değeri: {side}")


### PR DESCRIPTION
## Summary
- Use `pd.notna` to validate `Side` values in `run_screener`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961a910f8c8325ac9154cefde248ea