### PR TITLE
Normalize enable_cache values to boolean

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -228,6 +228,8 @@ def read_excels_long(
     excel_files: List[Path] = []
     if excel_dir and excel_dir.exists():
         excel_files = sorted(p for p in excel_dir.glob("*.xlsx"))
+    if enable_cache is not None:
+        enable_cache = bool(str(enable_cache).lower() in ("true", "1"))
     if enable_cache is None:
         enable_cache = len(excel_files) > 5
         if enable_cache:

--- a/tests/test_enable_cache_coercion.py
+++ b/tests/test_enable_cache_coercion.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+
+from backtest.data_loader import read_excels_long
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("true", True),
+        (1, True),
+        (True, True),
+        ("false", False),
+        (0, False),
+        (False, False),
+    ],
+)
+def test_enable_cache_coercion(tmp_path, monkeypatch, value, expected):
+    df = pd.DataFrame({"a": [1]})
+    cache_file = tmp_path / "cache.parquet"
+    cache_file.write_text("dummy")
+    monkeypatch.setattr(pd, "read_parquet", lambda _: df)
+
+    config = {
+        "data": {
+            "excel_dir": tmp_path,
+            "enable_cache": value,
+            "cache_parquet_path": cache_file,
+        }
+    }
+
+    if expected:
+        result = read_excels_long(config)
+        assert result.equals(df)
+    else:
+        with pytest.raises(RuntimeError):
+            read_excels_long(config)


### PR DESCRIPTION
## Summary
- Ensure `enable_cache` flag is coerced to a boolean before use
- Add unit tests covering string, integer, and boolean inputs for `enable_cache`

## Testing
- `pytest tests/test_enable_cache_coercion.py tests/test_data_loader_cache.py tests/test_data_loader_empty_records.py tests/test_data_loader_negative_nan.py tests/test_data_loader_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68961ad07e008325822a2f011dcec4f7