### PR TITLE
doc: note removal of spacy/fastai deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Python 3.10–3.12 sürümleri desteklenir; 3.13 henüz destek dışıdır.
 
 Excel dosyalarını okuyup yazmak için gerekli `openpyxl` ve `XlsxWriter` paketleri de bu gereksinimlerle kurulur.
 
+Spacy, fastai ve fastdownload bağımlılıkları kaldırılmış olup kurulmasına gerek yoktur.
+
 ```bash
 python -m backtest.cli scan-day --config examples/example_config.yaml --date 2024-01-02
 ```
@@ -174,6 +176,7 @@ pytest -q
 5. **Raporlama:** Çıktıları `backtest.reporter.write_reports` veya `backtest.report.write_report` aracılığıyla Excel/CSV olarak kaydedin.
 
 ## Sürüm Notları
+- 1.2.0: spacy, fastai ve fastdownload bağımlılıkları kaldırıldı.
 - 1.1.0: Colab desteği ve yeni README.
 - 1.0.0: İlk yayımlanan sürüm.
 

--- a/README_COLAB.md
+++ b/README_COLAB.md
@@ -20,6 +20,7 @@ Aşağıdaki hücre Colab ortamında projeyi kurar ve örnek bir tarama çalış
 ```
 
 > Excel okuma/yazma için gerekli `openpyxl` ve `XlsxWriter` paketleri `requirements_colab.txt` içinde yer alır.
+> Spacy, fastai ve fastdownload bağımlılıkları kaldırılmıştır.
 
 ## İsim normalizasyonu
 


### PR DESCRIPTION
## Summary
- document that spacy, fastai and fastdownload dependencies were dropped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d0b2cf1bc83259a02673adf0418dc