### PR TITLE
Ensure Side column present in empty backtester outputs

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -73,20 +73,40 @@ def run_1g_returns(
 
     if df_with_next.empty:
         logger.warning("df_with_next is empty")
-        cols = ["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win", "Reason"]
+        cols = [
+            "FilterCode",
+            "Symbol",
+            "Date",
+            "EntryClose",
+            "ExitClose",
+            "ReturnPct",
+            "Win",
+            "Reason",
+        ]
         if "Group" in signals.columns:
             cols.insert(1, "Group")
-        if "Side" in signals.columns:
-            cols.insert(len(cols) - 2, "Side")
-        return pd.DataFrame(columns=cols)
+        cols.insert(cols.index("ReturnPct"), "Side")
+        empty_df = pd.DataFrame(columns=cols)
+        empty_df["Side"] = pd.Series(dtype="object")
+        return empty_df
     if signals.empty:
         logger.warning("signals DataFrame is empty")
-        cols = ["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win", "Reason"]
+        cols = [
+            "FilterCode",
+            "Symbol",
+            "Date",
+            "EntryClose",
+            "ExitClose",
+            "ReturnPct",
+            "Win",
+            "Reason",
+        ]
         if "Group" in signals.columns:
             cols.insert(1, "Group")
-        if "Side" in signals.columns:
-            cols.insert(len(cols) - 2, "Side")
-        return pd.DataFrame(columns=cols)
+        cols.insert(cols.index("ReturnPct"), "Side")
+        empty_df = pd.DataFrame(columns=cols)
+        empty_df["Side"] = pd.Series(dtype="object")
+        return empty_df
 
     req_base = {"symbol", "date", "close"}
     missing_base = req_base.difference(df_with_next.columns)
@@ -126,12 +146,22 @@ def run_1g_returns(
             sides = sides.loc[valid_mask]
             if signals.empty:
                 logger.warning("signals DataFrame is empty after dropping invalid Side")
-                cols = ["FilterCode", "Symbol", "Date", "EntryClose", "ExitClose", "ReturnPct", "Win", "Reason"]
+                cols = [
+                    "FilterCode",
+                    "Symbol",
+                    "Date",
+                    "EntryClose",
+                    "ExitClose",
+                    "ReturnPct",
+                    "Win",
+                    "Reason",
+                ]
                 if "Group" in signals.columns:
                     cols.insert(1, "Group")
-                if "Side" in signals.columns:
-                    cols.insert(len(cols) - 2, "Side")
-                return pd.DataFrame(columns=cols)
+                cols.insert(cols.index("ReturnPct"), "Side")
+                empty_df = pd.DataFrame(columns=cols)
+                empty_df["Side"] = pd.Series(dtype="object")
+                return empty_df
         signals = signals.copy()
         signals["Side"] = sides.replace("", "long").map(TradeSide.from_value)
 

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -65,6 +65,7 @@ def test_pipeline_no_signals():
         "Date",
         "EntryClose",
         "ExitClose",
+        "Side",
         "ReturnPct",
         "Win",
         "Reason",


### PR DESCRIPTION
## Summary
- Always include `Side` column in early return paths of `run_1g_returns`
- Update smoke test to expect the `Side` column when no signals are returned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962dd128e0832595d4de982cc0b7b9