### PR TITLE
Clean up unused imports and duplicate factory in tests

### DIFF
--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-from types import SimpleNamespace
-
 import pandas as pd
 from click.testing import CliRunner
 

--- a/tests/test_data_loader_negative_nan.py
+++ b/tests/test_data_loader_negative_nan.py
@@ -1,6 +1,4 @@
 import pandas as pd
-import pytest
-
 from backtest.data_loader import read_excels_long
 
 

--- a/tests/test_price_schema.py
+++ b/tests/test_price_schema.py
@@ -65,12 +65,6 @@ def test_read_excels_long_price_schema(tmp_path, monkeypatch):
 def test_read_excels_long_closes_files(tmp_path, monkeypatch):
     (tmp_path / "a.xlsx").write_text("dummy")
     instances = []
-
-    def _factory(*args, **kwargs):
-        inst = _DummyExcelFile(*args, **kwargs)
-        instances.append(inst)
-        return inst
-
     def _factory(*args, **kwargs):
         inst = _StdExcelFile(*args, **kwargs)
         instances.append(inst)


### PR DESCRIPTION
## Summary
- Remove unused imports in CLI integration and data loader tests
- Drop redundant factory definition in price schema test to avoid redefinition

## Testing
- `python -m pyflakes $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963803be248325a08df0b14315ba1c