### PR TITLE
Add NumPy version guard to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,10 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel -c constraints.txt
           pip install -r requirements_dev.txt -c constraints.txt --only-binary=:all: --no-binary=pandas-ta
+      - name: Verify environment
+        run: python tools/verify_env.py
       - name: Show versions
         run: pip freeze | grep -Ei 'pandas(-ta)?|numpy|pandera|PyYAML' || true
       - name: Run tests

--- a/tools/verify_env.py
+++ b/tools/verify_env.py
@@ -1,0 +1,5 @@
+import sys
+import numpy as np
+
+if int(np.__version__.split(".")[0]) >= 2:
+    sys.exit("NumPy >= 2.0 detected, aborting.")


### PR DESCRIPTION
## Summary
- add NumPy version verification script
- enforce constraints.txt during dependency installation in CI

## Testing
- `pre-commit run --files .github/workflows/tests.yml tools/verify_env.py`
- `python tools/verify_env.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d122d24388325a35536c19ae67f4a