### PR TITLE
Fix query validation and calendar checks

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -11,7 +11,7 @@ from .calendars import (
     add_next_close,
     add_next_close_calendar,
     build_trading_days,
-    check_missing_trading_days,
+    check_missing_trading_days_by_symbol,
 )
 
 
@@ -130,12 +130,15 @@ def run_1g_returns(
 
     has_next = {"next_date", "next_close"}.issubset(df_with_next.columns)
     if not has_next:
-        missing_days = check_missing_trading_days(df_with_next, raise_error=False)
-        if not missing_days.empty:
-            warnings.warn(
-                "Missing trading days: "
-                + ", ".join(d.strftime("%Y-%m-%d") for d in missing_days)
-            )
+        missing_days = check_missing_trading_days_by_symbol(
+            df_with_next, raise_error=False
+        )
+        if missing_days:
+            parts = []
+            for sym, days in missing_days.items():
+                day_str = ", ".join(d.strftime("%Y-%m-%d") for d in days)
+                parts.append(f"{sym}: {day_str}")
+            warnings.warn("Missing trading days: " + "; ".join(parts))
         if trading_days is not None:
             df_with_next = add_next_close_calendar(df_with_next, trading_days)
         else:

--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -65,7 +65,8 @@ class SafeQuery:
             return False, names, "syntax error"
         for node in ast.walk(tree):
             if isinstance(node, ast.Name):
-                names.add(node.id)
+                if node.id not in cls._ALLOWED_FUNCS:
+                    names.add(node.id)
             if isinstance(node, ast.Call):
                 func = node.func
                 if isinstance(func, ast.Attribute):

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -82,6 +82,9 @@ def run_screener(
         logger.error(msg)
         raise ValueError(msg)
 
+    df_ind = df_ind.copy()
+    df_ind["date"] = pd.to_datetime(df_ind["date"]).dt.normalize()
+
     def _empty_output() -> pd.DataFrame:
         cols = ["FilterCode"]
         if "Group" in filters_df.columns:


### PR DESCRIPTION
## Summary
- avoid treating allowed functions as column names in SafeQuery
- normalize DataFrame `date` column before screener runs
- detect missing trading days per symbol and warn in backtester

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68970c468aa483259e4d42c2c2dfc20c