### PR TITLE
chore: remove unused utils re-exports

### DIFF
--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -4,12 +4,7 @@ import re
 import unicodedata
 from typing import Optional
 
-from .names import (
-    canonical_name,
-    canonicalize_columns,
-    canonicalize_filter_token,
-    set_name_normalization,
-)
+from .names import set_name_normalization
 
 def normalize_key(s: Optional[str]) -> str:
     if s is None:
@@ -42,8 +37,5 @@ def normalize_key(s: Optional[str]) -> str:
 
 __all__ = [
     "normalize_key",
-    "canonical_name",
-    "canonicalize_columns",
-    "canonicalize_filter_token",
     "set_name_normalization",
 ]


### PR DESCRIPTION
## Summary
- drop unused canonicalization helpers from `backtest.utils`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce6d5f434832583b07805bda54b8a