### PR TITLE
chore: remove unused imports

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,9 +1,12 @@
 def test_imports():
-    import numpy as np  # noqa: F401
-    import pandas as pd  # noqa: F401
+    import numpy as np
+    import pandas as pd
     try:
-        import pandas_ta  # noqa: F401
+        import pandas_ta
     except ModuleNotFoundError:
-        pass
-    import backtest  # noqa: F401
-    from backtest import indicators, screener, data_loader  # noqa: F401
+        pandas_ta = None
+    import backtest
+    from backtest import indicators, screener, data_loader
+    assert np and pd and backtest and indicators and screener and data_loader
+    if pandas_ta:
+        assert pandas_ta

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -20,5 +20,6 @@ def test_alias_cases():
 
 
 def test_imports():
-    import backtest  # noqa: F401
-    from backtest.utils import names  # noqa: F401
+    import backtest
+    from backtest.utils import names
+    assert backtest and names


### PR DESCRIPTION
## Summary
- avoid unused imports in tests by asserting modules are loaded

## Testing
- `pyflakes .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf5644b3c83258a6776441d71488b