### PR TITLE
refactor: drop unused info wrapper

### DIFF
--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -4,18 +4,12 @@ import re
 import unicodedata
 from typing import Optional
 
-from loguru import logger
-
 from .names import (
     canonical_name,
     canonicalize_columns,
     canonicalize_filter_token,
     set_name_normalization,
 )
-
-
-def info(msg: str):
-    logger.info(msg)
 
 def normalize_key(s: Optional[str]) -> str:
     if s is None:
@@ -47,7 +41,6 @@ def normalize_key(s: Optional[str]) -> str:
 
 
 __all__ = [
-    "info",
     "normalize_key",
     "canonical_name",
     "canonicalize_columns",


### PR DESCRIPTION
## Summary
- remove unused `info` logging helper from utils
- call `logger.info` directly in CLI with a minimal compatibility alias

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd67baaa883259713fc40bedac634