### PR TITLE
Remove leftover cleanup comments

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Backtest Project - 1G (T close -> T+1 close) pipeline."""
 
 from __future__ import annotations

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 from enum import Enum
@@ -14,7 +13,6 @@ from .calendars import (
     check_missing_trading_days_by_symbol,
 )
 
-
 class TradeSide(Enum):
     LONG = "long"
     SHORT = "short"
@@ -25,7 +23,6 @@ class TradeSide(Enum):
             return cls(value.lower())
         except Exception as exc:  # pragma: no cover - explicit ValueError below
             raise ValueError(f"Geçersiz Side değeri: {value!r}") from exc
-
 
 def run_1g_returns(
     df_with_next: pd.DataFrame,

--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import warnings
@@ -8,20 +7,19 @@ import pandas as pd
 
 from utils.paths import resolve_path
 
-
 def _read_csv_any(path: str | Path) -> pd.DataFrame:
     """Read CSV with fallback separator/decimal handling."""
     p = resolve_path(path)
     if not p.exists():
         raise FileNotFoundError(f"CSV bulunamadı: {p}")
     try:
-        df = pd.read_csv(p, encoding="utf-8")  # PATH DÜZENLENDİ
+        df = pd.read_csv(p, encoding="utf-8")
         if df.shape[1] > 1:
             return df
     except Exception:
         pass
     try:
-        with p.open("r", encoding="utf-8") as f:  # PATH DÜZENLENDİ
+        with p.open("r", encoding="utf-8") as f:
             sample = f.read(2048)
     except Exception as e:  # SPECIFIC EXCEPTIONS
         raise FileNotFoundError(f"CSV okunamadı: {p}") from e
@@ -33,17 +31,16 @@ def _read_csv_any(path: str | Path) -> pd.DataFrame:
         sep = ","
     dec = "," if sep == ";" else "."
     try:
-        return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")  # PATH DÜZENLENDİ
+        return pd.read_csv(p, sep=sep, decimal=dec, encoding="utf-8")
     except Exception as e:
         raise RuntimeError(f"CSV parse edilemedi: {p}") from e
 
-
 def load_xu100_pct(csv_path: str | Path) -> pd.Series:
     if not isinstance(csv_path, (str, Path)):
-        raise TypeError("csv_path must be str or Path")  # TİP DÜZELTİLDİ
-    df = _read_csv_any(csv_path)  # PATH DÜZENLENDİ
+        raise TypeError("csv_path must be str or Path")
+    df = _read_csv_any(csv_path)
     # En az iki kolon yoksa tarih ve fiyat ayrılamaz
-    if df.empty or df.shape[1] < 2:  # LOJİK HATASI DÜZELTİLDİ
+    if df.empty or df.shape[1] < 2:
         warnings.warn(f"Boş CSV: {csv_path}")
         return pd.Series(dtype=float)
     cols = {c.lower().strip(): c for c in df.columns}
@@ -58,7 +55,7 @@ def load_xu100_pct(csv_path: str | Path) -> pd.Series:
         "adj_close",
         "kapanis_tl",
         "fiyat",
-    )  # TİP DÜZELTİLDİ
+    )
     close_col = None
     for k in cand:
         if k in cols:

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,22 +8,20 @@ import warnings
 
 from utils.paths import resolve_path
 
-
 def add_next_close(df: pd.DataFrame) -> pd.DataFrame:
     """Price-driven next bar (symbol-based)."""
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     req = {"symbol", "date", "close"}
     missing = req.difference(df.columns)
     if missing:
         raise ValueError(
             f"Eksik kolon(lar): {', '.join(sorted(missing))}"
-        )  # TİP DÜZELTİLDİ
+        )
     df = df.copy().sort_values(["symbol", "date"])
     df["next_date"] = df.groupby("symbol")["date"].shift(-1)
     df["next_close"] = df.groupby("symbol")["close"].shift(-1)
     return df
-
 
 def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
     """Read holiday CSV with a 'date' column (case-insens.),
@@ -43,14 +40,12 @@ def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
     cols = {c.lower(): c for c in h.columns}
     c_date = cols.get("date")
     if c_date is None:
-        raise ValueError("CSV must contain a 'date' column")  # TİP DÜZELTİLDİ
+        raise ValueError("CSV must contain a 'date' column")
     h[c_date] = pd.to_datetime(h[c_date]).dt.normalize()
     return set(h[c_date].unique())
 
-
 def is_weekend(ts: pd.Timestamp) -> bool:
     return ts.weekday() >= 5  # 5=Sat,6=Sun
-
 
 def build_trading_days(
     df: pd.DataFrame, holidays: Optional[Iterable[pd.Timestamp]] = None
@@ -58,7 +53,7 @@ def build_trading_days(
     """Build calendar trading days from min..max of df, excluding weekends
     and holidays."""
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     if df.empty:
         return pd.DatetimeIndex([])
     start = pd.to_datetime(df["date"]).min()
@@ -66,7 +61,7 @@ def build_trading_days(
     all_days = pd.date_range(start=start, end=end, freq="D")
     if holidays is not None:
         if isinstance(holidays, (int, float)):
-            raise TypeError("holidays must be iterable or date-like")  # TİP DÜZELTİLDİ
+            raise TypeError("holidays must be iterable or date-like")
         if isinstance(holidays, Iterable) and not isinstance(
             holidays, (str, bytes, pd.Timestamp)
         ):
@@ -74,16 +69,15 @@ def build_trading_days(
         else:
             hol_iter = [holidays]
         try:
-            hol = set(pd.to_datetime(hol_iter).normalize())  # TİP DÜZELTİLDİ
+            hol = set(pd.to_datetime(hol_iter).normalize())
         except Exception as e:  # pragma: no cover - defensive
             raise ValueError(
                 "holidays contains non-date values"
-            ) from e  # TİP DÜZELTİLDİ
+            ) from e
     else:
         hol = set()
     trade = [d for d in all_days if (not is_weekend(d)) and (d.normalize() not in hol)]
     return pd.DatetimeIndex(trade)
-
 
 def check_missing_trading_days(
     df: pd.DataFrame,
@@ -112,7 +106,6 @@ def check_missing_trading_days(
         else:  # pragma: no cover - warning path
             warnings.warn(msg)
     return missing
-
 
 def check_missing_trading_days_by_symbol(
     df: pd.DataFrame,
@@ -148,7 +141,6 @@ def check_missing_trading_days_by_symbol(
             warnings.warn(msg)
     return missing
 
-
 def add_next_close_calendar(
     df: pd.DataFrame, trading_days: pd.DatetimeIndex
 ) -> pd.DataFrame:
@@ -157,15 +149,15 @@ def add_next_close_calendar(
     remains NaN (no trade possible).
     """
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     req = {"symbol", "date", "close"}
     missing = req.difference(df.columns)
     if missing:
         raise ValueError(
             f"Eksik kolon(lar): {', '.join(sorted(missing))}"
-        )  # TİP DÜZELTİLDİ
+        )
     if not isinstance(trading_days, pd.DatetimeIndex):
-        raise TypeError("trading_days must be a DatetimeIndex")  # TİP DÜZELTİLDİ
+        raise TypeError("trading_days must be a DatetimeIndex")
     df = df.copy().sort_values(["symbol", "date"])
     dates = pd.to_datetime(df["date"]).dt.normalize()
     pos = trading_days.get_indexer(dates)

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import click
@@ -25,11 +24,9 @@ from .screener import run_screener
 from .utils import info, set_name_normalization
 from .validator import dataset_summary, quality_warnings
 
-
 @click.group()
 def cli():
     pass
-
 
 def _run_scan(cfg) -> None:
     """Common execution for scan commands.
@@ -188,7 +185,6 @@ def _run_scan(cfg) -> None:
     if outputs.get("csv"):
         info(f"CSV klasörü: {outputs['csv'][0].parent}")
 
-
 @cli.command("scan-range")
 @click.option("--config", "config_path", required=True, help="YAML config yolu")
 @click.option("--start", "start_date", required=False, default=None, help="YYYY-MM-DD")
@@ -226,7 +222,6 @@ def scan_range(
     cfg.project.run_mode = "range"
     _run_scan(cfg)
 
-
 @cli.command("scan-day")
 @click.option("--config", "config_path", required=True)
 @click.option("--date", "date_str", required=True, help="YYYY-MM-DD")
@@ -245,7 +240,6 @@ def scan_day(config_path, date_str, holding_period, transaction_cost):
     if transaction_cost is not None:
         cfg.project.transaction_cost = transaction_cost
     _run_scan(cfg)
-
 
 if __name__ == "__main__":
     cli()

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -1,15 +1,13 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import os
-from pathlib import Path  # TİP DÜZELTİLDİ
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
 from pydantic import BaseModel, Field
 
 from utils.paths import resolve_path
-
 
 class ProjectCfg(BaseModel):
     out_dir: str = "raporlar"
@@ -20,7 +18,6 @@ class ProjectCfg(BaseModel):
     holding_period: int = 1
     transaction_cost: float = 0.0
     raise_on_error: bool = False
-
 
 class DataCfg(BaseModel):
     excel_dir: str
@@ -39,12 +36,10 @@ class DataCfg(BaseModel):
         }
     )
 
-
 class CalendarCfg(BaseModel):
     tplus1_mode: str = "price"  # price | calendar
     holidays_source: str = "none"  # none | csv
     holidays_csv_path: Optional[str] = None
-
 
 class IndicatorsCfg(BaseModel):
     engine: str = "pandas_ta"  # pandas_ta | ta_lib
@@ -52,26 +47,22 @@ class IndicatorsCfg(BaseModel):
         default_factory=lambda: {"rsi": [14], "ema": [10, 20, 50], "macd": [12, 26, 9]}
     )
 
-
 class BenchmarkCfg(BaseModel):
     xu100_source: str = "none"  # csv | none
     xu100_csv_path: Optional[str] = None
-
 
 class ReportCfg(BaseModel):
     percent_format: str = "0.00%"
     daily_sheet_prefix: str = "SCAN_"
     summary_sheet_name: str = "SUMMARY"
 
-
 class RootCfg(BaseModel):
     project: ProjectCfg
     data: DataCfg
-    calendar: CalendarCfg = Field(default_factory=CalendarCfg)  # TİP DÜZELTİLDİ
-    indicators: IndicatorsCfg = Field(default_factory=IndicatorsCfg)  # TİP DÜZELTİLDİ
-    benchmark: BenchmarkCfg = Field(default_factory=BenchmarkCfg)  # TİP DÜZELTİLDİ
-    report: ReportCfg = Field(default_factory=ReportCfg)  # TİP DÜZELTİLDİ
-
+    calendar: CalendarCfg = Field(default_factory=CalendarCfg)
+    indicators: IndicatorsCfg = Field(default_factory=IndicatorsCfg)
+    benchmark: BenchmarkCfg = Field(default_factory=BenchmarkCfg)
+    report: ReportCfg = Field(default_factory=ReportCfg)
 
 def load_config(path: str | Path) -> RootCfg:
     p = resolve_path(path)
@@ -80,7 +71,7 @@ def load_config(path: str | Path) -> RootCfg:
     with p.open("r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     if not isinstance(cfg, dict):
-        raise TypeError("Config içeriği sözlük olmalı")  # TİP DÜZELTİLDİ
+        raise TypeError("Config içeriği sözlük olmalı")
     base = p.parent
 
     def _join(v: Optional[str], *, allow_cwd: bool = False) -> Optional[str]:
@@ -101,7 +92,7 @@ def load_config(path: str | Path) -> RootCfg:
 
     proj = cfg.get("project", {}) if isinstance(cfg, dict) else {}
     if isinstance(proj, dict) and proj.get("out_dir"):
-        proj["out_dir"] = _join(proj.get("out_dir"))  # PATH DÜZENLENDİ
+        proj["out_dir"] = _join(proj.get("out_dir"))
     data = cfg.get("data", {}) if isinstance(cfg, dict) else {}
     for req_key in ("excel_dir", "filters_csv"):
         if not data.get(req_key):
@@ -117,15 +108,15 @@ def load_config(path: str | Path) -> RootCfg:
     ]:
         v = data.get(k)
         if v:
-            data[k] = _join(v, allow_cwd=(k == "filters_csv"))  # PATH DÜZENLENDİ
+            data[k] = _join(v, allow_cwd=(k == "filters_csv"))
     cal = cfg.get("calendar", {}) if isinstance(cfg, dict) else {}
     if isinstance(cal, dict) and cal.get("holidays_csv_path"):
         cal["holidays_csv_path"] = _join(
             cal.get("holidays_csv_path")
-        )  # PATH DÜZENLENDİ
+        )
     bench = cfg.get("benchmark", {}) if isinstance(cfg, dict) else {}
     if isinstance(bench, dict) and bench.get("xu100_csv_path"):
-        bench["xu100_csv_path"] = _join(bench.get("xu100_csv_path"))  # PATH DÜZENLENDİ
+        bench["xu100_csv_path"] = _join(bench.get("xu100_csv_path"))
     cfg["project"], cfg["data"], cfg["calendar"], cfg["benchmark"] = (
         proj,
         data,

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import warnings
@@ -13,7 +12,6 @@ from backtest.utils import normalize_key
 from backtest.utils.names import canonicalize_columns
 from utils.paths import resolve_path
 
-
 def _first_existing(*paths: Union[str, Path]) -> Optional[Path]:
     for p in paths:
         if not p:
@@ -26,7 +24,6 @@ def _first_existing(*paths: Union[str, Path]) -> Optional[Path]:
         if p_res.exists():
             return p_res
     return None
-
 
 def _guess_excel_dir_from_cfg(cfg: Any) -> Optional[Path]:
     if cfg is None:
@@ -49,7 +46,6 @@ def _guess_excel_dir_from_cfg(cfg: Any) -> Optional[Path]:
             return None
 
     return None
-
 
 COL_ALIASES: Dict[str, str] = {
     "date": "date",
@@ -82,10 +78,9 @@ COL_ALIASES: Dict[str, str] = {
     "kapanis_fiyat": "close",
 }
 
-
 def normalize_columns(df: pd.DataFrame, price_schema: Optional[Dict[str, Iterable[str] | str]] = None) -> pd.DataFrame:
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     mapping = COL_ALIASES.copy()
     if price_schema:
         for std, aliases in price_schema.items():
@@ -107,7 +102,6 @@ def normalize_columns(df: pd.DataFrame, price_schema: Optional[Dict[str, Iterabl
         seen[std] = c
     result = df.drop(columns=drops).rename(columns=rename_map)
     return result
-
 
 def validate_columns(df: pd.DataFrame, required: Iterable[str]) -> pd.DataFrame:
     """Ensure that ``df`` contains all columns in ``required``.
@@ -135,7 +129,6 @@ def validate_columns(df: pd.DataFrame, required: Iterable[str]) -> pd.DataFrame:
             f"Missing required columns: {', '.join(sorted(missing))}"
         )
     return df
-
 
 def apply_corporate_actions(
     df: pd.DataFrame, csv_path: Optional[Union[str, Path]] = None
@@ -190,7 +183,6 @@ def apply_corporate_actions(
     merged = merged.drop(columns=["cum_factor"])
     # benchmark note: vectorized version ~5x faster on 10k rows vs loop
     return merged
-
 
 def read_excels_long(
     cfg_or_path: Union[str, Path, Any],
@@ -359,6 +351,5 @@ def read_excels_long(
             logger.warning("Önbelleğe yazılamadı: {} -> {}", cache_path, e)
 
     return full
-
 
 __all__ = ["read_excels_long", "normalize_columns", "apply_corporate_actions", "validate_columns"]

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 from typing import Dict, List, Optional
@@ -10,7 +9,6 @@ import pandas as pd  # module-level; fonksiyon içi import yok
 from backtest.utils.names import canonicalize_columns
 
 logger = logging.getLogger(__name__)
-
 
 def _safe_alias(df2: pd.DataFrame, alias: str, base: str) -> bool:
     """Safely copy ``base`` column to ``alias`` without raising.
@@ -48,10 +46,8 @@ def _safe_alias(df2: pd.DataFrame, alias: str, base: str) -> bool:
     logger.warning("alias skipped (non-1d): alias=%s base=%s", alias, base)
     return False
 
-
 def _ema(series: pd.Series, length: int) -> pd.Series:
     return series.ewm(span=length, adjust=False).mean()
-
 
 def _rsi(series: pd.Series, length: int) -> pd.Series:
     delta = series.diff()
@@ -59,7 +55,6 @@ def _rsi(series: pd.Series, length: int) -> pd.Series:
     loss = -delta.clip(upper=0).ewm(alpha=1 / length, adjust=False).mean()
     rs = gain / loss
     return 100 - (100 / (1 + rs))
-
 
 def _stoch_rsi(
     series: pd.Series, rsi_len: int, stoch_len: int, k: int, d: int
@@ -72,7 +67,6 @@ def _stoch_rsi(
     k_line = stoch.rolling(k, min_periods=k).mean() * 100
     d_line = k_line.rolling(d, min_periods=d).mean()
     return k_line, d_line
-
 
 def compute_indicators(
     df: pd.DataFrame,
@@ -99,13 +93,13 @@ def compute_indicators(
         DataFrame containing the original data along with computed indicators.
     """
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     if params is not None and not isinstance(params, dict):
-        raise TypeError("params must be a dict or None")  # TİP DÜZELTİLDİ
+        raise TypeError("params must be a dict or None")
     if params is None:
-        params = {}  # TİP DÜZELTİLDİ
+        params = {}
     if df.empty:
-        return df.copy()  # TİP DÜZELTİLDİ
+        return df.copy()
     supported_engines = {"builtin", "pandas_ta"}
     if engine not in supported_engines:
         raise ValueError(f"Unsupported engine: {engine}")
@@ -146,7 +140,7 @@ def compute_indicators(
         g = g.copy()
         ema_params = params.get("ema", [10, 20, 50])
         if isinstance(ema_params, (int, float)):
-            ema_params = [ema_params]  # TİP DÜZELTİLDİ
+            ema_params = [ema_params]
         logger.debug("EMA params: %s", ema_params)
         for p in ema_params:
             p_int = int(p)
@@ -159,7 +153,7 @@ def compute_indicators(
                 g[col] = _ema(g["close"], p_int)
         rsi_params = params.get("rsi", [14])
         if isinstance(rsi_params, (int, float)):
-            rsi_params = [rsi_params]  # TİP DÜZELTİLDİ
+            rsi_params = [rsi_params]
         logger.debug("RSI params: %s", rsi_params)
         for p in rsi_params:
             p_int = int(p)
@@ -193,12 +187,12 @@ def compute_indicators(
         macd_params = params.get("macd", [])
         if macd_params:
             if isinstance(macd_params, (int, float)):
-                macd_params = [macd_params]  # TİP DÜZELTİLDİ
+                macd_params = [macd_params]
             macd_params = list(macd_params)
             if len(macd_params) < 3:
                 raise ValueError(
                     "macd params must have at least three values",
-                )  # TİP DÜZELTİLDİ
+                )
             fast, slow, sig = map(int, macd_params[:3])
             if fast <= 0 or slow <= 0 or sig <= 0:
                 raise ValueError("macd params must be positive")
@@ -280,7 +274,6 @@ def compute_indicators(
     logger.info("aliases added=%s skipped=%s", alias_added, alias_skipped)
     return df2
 
-
 def _ensure_adx_stochrsi(df):
     try:
         import pandas_ta as ta
@@ -316,7 +309,6 @@ def _ensure_adx_stochrsi(df):
         df["stochrsi_d_keser_stochrsi_k_yukari"] = up
         df["stochrsi_d_keser_stochrsi_k_asagi"] = down
     return df
-
 
 if "_compute_indicators_wrapped" not in globals():
     _orig_compute_indicators = compute_indicators

--- a/backtest/normalizer.py
+++ b/backtest/normalizer.py
@@ -1,16 +1,14 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 
-
 def normalize(df: pd.DataFrame) -> pd.DataFrame:
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     need = ["symbol", "date", "open", "high", "low", "close", "volume"]
     for n in need:
         if n not in df.columns:
-            raise ValueError(f"Eksik zorunlu kolon: {n}")  # TİP DÜZELTİLDİ
+            raise ValueError(f"Eksik zorunlu kolon: {n}")
     df = df.copy()
     df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
     df["date"] = pd.to_datetime(df["date"]).dt.normalize()

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -1,15 +1,13 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import warnings
-from datetime import date  # TİP DÜZELTİLDİ
+from datetime import date
 from pathlib import Path
-from typing import Iterable, Mapping, Optional  # TİP DÜZELTİLDİ
+from typing import Iterable, Mapping, Optional
 
 import pandas as pd
 
 from utils.paths import resolve_path
-
 
 def _ensure_dir(path: Optional[str | Path]):
     if not path:
@@ -18,10 +16,9 @@ def _ensure_dir(path: Optional[str | Path]):
     target = p if not p.suffix else p.parent
     target.mkdir(parents=True, exist_ok=True)
 
-
 def write_reports(
     trades_all: pd.DataFrame,
-    dates: Optional[Iterable] = None,  # TİP DÜZELTİLDİ
+    dates: Optional[Iterable] = None,
     summary_wide: Optional[pd.DataFrame] = None,
     xu100_pct: Optional[Mapping] = None,
     out_xlsx: Optional[str] = None,
@@ -46,7 +43,7 @@ def write_reports(
         ``csv`` for a list of CSV exports (if requested).
     """
     if not isinstance(trades_all, pd.DataFrame):
-        raise TypeError("trades_all must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("trades_all must be a DataFrame")
     req_cols = {
         "FilterCode",
         "Symbol",
@@ -60,45 +57,45 @@ def write_reports(
     if missing:
         raise ValueError(
             f"trades_all missing columns: {', '.join(sorted(missing))}"
-        )  # TİP DÜZELTİLDİ
+        )
     if "Reason" not in trades_all.columns:
         trades_all["Reason"] = pd.NA
     n_cols = trades_all.shape[1]
     if summary_wide is not None and not isinstance(summary_wide, pd.DataFrame):
-        raise TypeError("summary_wide must be a DataFrame or None")  # TİP DÜZELTİLDİ
+        raise TypeError("summary_wide must be a DataFrame or None")
     if summary_winrate is not None and not isinstance(summary_winrate, pd.DataFrame):
-        raise TypeError("summary_winrate must be a DataFrame or None")  # TİP DÜZELTİLDİ
+        raise TypeError("summary_winrate must be a DataFrame or None")
     if validation_summary is not None and not isinstance(
         validation_summary, pd.DataFrame
     ):
         raise TypeError(
             "validation_summary must be a DataFrame or None"
-        )  # TİP DÜZELTİLDİ
+        )
     if validation_issues is not None and not isinstance(
         validation_issues, pd.DataFrame
     ):
         raise TypeError(
             "validation_issues must be a DataFrame or None"
-        )  # TİP DÜZELTİLDİ
+        )
 
     if dates is None:
-        dates = tuple()  # TİP DÜZELTİLDİ
+        dates = tuple()
     elif isinstance(dates, (str, bytes, pd.Timestamp, date)):
-        dates = (dates,)  # TİP DÜZELTİLDİ
+        dates = (dates,)
     elif isinstance(dates, Iterable):
-        dates = tuple(dates)  # TİP DÜZELTİLDİ
+        dates = tuple(dates)
     else:
-        raise TypeError("dates must be iterable or date-like")  # TİP DÜZELTİLDİ
+        raise TypeError("dates must be iterable or date-like")
     outputs: dict[str, Path | list[Path]] = {}
     if summary_wide is None:
-        summary_wide = pd.DataFrame()  # TİP DÜZELTİLDİ
+        summary_wide = pd.DataFrame()
     if out_xlsx:
         out_xlsx_path = resolve_path(out_xlsx)
         _ensure_dir(out_xlsx_path)
         try:
             writer = pd.ExcelWriter(
                 out_xlsx_path, engine="xlsxwriter"
-            )  # PATH DÜZENLENDİ
+            )
         except Exception as exc:
             raise RuntimeError(f"Excel yazılamadı: {out_xlsx_path}") from exc
         else:
@@ -119,15 +116,15 @@ def write_reports(
 
                 if xu100_pct is not None:
                     if isinstance(xu100_pct, pd.Series):
-                        xu100_series = xu100_pct.astype(float)  # TİP DÜZELTİLDİ
+                        xu100_series = xu100_pct.astype(float)
                     elif isinstance(xu100_pct, Mapping):
                         xu100_series = pd.Series(
                             dict(xu100_pct), dtype=float
-                        )  # TİP DÜZELTİLDİ
+                        )
                     else:
                         raise TypeError(
                             "xu100_pct must be a mapping or Series"
-                        )  # TİP DÜZELTİLDİ
+                        )
                     cols = [
                         c
                         for c in summary_wide.columns
@@ -179,7 +176,7 @@ def write_reports(
                     ws.set_column(5, 5, 10, num_fmt)
                     ws.set_column(6, 6, 8)
                     rows = len(trades_all[trades_all["Date"] == day_ts])
-                    last_row = rows if rows > 0 else 0  # LOJİK HATASI DÜZELTİLDİ
+                    last_row = rows if rows > 0 else 0
                     ws.autofilter(0, 0, last_row, n_cols - 1)
 
                 if summary_sheet_name in writer.sheets:
@@ -217,17 +214,17 @@ def write_reports(
                 daily_csv,
                 index=False,
                 encoding="utf-8",
-            )  # PATH DÜZENLENDİ
+            )
             csv_paths.append(daily_csv)
             summary_csv = out_csv_path / "summary.csv"
-            summary_wide.to_csv(summary_csv, encoding="utf-8")  # PATH DÜZENLENDİ
+            summary_wide.to_csv(summary_csv, encoding="utf-8")
             csv_paths.append(summary_csv)
             if summary_winrate is not None and not summary_winrate.empty:
                 winrate_csv = out_csv_path / "summary_winrate.csv"
                 summary_winrate.to_csv(
                     winrate_csv,
                     encoding="utf-8",
-                )  # PATH DÜZENLENDİ
+                )
                 csv_paths.append(winrate_csv)
             if validation_summary is not None and not validation_summary.empty:
                 val_sum_csv = out_csv_path / "validation_summary.csv"
@@ -235,7 +232,7 @@ def write_reports(
                     val_sum_csv,
                     index=False,
                     encoding="utf-8",
-                )  # PATH DÜZENLENDİ
+                )
                 csv_paths.append(val_sum_csv)
             if validation_issues is not None and not validation_issues.empty:
                 val_iss_csv = out_csv_path / "validation_issues.csv"
@@ -243,10 +240,10 @@ def write_reports(
                     val_iss_csv,
                     index=False,
                     encoding="utf-8",
-                )  # PATH DÜZENLENDİ
+                )
                 csv_paths.append(val_iss_csv)
         except Exception:
-            warnings.warn(f"CSV yazılamadı: {out_csv_path}")  # PATH DÜZENLENDİ
+            warnings.warn(f"CSV yazılamadı: {out_csv_path}")
         else:
             missing = [p for p in csv_paths if not p.exists()]
             if missing:

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import re
@@ -9,13 +8,11 @@ from loguru import logger
 
 from backtest.query_parser import SafeQuery
 
-
 def _to_pandas_ops(expr: str) -> str:
     expr = re.sub(r"\bAND\b", "&", expr, flags=re.I)
     expr = re.sub(r"\bOR\b", "|", expr, flags=re.I)
     expr = re.sub(r"\bNOT\b", "~", expr, flags=re.I)
     return expr
-
 
 def run_screener(
     df_ind: pd.DataFrame,

--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -1,10 +1,9 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import re
 import unicodedata
 from pathlib import Path
-from typing import Optional  # TİP DÜZELTİLDİ
+from typing import Optional
 
 from loguru import logger
 
@@ -16,18 +15,15 @@ from .names import (
     set_name_normalization,
 )
 
-
 def ensure_dir(path: str | Path):
     p = resolve_path(path)
     target = p if not p.suffix else p.parent
     target.mkdir(parents=True, exist_ok=True)
 
-
 def info(msg: str):
     logger.info(msg)
 
-
-def normalize_key(s: Optional[str]) -> str:  # TİP DÜZELTİLDİ
+def normalize_key(s: Optional[str]) -> str:
     if s is None:
         return ""
     s = str(s).strip()
@@ -54,7 +50,6 @@ def normalize_key(s: Optional[str]) -> str:  # TİP DÜZELTİLDİ
     s = s.lower()
     s = re.sub(r"[^a-z0-9]+", "_", s)
     return s.strip("_")
-
 
 __all__ = [
     "ensure_dir",

--- a/backtest/validator.py
+++ b/backtest/validator.py
@@ -1,20 +1,18 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
-
 
 def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:
     """Return simple stats per symbol: first/last date, rows, NA close
     count, dup count."""
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     req = {"symbol", "date", "close"}
     missing = req.difference(df.columns)
     if missing:
         raise ValueError(
             f"Eksik kolon(lar): {', '.join(sorted(missing))}"
-        )  # TİP DÜZELTİLDİ
+        )
     if df.empty:
         return pd.DataFrame(
             columns=[
@@ -36,18 +34,17 @@ def dataset_summary(df: pd.DataFrame) -> pd.DataFrame:
     out["dup_symbol_date"] = out["symbol"].map(dup).fillna(0).astype(int)
     return out.sort_values("symbol").reset_index(drop=True)
 
-
 def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
     """Return row-level issues for quick inspection (date order, negative
     prices, etc.)."""
     if not isinstance(df, pd.DataFrame):
-        raise TypeError("df must be a DataFrame")  # TİP DÜZELTİLDİ
+        raise TypeError("df must be a DataFrame")
     req = {"symbol", "date", "close"}
     missing = req.difference(df.columns)
     if missing:
         raise ValueError(
             f"Eksik kolon(lar): {', '.join(sorted(missing))}"
-        )  # TİP DÜZELTİLDİ
+        )
     issues = []
     if df.empty:
         return pd.DataFrame(columns=["symbol", "date", "issue", "value"])
@@ -118,7 +115,7 @@ def quality_warnings(df: pd.DataFrame) -> pd.DataFrame:
     if not issues:
         return pd.DataFrame(
             columns=["symbol", "date", "issue", "value"]
-        )  # TİP DÜZELTİLDİ
+        )
     return pd.DataFrame(
         issues, columns=["symbol", "date", "issue", "value"]
-    )  # TİP DÜZELTİLDİ
+    )

--- a/io_filters.py
+++ b/io_filters.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Helpers for reading filter CSV files.
 
 Filter definition files are expected to contain ``FilterCode`` and
@@ -14,7 +13,6 @@ import pandas as pd
 from utils.paths import resolve_path
 
 REQUIRED_COLUMNS = {"FilterCode", "PythonQuery"}
-
 
 def load_filters_csv(path: str | Path) -> pd.DataFrame:
     """Load filters from CSV with validation and basic normalization.
@@ -59,6 +57,5 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
         dup_codes = ", ".join(sorted(dups.unique()))
         raise RuntimeError(f"Duplicate FilterCode detected: {dup_codes}")
     return df
-
 
 __all__ = ["load_filters_csv"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import sys

--- a/tests/test_backtest_imports.py
+++ b/tests/test_backtest_imports.py
@@ -1,11 +1,9 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import importlib
 import pkgutil
 
 import backtest
-
 
 def test_backtest_all_modules_importable():
     for module_info in pkgutil.iter_modules(backtest.__path__):

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,11 +1,9 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 import pytest
 
 from backtest.backtester import run_1g_returns
-
 
 def test_backtester_basic():
     df = pd.DataFrame(
@@ -27,7 +25,6 @@ def test_backtester_basic():
     assert out["Reason"].isna().all()
     assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == 10.0
 
-
 def test_run_1g_returns_drops_duplicates():
     df = pd.DataFrame(
         {
@@ -47,7 +44,6 @@ def test_run_1g_returns_drops_duplicates():
     assert len(out) == 1
     assert "Reason" in out.columns
 
-
 def test_run_1g_returns_holding_period_and_cost():
     df = pd.DataFrame(
         {
@@ -66,7 +62,6 @@ def test_run_1g_returns_holding_period_and_cost():
     out = run_1g_returns(df, sigs, holding_period=2, transaction_cost=1.0)
     expected = ((12.0 / 10.0 - 1.0) * 100.0) - 1.0
     assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == expected
-
 
 def test_run_1g_returns_marks_exit_date_out_of_bounds():
     df = pd.DataFrame(
@@ -88,7 +83,6 @@ def test_run_1g_returns_marks_exit_date_out_of_bounds():
     assert out.loc[0, "Reason"] == "Invalid ExitClose"
     assert pd.isna(out.loc[0, "ReturnPct"])
 
-
 def test_run_1g_returns_ignores_out_of_bounds_signals():
     df = pd.DataFrame(
         {
@@ -107,7 +101,6 @@ def test_run_1g_returns_ignores_out_of_bounds_signals():
     out = run_1g_returns(df, sigs)
     assert len(out) == 2
     assert pd.isna(out.loc[out["Date"] == pd.Timestamp("2024-01-03"), "ReturnPct"]).all()
-
 
 def test_run_1g_returns_side_validation():
     df = pd.DataFrame(
@@ -133,7 +126,6 @@ def test_run_1g_returns_side_validation():
     out_bad = run_1g_returns(df, sigs_bad)
     assert out_bad.loc[0, "Reason"] == "Invalid Side"
     assert pd.isna(out_bad.loc[0, "ReturnPct"])
-
 
 def test_run_1g_returns_fills_missing_side_with_long():
     df = pd.DataFrame(
@@ -192,7 +184,6 @@ def test_run_1g_returns_fills_missing_exit_data():
     assert out2.loc[0, "ExitClose"] == 12.0
     assert pytest.approx(out2.loc[0, "ReturnPct"], 0.01) == 20.0
 
-
 def test_run_1g_returns_multiday_price_mode():
     df = pd.DataFrame(
         {
@@ -212,7 +203,6 @@ def test_run_1g_returns_multiday_price_mode():
     assert out.loc[0, "ExitClose"] == 13.0
     assert out["Reason"].isna().all()
     assert pytest.approx(out.loc[0, "ReturnPct"], 0.01) == 30.0
-
 
 def test_run_1g_returns_empty_base_returns_empty(caplog):
     from loguru import logger

--- a/tests/test_backtester_validation.py
+++ b/tests/test_backtester_validation.py
@@ -1,9 +1,7 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
 from backtest.backtester import run_1g_returns
-
 
 def _base_df():
     return pd.DataFrame(
@@ -16,7 +14,6 @@ def _base_df():
         }
     )
 
-
 def _signals_df():
     return pd.DataFrame(
         {
@@ -26,13 +23,11 @@ def _signals_df():
         }
     )
 
-
 def test_run_1g_returns_type_validation():
     with pytest.raises(TypeError):
         run_1g_returns([], pd.DataFrame())  # type: ignore[arg-type]
     with pytest.raises(TypeError):
         run_1g_returns(_base_df(), [])  # type: ignore[arg-type]
-
 
 def test_run_1g_returns_missing_columns():
     bad_df = pd.DataFrame({"symbol": ["AAA"]})
@@ -42,13 +37,11 @@ def test_run_1g_returns_missing_columns():
     with pytest.raises(ValueError):
         run_1g_returns(_base_df(), bad_sig)
 
-
 def test_run_1g_returns_empty_signals():
     out = run_1g_returns(
         _base_df(), pd.DataFrame(columns=["FilterCode", "Symbol", "Date"])
     )
     assert out.empty
-
 
 def test_run_1g_returns_logs_empty_signals(caplog):
     from loguru import logger
@@ -60,7 +53,6 @@ def test_run_1g_returns_logs_empty_signals(caplog):
     assert out.empty
     assert "signals DataFrame is empty" in caplog.text
 
-
 def test_run_1g_returns_logs_missing_base_columns(caplog):
     from loguru import logger
 
@@ -71,7 +63,6 @@ def test_run_1g_returns_logs_missing_base_columns(caplog):
     assert caplog.records[0].levelname == "ERROR"
     assert "Eksik kolon(lar): close" in caplog.text
 
-
 def test_run_1g_returns_logs_missing_signal_columns(caplog):
     from loguru import logger
 
@@ -81,7 +72,6 @@ def test_run_1g_returns_logs_missing_signal_columns(caplog):
         run_1g_returns(_base_df(), bad_sig)
     assert caplog.records[0].levelname == "ERROR"
     assert "Eksik kolon(lar): Date" in caplog.text
-
 
 def test_run_1g_returns_negative_transaction_cost():
     with pytest.raises(ValueError):

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
@@ -11,7 +10,6 @@ from backtest.calendars import (
     build_trading_days,
     check_missing_trading_days,
 )
-
 
 def test_next_close():
     df = pd.DataFrame(
@@ -30,13 +28,11 @@ def test_next_close():
     assert out.loc[0, "next_close"] == 11
     assert pd.isna(out.loc[2, "next_close"])
 
-
 def test_build_trading_days_single_holiday():
     df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).normalize()})
     tdays = build_trading_days(df, pd.Timestamp("2024-01-02"))
     assert pd.Timestamp("2024-01-02") not in tdays
     assert isinstance(tdays[0], pd.Timestamp)
-
 
 def test_add_next_close_calendar():
     df = pd.DataFrame(
@@ -53,7 +49,6 @@ def test_add_next_close_calendar():
     assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-02")
     assert isinstance(out.loc[0, "next_date"], pd.Timestamp)
 
-
 def test_add_next_close_calendar_skips_weekend():
     df = pd.DataFrame(
         {
@@ -67,12 +62,10 @@ def test_add_next_close_calendar_skips_weekend():
     assert out.loc[0, "next_date"] == pd.Timestamp("2024-01-08")
     assert out.loc[0, "next_close"] == 11.0
 
-
 def test_check_missing_trading_days_raise():
     df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).normalize()})
     with pytest.raises(ValueError):
         check_missing_trading_days(df)
-
 
 def test_check_missing_trading_days_warn():
     df = pd.DataFrame({"date": pd.to_datetime(["2024-01-01", "2024-01-03"]).normalize()})

--- a/tests/test_calendars_validation.py
+++ b/tests/test_calendars_validation.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
@@ -9,14 +8,12 @@ from backtest.calendars import (
     load_holidays_csv,
 )
 
-
 def test_add_next_close_invalid_inputs():
     with pytest.raises(TypeError):
         add_next_close([])
     df_missing = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")]})
     with pytest.raises(ValueError):
         add_next_close(df_missing)
-
 
 def test_add_next_close_calendar_invalid_inputs():
     df = pd.DataFrame(
@@ -29,12 +26,10 @@ def test_add_next_close_calendar_invalid_inputs():
     with pytest.raises(ValueError):
         add_next_close_calendar(df.drop(columns=["close"]), pd.DatetimeIndex([]))
 
-
 def test_build_trading_days_invalid_holidays():
     df = pd.DataFrame({"symbol": ["A"], "date": [pd.Timestamp("2020-01-01")]})
     with pytest.raises(TypeError):
         build_trading_days(df, holidays=123)
-
 
 def test_load_holidays_csv_validation(tmp_path):
     with pytest.raises(TypeError):

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -8,7 +7,6 @@ import pytest
 
 import click
 from backtest import cli
-
 
 def _cfg():
     return SimpleNamespace(
@@ -32,7 +30,6 @@ def _cfg():
             percent_format="0.00%",
         ),
     )
-
 
 def test_scan_range_empty(monkeypatch):
     cfg = _cfg()
@@ -90,7 +87,6 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(cli, "info", lambda msg: None)
     cli.scan_range.callback("cfg.yml", None, None, None, None)
 
-
 def test_scan_day_empty(monkeypatch):
     cfg = _cfg()
     monkeypatch.setattr(cli, "load_config", lambda _: cfg)
@@ -146,7 +142,6 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "info", lambda msg: None)
     cli.scan_day.callback("cfg.yml", "2024-01-02", None, None)
-
 
 def test_scan_range_missing_excel(monkeypatch):
     cfg = _cfg()

--- a/tests/test_config_missing.py
+++ b/tests/test_config_missing.py
@@ -1,8 +1,6 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pytest
 
 from backtest.config import load_config
-
 
 def test_load_config_missing_file(tmp_path):
     missing = tmp_path / "nonexistent.yml"

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from pathlib import Path
 import tempfile
 import textwrap
@@ -7,15 +6,13 @@ import pytest
 
 from backtest.config import load_config
 
-
 def _write_cfg(text: str) -> Path:
     with tempfile.NamedTemporaryFile(
         "w", delete=False, encoding="utf-8"
-    ) as tmp:  # PATH DÜZENLENDİ
+    ) as tmp:
         tmp.write(text)
         tmp.flush()
         return Path(tmp.name)
-
 
 def test_load_config_independent_defaults():
     cfg_text = textwrap.dedent(
@@ -38,12 +35,10 @@ def test_load_config_independent_defaults():
     assert cfg2.calendar.holidays_source == "none"
     assert 99 not in cfg2.indicators.params["ema"]
 
-
 def test_load_config_invalid_yaml():
     path = _write_cfg("- just\n- a\n- list\n")
     with pytest.raises(TypeError):
         load_config(path)
-
 
 def test_load_config_relative_paths(tmp_path):
     cfg_text = textwrap.dedent(
@@ -59,8 +54,8 @@ def test_load_config_relative_paths(tmp_path):
           xu100_csv_path: xu.csv
         """
     )
-    cfg_file = tmp_path / "cfg.yaml"  # PATH DÜZENLENDİ
-    cfg_file.write_text(cfg_text, encoding="utf-8")  # PATH DÜZENLENDİ
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(cfg_text, encoding="utf-8")
     cfg = load_config(cfg_file)
     base = cfg_file.parent
     cwd = Path.cwd()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
@@ -6,14 +5,12 @@ from backtest.normalizer import normalize
 from backtest.screener import run_screener
 from backtest.validator import quality_warnings
 
-
 def test_normalize_type_and_missing_columns():
     with pytest.raises(TypeError):
         normalize([])  # not a DataFrame
     df_missing = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
     with pytest.raises(ValueError):
         normalize(df_missing)
-
 
 def test_quality_warnings_no_issues():
     df = pd.DataFrame(
@@ -28,7 +25,6 @@ def test_quality_warnings_no_issues():
     assert list(res.columns) == ["symbol", "date", "issue", "value"]
     assert res.empty
 
-
 def test_run_screener_no_hits():
     df_ind = pd.DataFrame(
         {
@@ -40,7 +36,7 @@ def test_run_screener_no_hits():
             "close": [1.0],
             "volume": [100],
         }
-    )  # TİP DÜZELTİLDİ
+    )
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 2"]})
     res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert isinstance(df_ind.loc[0, "date"], pd.Timestamp)

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,11 +1,9 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
 
 from backtest.backtester import run_1g_returns
 from backtest.screener import run_screener
-
 
 def test_pipeline_smoke():
     df = pd.DataFrame(
@@ -33,7 +31,6 @@ def test_pipeline_smoke():
     out = run_1g_returns(df, sigs)
     assert not out.empty
     assert isinstance(out.loc[0, "Date"], pd.Timestamp)
-
 
 def test_pipeline_no_signals():
     df = pd.DataFrame(

--- a/tests/test_screener_indicators_validation.py
+++ b/tests/test_screener_indicators_validation.py
@@ -1,10 +1,8 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 import pandas as pd
 import pytest
 
 from backtest.indicators import compute_indicators
 from backtest.screener import run_screener
-
 
 def test_compute_indicators_invalid_inputs():
     with pytest.raises(TypeError):
@@ -12,7 +10,6 @@ def test_compute_indicators_invalid_inputs():
     df = pd.DataFrame()
     with pytest.raises(TypeError):
         compute_indicators(df, params=[])
-
 
 def test_run_screener_invalid_inputs():
     filters_df = pd.DataFrame({"FilterCode": [], "PythonQuery": []})
@@ -40,7 +37,6 @@ def test_run_screener_invalid_inputs():
     with pytest.raises(ValueError):
         run_screener(df_ok, bad_filters, pd.Timestamp("2024-01-02"))
 
-
 def test_run_screener_empty_dataset_logs(caplog):
     from loguru import logger
 
@@ -52,7 +48,6 @@ def test_run_screener_empty_dataset_logs(caplog):
     with pytest.raises(ValueError):
         run_screener(df_empty, filters_df, pd.Timestamp("2024-01-02"))
     assert "df_ind is empty" in caplog.text
-
 
 def test_run_screener_empty_filters_logs(caplog):
     from loguru import logger
@@ -74,7 +69,6 @@ def test_run_screener_empty_filters_logs(caplog):
         run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert "filters_df is empty" in caplog.text
 
-
 def test_run_screener_logs_missing_df_columns(caplog):
     from loguru import logger
 
@@ -94,7 +88,6 @@ def test_run_screener_logs_missing_df_columns(caplog):
         run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert caplog.records[0].levelname == "ERROR"
     assert "df_ind missing columns: close" in caplog.text
-
 
 def test_run_screener_logs_missing_filters_columns(caplog):
     from loguru import logger
@@ -117,7 +110,6 @@ def test_run_screener_logs_missing_filters_columns(caplog):
     assert caplog.records[0].levelname == "ERROR"
     assert "filters_df missing required columns" in caplog.text
 
-
 def test_run_screener_outputs_timestamp_dates():
     df_ind = pd.DataFrame(
         {
@@ -133,7 +125,6 @@ def test_run_screener_outputs_timestamp_dates():
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > 0"]})
     res = run_screener(df_ind, filters_df, pd.Timestamp("2024-01-02"))
     assert isinstance(res.loc[0, "Date"], pd.Timestamp)
-
 
 def test_run_screener_side_validation():
     df_ind = pd.DataFrame(
@@ -160,7 +151,6 @@ def test_run_screener_side_validation():
     bad["Side"] = ["foo"]
     with pytest.raises(ValueError):
         run_screener(df_ind, bad, pd.Timestamp("2024-01-02"))
-
 
 def test_run_screener_duplicate_filter_code():
     df_ind = pd.DataFrame(

--- a/tests/test_summary_diff.py
+++ b/tests/test_summary_diff.py
@@ -1,8 +1,6 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
-
 
 def test_summary_and_winrate():
     trades = pd.DataFrame(

--- a/tests/test_utils_normalize_key.py
+++ b/tests/test_utils_normalize_key.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from __future__ import annotations
 
 import pandas as pd
@@ -7,16 +6,13 @@ import warnings
 from backtest.utils import normalize_key
 from backtest.data_loader import normalize_columns
 
-
 def test_normalize_key_basic():
     assert normalize_key("İşlem Hacmi") == "islem_hacmi"
-
 
 def test_normalize_columns_uses_common_normalize_key():
     df = pd.DataFrame({"Kapanış": [1], "İşlem Hacmi": [100]})
     normalized = normalize_columns(df)
     assert set(normalized.columns) == {"close", "volume"}
-
 
 def test_normalize_columns_drops_duplicate_aliases_without_warning():
     df = pd.DataFrame(

--- a/tests/test_validator_extra.py
+++ b/tests/test_validator_extra.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 from types import SimpleNamespace
 
 import pandas as pd
@@ -7,23 +6,19 @@ import pytest
 from backtest.reporter import write_reports
 from backtest.validator import dataset_summary, quality_warnings
 
-
 def test_dataset_summary_invalid_type():
     with pytest.raises(TypeError):
         dataset_summary([])  # not a DataFrame
-
 
 def test_dataset_summary_missing_columns():
     df = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
     with pytest.raises(ValueError):
         dataset_summary(df)
 
-
 def test_quality_warnings_missing_columns():
     df = pd.DataFrame({"symbol": ["AAA"], "close": [1.0]})
     with pytest.raises(ValueError):
         quality_warnings(df)
-
 
 def test_quality_warnings_extra_checks():
     df = pd.DataFrame(
@@ -53,7 +48,6 @@ def test_quality_warnings_extra_checks():
         "na_close",
     }
 
-
 class _DummyWriter:
     def __init__(self, *args, **kwargs):
         self.book = SimpleNamespace(add_format=lambda *a, **k: None)
@@ -64,7 +58,6 @@ class _DummyWriter:
 
     def __exit__(self, _exc_type, _exc, _tb):
         return False
-
 
 def test_write_reports_xu100_pct_type(monkeypatch):
     monkeypatch.setattr(pd, "ExcelWriter", _DummyWriter)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Utility package for shared helpers."""
 
 from .paths import resolve_path

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,4 +1,3 @@
-# DÜZENLENDİ – SYNTAX TEMİZLİĞİ
 """Path utilities."""
 
 from __future__ import annotations
@@ -6,7 +5,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Union
-
 
 def resolve_path(path: Union[str, os.PathLike]) -> Path:
     """Expand user home (``~``) and environment variables safely.
@@ -29,6 +27,5 @@ def resolve_path(path: Union[str, os.PathLike]) -> Path:
     expanded = os.path.expandvars(str(path))
     expanded = os.path.expanduser(expanded)
     return Path(expanded).resolve()
-
 
 __all__ = ["resolve_path"]


### PR DESCRIPTION
## Summary
- strip residual clean-up markers from code and tests
- tidy module headers for clearer source files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cceb02eec83258d0d5fd06e3ff681