### PR TITLE
Add trade count summary column

### DIFF
--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -128,7 +128,11 @@ def write_reports(
                         raise TypeError(
                             "xu100_pct must be a mapping or Series"
                         )  # TİP DÜZELTİLDİ
-                    cols = [c for c in summary_wide.columns if c != "Ortalama"]
+                    cols = [
+                        c
+                        for c in summary_wide.columns
+                        if c not in {"Ortalama", "TradeCount"}
+                    ]
                     if set(cols).issubset(set(xu100_series.index)):
                         diff = summary_wide.copy()
                         for c in cols:


### PR DESCRIPTION
## Summary
- count trades per filter code and side to enhance scan summaries
- include TradeCount column in reports and exclude it from BIST comparisons
- add regression test ensuring TradeCount appears in summary sheets

## Testing
- `flake8 backtest/cli.py backtest/reporter.py tests/test_reporter.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689628960348832582744baa08c0bde1