### PR TITLE
Gracefully handle missing pandas_ta

### DIFF
--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -48,3 +48,19 @@ def test_duplicate_columns_dropped(caplog):
         res = compute_indicators(df, params={}, engine="builtin")
     assert res.columns.tolist().count("change_1d_percent") == 1
     assert "duplicate columns dropped" in caplog.text
+
+
+def test_pandas_ta_missing(monkeypatch, caplog):
+    df = pd.DataFrame(
+        {
+            "symbol": ["AAA"] * 3,
+            "date": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "close": [1, 2, 3],
+            "volume": [1, 2, 3],
+        }
+    )
+    monkeypatch.setattr("backtest.indicators.ta", None, raising=False)
+    with caplog.at_level(logging.WARNING, logger="backtest.indicators"):
+        res = compute_indicators(df, params={}, engine="pandas_ta")
+    assert "pandas_ta bulunamadı" in caplog.text
+    assert "EMA_10" in res.columns

--- a/tests/test_indicators_engine.py
+++ b/tests/test_indicators_engine.py
@@ -48,6 +48,7 @@ def test_pandas_ta_fallback(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr("backtest.indicators.ta", None, raising=False)
     df = _sample_df()
     res = compute_indicators(df, params={}, engine="pandas_ta")
     res2 = compute_indicators(df, params={}, engine="builtin")


### PR DESCRIPTION
## Summary
- make `pandas_ta` import optional and add `engine="none"` shortcut
- warn and fall back to builtin indicators when `pandas_ta` is unavailable
- test indicator computation without `pandas_ta`

## Testing
- `pre-commit run --files backtest/indicators.py tests/test_indicators.py`
- `pytest tests/test_indicators.py`


------
https://chatgpt.com/codex/tasks/task_e_689d0d0864108325b9e181ee0f00afec