### PR TITLE
Enforce boolean masks in SafeQuery

### DIFF
--- a/tests/test_query_parser_security.py
+++ b/tests/test_query_parser_security.py
@@ -16,3 +16,17 @@ def test_filter_rejects_unsafe_expression():
     q = SafeQuery("__import__('os').system('echo 1')")
     with pytest.raises(ValueError):
         q.filter(df)
+
+
+def test_get_mask_requires_boolean_result():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    q = SafeQuery("x + 1")
+    with pytest.raises(ValueError):
+        q.get_mask(df)
+
+
+def test_filter_rejects_non_boolean_mask():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    q = SafeQuery("x + 1")
+    with pytest.raises(ValueError):
+        q.filter(df)


### PR DESCRIPTION
## Summary
- validate that query expressions evaluate to boolean masks
- safeguard filter to operate only on boolean masks
- add tests for non-boolean query results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68970f91de048325ad93b9151a9b186a