### PR TITLE
Remove unused ensure_dir helper

### DIFF
--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from pathlib import Path
 from typing import Optional
 
 from loguru import logger
 
-from utils.paths import resolve_path
 from .names import (
     canonical_name,
     canonicalize_columns,
@@ -15,10 +13,6 @@ from .names import (
     set_name_normalization,
 )
 
-def ensure_dir(path: str | Path):
-    p = resolve_path(path)
-    target = p if not p.suffix else p.parent
-    target.mkdir(parents=True, exist_ok=True)
 
 def info(msg: str):
     logger.info(msg)
@@ -51,8 +45,8 @@ def normalize_key(s: Optional[str]) -> str:
     s = re.sub(r"[^a-z0-9]+", "_", s)
     return s.strip("_")
 
+
 __all__ = [
-    "ensure_dir",
     "info",
     "normalize_key",
     "canonical_name",


### PR DESCRIPTION
## Summary
- drop unused `ensure_dir` helper from utils
- simplify utils imports and exports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd4a297308325bb4499204278443b