### PR TITLE
Remove unused CLI info wrapper

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -28,11 +28,6 @@ from .validator import dataset_summary, quality_warnings
 def cli():
     pass
 
-
-def info(msg: str) -> None:  # pragma: no cover - compatibility wrapper
-    """Compatibility wrapper for legacy utils.info."""
-    logger.info(msg)
-
 def _run_scan(cfg) -> None:
     """Common execution for scan commands.
 

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -84,7 +84,6 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(cli, "write_reports", lambda *args, **kwargs: {})
     monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
-    monkeypatch.setattr(cli, "info", lambda msg: None)
     cli.scan_range.callback("cfg.yml", None, None, None, None)
 
 def test_scan_day_empty(monkeypatch):
@@ -140,7 +139,6 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(cli, "write_reports", lambda *args, **kwargs: {})
     monkeypatch.setattr(cli, "dataset_summary", lambda df: pd.DataFrame())
     monkeypatch.setattr(cli, "quality_warnings", lambda df: pd.DataFrame())
-    monkeypatch.setattr(cli, "info", lambda msg: None)
     cli.scan_day.callback("cfg.yml", "2024-01-02", None, None)
 
 def test_scan_range_missing_excel(monkeypatch):


### PR DESCRIPTION
## Summary
- drop obsolete `info` compatibility helper from CLI
- adjust CLI tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd96b6d5c83258b7c84756819a43b