### PR TITLE
Fix SafeQuery not operator handling

### DIFF
--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -26,7 +26,7 @@ class SafeQuery:
     """
 
     # characters permitted inside a query expression
-    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.%[], '") | set(
+    _ALLOWED_CHARS: Set[str] = set("()&|><=+-/*.%[], '~") | set(
         string.ascii_letters + string.digits + "_\""
     )
     _ALLOWED_FUNCS: Set[str] = {

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -10,6 +10,14 @@ def test_safequery_basic():
     assert q.is_safe
 
 
+def test_safequery_supports_not_operator():
+    df = pd.DataFrame({"close": [1, -1]})
+    q = SafeQuery("not (close > 0)")
+    assert q.is_safe
+    out = q.filter(df)
+    assert out["close"].tolist() == [-1]
+
+
 def test_safequery_rejects_calls_and_attributes():
     assert not SafeQuery("__import__('os').system('echo 1')").is_safe
     assert not SafeQuery("df.__class__").is_safe


### PR DESCRIPTION
## Summary
- allow `SafeQuery` to process the `not` operator by permitting `~` in allowed characters
- add regression test for `not` operator support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf3d674cc83259b9653b2cd0e146f