### PR TITLE
Clean up utils naming patterns

### DIFF
--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -65,4 +65,3 @@ __all__ = [
     "canonicalize_filter_token",
     "set_name_normalization",
 ]
-

--- a/backtest/utils/names.py
+++ b/backtest/utils/names.py
@@ -75,14 +75,14 @@ ALIAS: Dict[str, str] = {
 
 # Örüntü temelli genel kurallar (EMA, SMA, RSI, MOM/ROC n, vb.)
 _PATTERNS = [
-    (re.compile(r"^ema[_\-]?(\d+)$"),      lambda m: f"ema_{m.group(1)}"),
-    (re.compile(r"^sma[_\-]?(\d+)$"),      lambda m: f"sma_{m.group(1)}"),
-    (re.compile(r"^rsi[_\-]?(\d+)$"),      lambda m: f"rsi_{m.group(1)}"),
+    (re.compile(r"^ema[_\-]?(\d+)$"), lambda m: f"ema_{m.group(1)}"),
+    (re.compile(r"^sma[_\-]?(\d+)$"), lambda m: f"sma_{m.group(1)}"),
+    (re.compile(r"^rsi[_\-]?(\d+)$"), lambda m: f"rsi_{m.group(1)}"),
     (re.compile(r"^(mom|momentum)[_\-]?(\d+)$"), lambda m: f"momentum_{m.group(2)}"),
-    (re.compile(r"^roc[_\-]?(\d+)$"),      lambda m: f"roc_{m.group(1)}"),
-    (re.compile(r"^adx[_\-]?(\d+)$"),      lambda m: f"adx_{m.group(1)}"),
-    (re.compile(r"^dmp[_\-]?(\d+)$"),      lambda m: f"dmp_{m.group(1)}"),
-    (re.compile(r"^dmn[_\-]?(\d+)$"),      lambda m: f"dmn_{m.group(1)}"),
+    (re.compile(r"^roc[_\-]?(\d+)$"), lambda m: f"roc_{m.group(1)}"),
+    (re.compile(r"^adx[_\-]?(\d+)$"), lambda m: f"adx_{m.group(1)}"),
+    (re.compile(r"^dmp[_\-]?(\d+)$"), lambda m: f"dmp_{m.group(1)}"),
+    (re.compile(r"^dmn[_\-]?(\d+)$"), lambda m: f"dmn_{m.group(1)}"),
 ]
 
 


### PR DESCRIPTION
## Summary
- remove extra spaces in indicator pattern rules
- drop trailing blank line from utils module

## Testing
- `flake8 backtest/utils/names.py backtest/utils/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cbab4b6348325bfb8905c3a069e14