### PR TITLE
Add GitHub Actions tests and fix Pandera warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-__pycache__/\n*.pyc\n.ipynb_checkpoints/\nraporlar/\n
+__pycache__/
+*.pyc
+.ipynb_checkpoints/
+raporlar/

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+import numpy as np
 import pandas as pd
 from loguru import logger
 
@@ -132,7 +133,7 @@ def compute_indicators(
                 g[f"MACD_{fast}_{slow}_{sig}_HIST"] = hist
         g["CHANGE_1D_PERCENT"] = g["close"].pct_change(1) * 100.0
         g["CHANGE_5D_PERCENT"] = g["close"].pct_change(5) * 100.0
-        vol_mean = g["volume"].rolling(20, min_periods=1).mean().replace(0, pd.NA)
+        vol_mean = g["volume"].rolling(20, min_periods=1).mean().replace(0, np.nan)
         g["RELATIVE_VOLUME"] = (g["volume"] / vol_mean).fillna(0)
         out_frames.append(g)
     df2 = pd.concat(out_frames, ignore_index=True)

--- a/lib/validator.py
+++ b/lib/validator.py
@@ -15,11 +15,14 @@ from pathlib import Path
 import pandas as pd
 
 try:  # Pandera import may vary by version
-    import pandera as pa
-except Exception as exc:  # pragma: no cover - import error path
-    raise ImportError(
-        "Pandera is required for filter validation. Install with 'pip install pandera'."
-    ) from exc
+    import pandera.pandas as pa  # preferred in newer versions
+except Exception:
+    try:  # pragma: no cover - fallback for older pandera releases
+        import pandera as pa
+    except Exception as exc:  # pragma: no cover - import error path
+        raise ImportError(
+            "Pandera is required for filter validation. Install with 'pip install pandera'."
+        ) from exc
 
 
 _SCHEMA = pa.DataFrameSchema(


### PR DESCRIPTION
## Summary
- run project tests automatically via GitHub Actions
- switch to `pandera.pandas` namespace with fallback for old versions
- compute relative volume without pandas downcasting warning
- ensure `__pycache__` directories stay ignored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961e11984483259722fa21b4efc2d3