### PR TITLE
Improve validation and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Aşağıdaki tablo bazı sık kullanılan indikatör kolonlarını ve bunlara il
 ### Yerel
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt  # Excel okuma için openpyxl/xlrd gereklidir
 python -m backtest.cli scan-day --config examples/example_config.yaml --date 2024-01-02
 ```
 ### Google Colab

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -40,7 +40,7 @@ def _run_scan(cfg) -> None:
     info("Excelleri okuyor...")
     try:
         df = read_excels_long(cfg)
-    except (FileNotFoundError, RuntimeError) as exc:
+    except (FileNotFoundError, RuntimeError, ImportError) as exc:
         logger.error(str(exc))
         raise click.ClickException(str(exc))
     df = apply_corporate_actions(df, getattr(cfg.data, "corporate_actions_csv", None))

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -123,12 +123,22 @@ def run_screener(
         if pd.notna(side) and str(side).strip():
             side_norm = str(side).strip().lower()
             if side_norm not in {"long", "short"}:
+                msg = f"Filter {code!r} has invalid Side {side!r}"
+                if strict:
+                    logger.error("Filter invalid Side", code=code, side=side)
+                    raise ValueError(msg)
                 logger.warning(
                     "Filter skipped due to invalid Side", code=code, side=side
                 )
                 continue
         sq = SafeQuery(expr)
         if not sq.is_safe:
+            msg = f"Filter {code!r} unsafe expression: {sq.error}"
+            if strict:
+                logger.error(
+                    "Filter unsafe expression", code=code, expr=expr, reason=sq.error
+                )
+                raise ValueError(msg)
             logger.warning(
                 "Filter skipped due to unsafe expression",
                 code=code,

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -68,7 +68,7 @@ def test_run_1g_returns_holding_period_and_cost():
     assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == expected
 
 
-def test_run_1g_returns_exit_date_out_of_bounds_returns_empty():
+def test_run_1g_returns_marks_exit_date_out_of_bounds():
     df = pd.DataFrame(
         {
             "symbol": ["AAA", "AAA"],
@@ -84,7 +84,9 @@ def test_run_1g_returns_exit_date_out_of_bounds_returns_empty():
         }
     )
     out = run_1g_returns(df, sigs)
-    assert out.empty
+    assert len(out) == 1
+    assert out.loc[0, "Reason"] == "Invalid ExitClose"
+    assert pd.isna(out.loc[0, "ReturnPct"])
 
 
 def test_run_1g_returns_ignores_out_of_bounds_signals():
@@ -103,8 +105,8 @@ def test_run_1g_returns_ignores_out_of_bounds_signals():
         }
     )
     out = run_1g_returns(df, sigs)
-    assert len(out) == 1
-    assert out.loc[0, "Date"] == pd.Timestamp("2024-01-01")
+    assert len(out) == 2
+    assert pd.isna(out.loc[out["Date"] == pd.Timestamp("2024-01-03"), "ReturnPct"]).all()
 
 
 def test_run_1g_returns_side_validation():
@@ -129,7 +131,8 @@ def test_run_1g_returns_side_validation():
     sigs_bad = sigs.copy()
     sigs_bad["Side"] = ["foo"]
     out_bad = run_1g_returns(df, sigs_bad)
-    assert out_bad.empty
+    assert out_bad.loc[0, "Reason"] == "Invalid Side"
+    assert pd.isna(out_bad.loc[0, "ReturnPct"])
 
 
 def test_run_1g_returns_fills_missing_side_with_long():

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -36,7 +36,7 @@ def test_run_screener_skips_unsafe(caplog):
         }
     )
     logger.add(caplog.handler, level="WARNING")
-    res = run_screener(df_ind, filters, pd.Timestamp("2024-01-02"))
+    res = run_screener(df_ind, filters, pd.Timestamp("2024-01-02"), strict=False)
     assert res["FilterCode"].tolist() == ["SAFE"]
     assert isinstance(res.loc[0, "Date"], pd.Timestamp)
     assert "unsafe expression" in caplog.text

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -158,8 +158,8 @@ def test_run_screener_side_validation():
     assert res.loc[0, "Side"] == "long"
     bad = filters_df.copy()
     bad["Side"] = ["foo"]
-    res_bad = run_screener(df_ind, bad, pd.Timestamp("2024-01-02"))
-    assert res_bad.empty
+    with pytest.raises(ValueError):
+        run_screener(df_ind, bad, pd.Timestamp("2024-01-02"))
 
 
 def test_run_screener_duplicate_filter_code():


### PR DESCRIPTION
## Summary
- Halt scanning when Excel dependencies are missing
- Treat invalid filter sides or expressions as errors when strict
- Preserve dropped trades with detailed reasons in backtests
- Document Excel engine requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897be4e29988325b9df6712fb5e7b30