### PR TITLE
Add environment verification step

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ pip install -r requirements.txt -c constraints.txt --only-binary=:all: --no-bina
 pip install -r requirements_dev.txt -c constraints.txt --only-binary=:all: --no-binary=pandas-ta  # test/geliştirici ortamı
 ```
 
+#### Ortam Doğrulama
+
+```python
+!python tools/verify_env.py
+```
+
 Python 3.10–3.12 sürümleri desteklenir; 3.13 henüz destek dışıdır.
 
 Excel dosyalarını okuyup yazmak için gerekli `openpyxl` ve `XlsxWriter` paketleri de bu gereksinimlerle kurulur.
@@ -65,6 +71,7 @@ python -m backtest.cli scan-day --config examples/example_config.yaml --date 202
 !pip install -q -r requirements_colab.txt -c constraints.txt --only-binary=:all: --no-binary=pandas-ta
 # Uygun wheel bulunamazsa veya pandas_ta uyumsuzluğu olursa:
 !pip install "numpy<2.0" "pandas<2.2" pandas-ta==0.3.14b0
+!python tools/verify_env.py
 !python -m backtest.cli scan-day --config config/colab_config.yaml --date 2024-01-02
 ```
 

--- a/README_COLAB.md
+++ b/README_COLAB.md
@@ -1,6 +1,6 @@
 # Google Colab Hızlı Başlangıç
 
-Aşağıdaki hücre Colab ortamında projeyi kurar ve örnek bir tarama çalıştırır:
+Aşağıdaki hücreler Colab ortamında projeyi kurar, ortamı doğrular ve örnek bir tarama çalıştırır:
 
 ```python
 # pip kurulumu
@@ -11,7 +11,17 @@ Aşağıdaki hücre Colab ortamında projeyi kurar ve örnek bir tarama çalış
 %cd /content/finansal-analiz-sistemi
 %env PYTHONPATH=/content/finansal-analiz-sistemi
 !mkdir -p raporlar
+```
 
+## Ortam Doğrulama
+
+```python
+!python tools/verify_env.py
+```
+
+## Örnek Tarama
+
+```python
 !python -m backtest.cli scan-range --config config/colab_config.yaml \
   --start 2025-03-07 --end 2025-03-11 \
   --holding-period 1 --transaction-cost 0.0005

--- a/tools/verify_env.py
+++ b/tools/verify_env.py
@@ -1,5 +1,32 @@
+import importlib
 import sys
-import numpy as np
 
-if int(np.__version__.split(".")[0]) >= 2:
-    sys.exit("NumPy >= 2.0 detected, aborting.")
+RECOMMENDED_CMD = (
+    'pip install "numpy<2.0.0" "pandas<2.2" pandas-ta==0.3.14b0'
+)
+
+
+def _parse(version: str) -> tuple:
+    return tuple(int(part) for part in version.split('.') if part.isdigit())
+
+
+def _check(pkg: str, max_version: str) -> bool:
+    try:
+        module = importlib.import_module(pkg)
+    except ImportError:
+        return True  # missing pkg will be handled by installation
+    return _parse(module.__version__) < _parse(max_version)
+
+
+if __name__ == "__main__":
+    issues = []
+    if not _check("numpy", "2.0.0"):
+        issues.append("numpy>=2.0.0 detected")
+    if not _check("pandas", "2.2.0"):
+        issues.append("pandas>=2.2.0 detected")
+    if issues:
+        for issue in issues:
+            print(issue)
+        print("Please install compatible versions with:")
+        print(RECOMMENDED_CMD)
+        sys.exit(1)

--- a/tools/verify_env.py
+++ b/tools/verify_env.py
@@ -1,13 +1,11 @@
 import importlib
 import sys
 
-RECOMMENDED_CMD = (
-    'pip install "numpy<2.0.0" "pandas<2.2" pandas-ta==0.3.14b0'
-)
+RECOMMENDED_CMD = 'pip install "numpy<2.0.0" "pandas<2.2" pandas-ta==0.3.14b0'
 
 
 def _parse(version: str) -> tuple:
-    return tuple(int(part) for part in version.split('.') if part.isdigit())
+    return tuple(int(part) for part in version.split(".") if part.isdigit())
 
 
 def _check(pkg: str, max_version: str) -> bool:


### PR DESCRIPTION
## Summary
- ensure numpy/pandas versions are compatible via new verify_env script
- document how to run environment validation locally and in Colab
- add explicit environment check step to Colab quick start

## Testing
- `python tools/verify_env.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d14ef9498832593320ddc8fb4c99b