### PR TITLE
refactor: drop unused utils re-export

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -21,7 +21,7 @@ from .indicators import compute_indicators
 from .normalizer import normalize
 from .reporter import write_reports
 from .screener import run_screener
-from .utils import set_name_normalization
+from .utils.names import set_name_normalization
 from .validator import dataset_summary, quality_warnings
 
 @click.group()

--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -4,8 +4,6 @@ import re
 import unicodedata
 from typing import Optional
 
-from .names import set_name_normalization
-
 def normalize_key(s: Optional[str]) -> str:
     if s is None:
         return ""
@@ -35,7 +33,4 @@ def normalize_key(s: Optional[str]) -> str:
     return s.strip("_")
 
 
-__all__ = [
-    "normalize_key",
-    "set_name_normalization",
-]
+__all__ = ["normalize_key"]


### PR DESCRIPTION
## Summary
- remove unused `set_name_normalization` re-export from utils
- import `set_name_normalization` directly from `backtest.utils.names`

## Testing
- `pytest`
- `flake8` *(fails: many E302/E501 warnings across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689ce887b0588325ab9836888bed3526