### PR TITLE
Ensure next_date retains datetime type

### DIFF
--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -137,7 +137,7 @@ def add_next_close_calendar(
     valid_pos = pos >= 0
     next_pos = pos.copy()
     next_pos[valid_pos] = pos[valid_pos] + 1
-    next_dates = pd.Series(pd.NaT, index=df.index)
+    next_dates = pd.Series(pd.NaT, dtype="datetime64[ns]", index=df.index)
     mask = valid_pos & (next_pos < len(trading_days))
     next_dates.loc[mask] = trading_days[next_pos[mask]]
     df["next_date"] = next_dates


### PR DESCRIPTION
## Summary
- keep `next_date` column as datetime even when empty by specifying dtype for the `pd.Series` placeholder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689714c7e2008325995b6cfa65bb7c4e