### PR TITLE
Add raise_on_error option to backtest configuration

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -95,7 +95,9 @@ def _run_scan(cfg) -> None:
     if len(days) > 1:
         info(f"{len(days)} gün taranacak...")
     for d in days:
-        sigs = run_screener(df_ind, filters_df, d)
+        sigs = run_screener(
+            df_ind, filters_df, d, raise_on_error=cfg.project.raise_on_error
+        )
         trades = run_1g_returns(
             df_ind,
             sigs,

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -19,6 +19,7 @@ class ProjectCfg(BaseModel):
     single_date: Optional[str] = None
     holding_period: int = 1
     transaction_cost: float = 0.0
+    raise_on_error: bool = False
 
 
 class DataCfg(BaseModel):

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -13,7 +13,12 @@ from backtest import cli
 def _cfg():
     return SimpleNamespace(
         project=SimpleNamespace(
-            out_dir="out", start_date=None, end_date=None, holding_period=1, transaction_cost=0.0
+            out_dir="out",
+            start_date=None,
+            end_date=None,
+            holding_period=1,
+            transaction_cost=0.0,
+            raise_on_error=False,
         ),
         data=SimpleNamespace(filters_csv="dummy.csv"),
         calendar=SimpleNamespace(
@@ -53,13 +58,11 @@ def test_scan_range_empty(monkeypatch):
     )
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]})
     monkeypatch.setattr(cli, "load_filters_csv", lambda _: filters_df)
-    monkeypatch.setattr(
-        cli,
-        "run_screener",
-        lambda df, filters, d: pd.DataFrame(
-            columns=["FilterCode", "Symbol", "Date"]
-        ),
-    )
+    def _run_screener(df, filters, d, raise_on_error=None):
+        assert raise_on_error is False
+        return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
+
+    monkeypatch.setattr(cli, "run_screener", _run_screener)
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
@@ -108,13 +111,11 @@ def test_scan_day_empty(monkeypatch):
     )
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]})
     monkeypatch.setattr(cli, "load_filters_csv", lambda _: filters_df)
-    monkeypatch.setattr(
-        cli,
-        "run_screener",
-        lambda df, filters, d: pd.DataFrame(
-            columns=["FilterCode", "Symbol", "Date"]
-        ),
-    )
+    def _run_screener(df, filters, d, raise_on_error=None):
+        assert raise_on_error is False
+        return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
+
+    monkeypatch.setattr(cli, "run_screener", _run_screener)
     monkeypatch.setattr(
         cli,
         "run_1g_returns",


### PR DESCRIPTION
## Summary
- Allow configuration of filter error handling via new `project.raise_on_error` setting
- Pass `raise_on_error` to `run_screener` so scans can skip failing filters by default
- Adjust CLI tests to account for new parameter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896325e00408325a41c38f9a88bf647