### PR TITLE
Make optional pandas_ta import in tests

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,9 @@
 def test_imports():
-    import numpy as np, pandas as pd, pandas_ta as ta  # noqa
+    import numpy as np  # noqa: F401
+    import pandas as pd  # noqa: F401
+    try:
+        import pandas_ta  # noqa: F401
+    except ModuleNotFoundError:
+        pass
     import backtest  # noqa: F401
-    from backtest import indicators, screener, data_loader  # noqa
+    from backtest import indicators, screener, data_loader  # noqa: F401


### PR DESCRIPTION
## Summary
- avoid failing tests when optional dependency `pandas_ta` is missing

## Testing
- `flake8 tests/test_imports.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd2efcf5c83259e9e94a0d7c7266f