### PR TITLE
Remove unused configuration fields and test artifacts

### DIFF
--- a/backtest/config.py
+++ b/backtest/config.py
@@ -20,7 +20,6 @@ class ProjectCfg(BaseModel):
     holding_period: int = 1
     transaction_cost: float = 0.0
     raise_on_error: bool = False
-    strict_filters: bool = False
 
 
 class DataCfg(BaseModel):
@@ -60,8 +59,6 @@ class BenchmarkCfg(BaseModel):
 
 
 class ReportCfg(BaseModel):
-    excel: bool = True
-    csv: bool = True
     percent_format: str = "0.00%"
     daily_sheet_prefix: str = "SCAN_"
     summary_sheet_name: str = "SUMMARY"
@@ -109,9 +106,15 @@ def load_config(path: str | Path) -> RootCfg:
     for req_key in ("excel_dir", "filters_csv"):
         if not data.get(req_key):
             raise ValueError(
-                f"config.data.{req_key} zorunlu; örnek için examples/example_config.yaml"
+                f"config.data.{req_key} zorunlu; "
+                "örnek için examples/example_config.yaml"
             )
-    for k in ["excel_dir", "filters_csv", "cache_parquet_path", "corporate_actions_csv"]:
+    for k in [
+        "excel_dir",
+        "filters_csv",
+        "cache_parquet_path",
+        "corporate_actions_csv",
+    ]:
         v = data.get(k)
         if v:
             data[k] = _join(v, allow_cwd=(k == "filters_csv"))  # PATH DÜZENLENDİ

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -38,8 +38,6 @@ benchmark:
   xu100_csv_path: ""
 
 report:
-  excel: true
-  csv: true
   percent_format: "0.00%"
   daily_sheet_prefix: "SCAN_"
   summary_sheet_name: "SUMMARY"

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -19,7 +19,6 @@ def _cfg():
             holding_period=1,
             transaction_cost=0.0,
             raise_on_error=False,
-            strict_filters=False,
         ),
         data=SimpleNamespace(filters_csv="dummy.csv"),
         calendar=SimpleNamespace(
@@ -57,8 +56,11 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(
         cli, "compute_indicators", lambda df, params, engine=None: df
     )
-    filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]})
+    filters_df = pd.DataFrame(
+        {"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]}
+    )
     monkeypatch.setattr(cli, "load_filters_csv", lambda _: filters_df)
+
     def _run_screener(df, filters, d, strict=None, raise_on_error=None):
         assert raise_on_error is False
         assert strict is True
@@ -111,8 +113,11 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(
         cli, "compute_indicators", lambda df, params, engine=None: df
     )
-    filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]})
+    filters_df = pd.DataFrame(
+        {"FilterCode": ["F1"], "PythonQuery": ["close>0"], "Group": ["G"]}
+    )
     monkeypatch.setattr(cli, "load_filters_csv", lambda _: filters_df)
+
     def _run_screener(df, filters, d, strict=None, raise_on_error=None):
         assert raise_on_error is False
         assert strict is True

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from click.testing import CliRunner
+import textwrap
 
 from backtest import cli
 
@@ -20,49 +21,47 @@ def test_cli_scan_range_integration(tmp_path):
     filters_csv.write_text("FilterCode;PythonQuery\nF1;close > 0\n", encoding="utf-8")
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(
-        (
+        textwrap.dedent(
             """
-project:
-  out_dir: "{out_dir}"
-  run_mode: "range"
-  start_date: "2024-01-02"
-  end_date: "2024-01-02"
-  holding_period: 1
-  transaction_cost: 0.0
+            project:
+              out_dir: "{out_dir}"
+              run_mode: "range"
+              start_date: "2024-01-02"
+              end_date: "2024-01-02"
+              holding_period: 1
+              transaction_cost: 0.0
 
-data:
-  excel_dir: "{out_dir}"
-  filters_csv: "{filters}"
-  enable_cache: false
-  cache_parquet_path: "{out_dir}/cache.parquet"
-  price_schema:
-    date: ["Tarih"]
-    open: ["Açılış"]
-    high: ["Yüksek"]
-    low: ["Düşük"]
-    close: ["Kapanış"]
-    volume: ["Hacim"]
+            data:
+              excel_dir: "{out_dir}"
+              filters_csv: "{filters}"
+              enable_cache: false
+              cache_parquet_path: "{out_dir}/cache.parquet"
+              price_schema:
+                date: ["Tarih"]
+                open: ["Açılış"]
+                high: ["Yüksek"]
+                low: ["Düşük"]
+                close: ["Kapanış"]
+                volume: ["Hacim"]
 
-calendar:
-  tplus1_mode: "price"
-  holidays_source: "none"
-  holidays_csv_path: ""
+            calendar:
+              tplus1_mode: "price"
+              holidays_source: "none"
+              holidays_csv_path: ""
 
-indicators:
-  engine: "builtin"
-  params: {{}}
+            indicators:
+              engine: "builtin"
+              params: {{}}
 
-benchmark:
-  xu100_source: "none"
-  xu100_csv_path: ""
+            benchmark:
+              xu100_source: "none"
+              xu100_csv_path: ""
 
-report:
-  excel: true
-  csv: false
-  percent_format: "0.00%"
-  daily_sheet_prefix: "SCAN_"
-  summary_sheet_name: "SUMMARY"
-"""
+            report:
+              percent_format: "0.00%"
+              daily_sheet_prefix: "SCAN_"
+              summary_sheet_name: "SUMMARY"
+            """
         ).format(out_dir=tmp_path, filters=filters_csv),
         encoding="utf-8",
     )
@@ -72,7 +71,7 @@ report:
     assert (tmp_path / "SCAN_2024-01-02.xlsx").exists()
 
 
-def test_cli_scan_strict_filters_missing_column(tmp_path):
+def test_cli_scan_missing_column(tmp_path):
     df = pd.DataFrame(
         {
             "Tarih": ["2024-01-02"],
@@ -91,50 +90,47 @@ def test_cli_scan_strict_filters_missing_column(tmp_path):
     )
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(
-        (
+        textwrap.dedent(
             """
-project:
-  out_dir: "{out_dir}"
-  run_mode: "range"
-  start_date: "2024-01-02"
-  end_date: "2024-01-02"
-  holding_period: 1
-  transaction_cost: 0.0
-  strict_filters: true
+            project:
+              out_dir: "{out_dir}"
+              run_mode: "range"
+              start_date: "2024-01-02"
+              end_date: "2024-01-02"
+              holding_period: 1
+              transaction_cost: 0.0
 
-data:
-  excel_dir: "{out_dir}"
-  filters_csv: "{filters}"
-  enable_cache: false
-  cache_parquet_path: "{out_dir}/cache.parquet"
-  price_schema:
-    date: ["Tarih"]
-    open: ["Açılış"]
-    high: ["Yüksek"]
-    low: ["Düşük"]
-    close: ["Kapanış"]
-    volume: ["Hacim"]
+            data:
+              excel_dir: "{out_dir}"
+              filters_csv: "{filters}"
+              enable_cache: false
+              cache_parquet_path: "{out_dir}/cache.parquet"
+              price_schema:
+                date: ["Tarih"]
+                open: ["Açılış"]
+                high: ["Yüksek"]
+                low: ["Düşük"]
+                close: ["Kapanış"]
+                volume: ["Hacim"]
 
-calendar:
-  tplus1_mode: "price"
-  holidays_source: "none"
-  holidays_csv_path: ""
+            calendar:
+              tplus1_mode: "price"
+              holidays_source: "none"
+              holidays_csv_path: ""
 
-indicators:
-  engine: "builtin"
-  params: {{}}
+            indicators:
+              engine: "builtin"
+              params: {{}}
 
-benchmark:
-  xu100_source: "none"
-  xu100_csv_path: ""
+            benchmark:
+              xu100_source: "none"
+              xu100_csv_path: ""
 
-report:
-  excel: true
-  csv: false
-  percent_format: "0.00%"
-  daily_sheet_prefix: "SCAN_"
-  summary_sheet_name: "SUMMARY"
-"""
+            report:
+              percent_format: "0.00%"
+              daily_sheet_prefix: "SCAN_"
+              summary_sheet_name: "SUMMARY"
+            """
         ).format(out_dir=tmp_path, filters=filters_csv),
         encoding="utf-8",
     )

--- a/tests/test_price_schema.py
+++ b/tests/test_price_schema.py
@@ -12,10 +12,11 @@ class _DummyExcelFile:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(self, _exc_type, _exc, _tb):
         self.closed = True
 
     def parse(self, sheet_name, header=0):
+        _ = sheet_name, header
         return pd.DataFrame(
             {
                 "Tarih": ["2024-01-01"],
@@ -30,6 +31,7 @@ class _DummyExcelFile:
 
 class _StdExcelFile(_DummyExcelFile):
     def parse(self, sheet_name, header=0):  # type: ignore[override]
+        _ = sheet_name, header
         return pd.DataFrame(
             {
                 "date": ["2024-01-01"],
@@ -65,6 +67,7 @@ def test_read_excels_long_price_schema(tmp_path, monkeypatch):
 def test_read_excels_long_closes_files(tmp_path, monkeypatch):
     (tmp_path / "a.xlsx").write_text("dummy")
     instances = []
+
     def _factory(*args, **kwargs):
         inst = _StdExcelFile(*args, **kwargs)
         instances.append(inst)

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -62,7 +62,7 @@ class _DummyWriter:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(self, _exc_type, _exc, _tb):
         return False
 
 


### PR DESCRIPTION
## Summary
- drop unused `strict_filters` and report output flags
- tidy tests and example configuration

## Testing
- `pytest`
- `flake8 backtest/config.py tests/test_cli_integration.py tests/test_cli_empty.py tests/test_price_schema.py tests/test_validator_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_689cc189b578832590c653012370955e