### PR TITLE
Handle NaN ReturnPct in trade count

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -139,7 +139,8 @@ def _run_scan(cfg) -> None:
         group_cols = ["FilterCode"]
         if "Side" in trades_all.columns:
             group_cols.append("Side")
-        trade_counts = trades_all.groupby(group_cols)["Symbol"].count()
+        valid_trades = trades_all[trades_all["ReturnPct"].notna()]
+        trade_counts = valid_trades.groupby(group_cols)["Symbol"].count()
         pivot = pivot.assign(TradeCount=trade_counts)
     else:
         pivot = pd.DataFrame(columns=[*days, "Ortalama", "TradeCount"])


### PR DESCRIPTION
## Summary
- count trades only when `ReturnPct` is a valid number

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962bd588d48325824e7dd057a5114a