### PR TITLE
Add strict filter option to config and CLI

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -96,7 +96,11 @@ def _run_scan(cfg) -> None:
         info(f"{len(days)} gün taranacak...")
     for d in days:
         sigs = run_screener(
-            df_ind, filters_df, d, raise_on_error=cfg.project.raise_on_error
+            df_ind,
+            filters_df,
+            d,
+            strict=cfg.project.strict_filters,
+            raise_on_error=cfg.project.raise_on_error,
         )
         trades = run_1g_returns(
             df_ind,

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -20,6 +20,7 @@ class ProjectCfg(BaseModel):
     holding_period: int = 1
     transaction_cost: float = 0.0
     raise_on_error: bool = False
+    strict_filters: bool = False
 
 
 class DataCfg(BaseModel):

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -7,6 +7,7 @@ project:
   single_date: null
   holding_period: 1
   transaction_cost: 0.0
+  strict_filters: false
 
 data:
   excel_dir: "../Veri"

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -19,6 +19,7 @@ def _cfg():
             holding_period=1,
             transaction_cost=0.0,
             raise_on_error=False,
+            strict_filters=False,
         ),
         data=SimpleNamespace(filters_csv="dummy.csv"),
         calendar=SimpleNamespace(
@@ -58,8 +59,9 @@ def test_scan_range_empty(monkeypatch):
     )
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]})
     monkeypatch.setattr(cli, "load_filters_csv", lambda _: filters_df)
-    def _run_screener(df, filters, d, raise_on_error=None):
+    def _run_screener(df, filters, d, strict=None, raise_on_error=None):
         assert raise_on_error is False
+        assert strict is False
         return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
 
     monkeypatch.setattr(cli, "run_screener", _run_screener)
@@ -111,8 +113,9 @@ def test_scan_day_empty(monkeypatch):
     )
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]})
     monkeypatch.setattr(cli, "load_filters_csv", lambda _: filters_df)
-    def _run_screener(df, filters, d, raise_on_error=None):
+    def _run_screener(df, filters, d, strict=None, raise_on_error=None):
         assert raise_on_error is False
+        assert strict is False
         return pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
 
     monkeypatch.setattr(cli, "run_screener", _run_screener)

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -70,3 +70,76 @@ report:
     result = runner.invoke(cli.scan_range, ["--config", str(cfg_path)])
     assert result.exit_code == 0, result.output
     assert (tmp_path / "SCAN_2024-01-02.xlsx").exists()
+
+
+def test_cli_scan_strict_filters_missing_column(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Tarih": ["2024-01-02"],
+            "Açılış": [10],
+            "Yüksek": [10],
+            "Düşük": [10],
+            "Kapanış": [10],
+            "Hacim": [100],
+        }
+    )
+    df.to_excel(tmp_path / "AAA.xlsx", index=False)
+    filters_csv = tmp_path / "filters.csv"
+    filters_csv.write_text(
+        "FilterCode;PythonQuery\nF1;nonexistent > 0\n",
+        encoding="utf-8",
+    )
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        (
+            """
+project:
+  out_dir: "{out_dir}"
+  run_mode: "range"
+  start_date: "2024-01-02"
+  end_date: "2024-01-02"
+  holding_period: 1
+  transaction_cost: 0.0
+  strict_filters: true
+
+data:
+  excel_dir: "{out_dir}"
+  filters_csv: "{filters}"
+  enable_cache: false
+  cache_parquet_path: "{out_dir}/cache.parquet"
+  price_schema:
+    date: ["Tarih"]
+    open: ["Açılış"]
+    high: ["Yüksek"]
+    low: ["Düşük"]
+    close: ["Kapanış"]
+    volume: ["Hacim"]
+
+calendar:
+  tplus1_mode: "price"
+  holidays_source: "none"
+  holidays_csv_path: ""
+
+indicators:
+  engine: "builtin"
+  params: {{}}
+
+benchmark:
+  xu100_source: "none"
+  xu100_csv_path: ""
+
+report:
+  excel: true
+  csv: false
+  percent_format: "0.00%"
+  daily_sheet_prefix: "SCAN_"
+  summary_sheet_name: "SUMMARY"
+"""
+        ).format(out_dir=tmp_path, filters=filters_csv),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli.scan_range, ["--config", str(cfg_path)])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    assert "missing columns" in str(result.exception)


### PR DESCRIPTION
## Summary
- add `project.strict_filters` option to configuration and example YAMLs
- pass `strict` flag from CLI to `run_screener`
- test strict mode raising error for missing columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68970d7b14e483258ed509e7a6819710