### PR TITLE
feat(report): add per-day output mode (+CSV) with safe overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ python -m backtest.cli scan-range \
   --transaction-cost 0.0005
 ```
 
+Gün başına Excel (ve varsayılan olarak CSV) üretmek için:
+
+```bash
+python -m backtest.cli scan-range \
+  --config examples/example_config.yaml \
+  --start 2025-03-07 \
+  --end   2025-03-11 \
+  --per-day-output
+```
+
+CSV istemiyorsanız `--no-csv` bayrağını ekleyin.
+
 ## Çıktı Açıklaması
 - Excel: `raporlar/{start}_{end}_1G_BIST100.xlsx`
 - Sheet'ler:

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -222,7 +222,9 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
     type=click.Choice(["off", "smart", "strict"]),
     default="smart",
 )
-@click.option("--per-day-output", is_flag=True, default=False, help="Günlük dosya çıktısı")
+@click.option(
+    "--per-day-output", is_flag=True, default=False, help="Günlük dosya çıktısı"
+)
 @click.option("--csv-also/--no-csv", default=True, help="CSV de yaz")
 def scan_range(
     config_path,

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -144,9 +144,7 @@ def write_reports(
                 summary_df.to_excel(writer, sheet_name="SUMMARY", index=False)
             excel_paths.append(xlsx_path)
             if csv_also:
-                csv_name = _sanitize_filename(
-                    csv_filename_pattern.format(date=day_str)
-                )
+                csv_name = _sanitize_filename(csv_filename_pattern.format(date=day_str))
                 csv_path = _handle_overwrite(base_dir / csv_name, overwrite)
                 day_df.to_csv(csv_path, index=False, encoding="utf-8")
                 csv_paths.append(csv_path)

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import re
 import warnings
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
-from typing import Iterable, Mapping, Optional
+from typing import Iterable, Mapping, Optional, Literal
 
 import pandas as pd
 
@@ -16,6 +17,27 @@ def _ensure_dir(path: Optional[str | Path]):
     p = resolve_path(path)
     target = p if not p.suffix else p.parent
     target.mkdir(parents=True, exist_ok=True)
+
+
+def _sanitize_filename(name: str) -> str:
+    """Remove characters that are invalid in file names."""
+    return re.sub(r'[<>:"/\\|?*]', "_", name)
+
+
+def _handle_overwrite(path: Path, policy: Literal["replace", "fail", "timestamp"]):
+    """Return a safe path according to overwrite policy."""
+    if policy not in {"replace", "fail", "timestamp"}:
+        raise ValueError("invalid overwrite policy")
+    if policy == "replace":
+        return path
+    if policy == "fail":
+        if path.exists():
+            raise FileExistsError(path)
+        return path
+    if path.exists():
+        stamp = datetime.now().strftime("%H%M%S")
+        return path.with_name(f"{path.stem}_{stamp}{path.suffix}")
+    return path
 
 
 def write_reports(
@@ -31,6 +53,13 @@ def write_reports(
     summary_winrate: Optional[pd.DataFrame] = None,
     validation_summary: Optional[pd.DataFrame] = None,
     validation_issues: Optional[pd.DataFrame] = None,
+    *,
+    per_day_output: bool = False,
+    csv_also: bool = True,
+    overwrite: Literal["replace", "fail", "timestamp"] = "replace",
+    filename_pattern: str = "{date}.xlsx",
+    csv_filename_pattern: str = "{date}.csv",
+    separate_dir_for_range: bool = False,
 ):
     """Write daily/summary and optional sheets and return output paths.
     - SUMMARY: ReturnPct ortalamaları (sayısal 0.00 -> yüzde puan)
@@ -41,8 +70,8 @@ def write_reports(
     Returns
     -------
     dict
-        Mapping of produced files. Keys are ``excel`` for the workbook and
-        ``csv`` for a list of CSV exports (if requested).
+        Mapping of produced files. Keys are ``excel`` for the workbook or list
+        of workbooks and ``csv`` for a list of CSV exports (if requested).
     """
     if not isinstance(trades_all, pd.DataFrame):
         raise TypeError("trades_all must be a DataFrame")
@@ -83,6 +112,48 @@ def write_reports(
     else:
         raise TypeError("dates must be iterable or date-like")
     outputs: dict[str, Path | list[Path]] = {}
+    if per_day_output:
+        if not out_xlsx:
+            raise ValueError("out_xlsx directory required for per_day_output")
+        base_dir = resolve_path(out_xlsx)
+        base_dir.mkdir(parents=True, exist_ok=True)
+        if separate_dir_for_range and dates:
+            start = pd.to_datetime(dates[0]).date()
+            end = pd.to_datetime(dates[-1]).date()
+            base_dir = base_dir / f"{start}_{end}"
+            base_dir.mkdir(parents=True, exist_ok=True)
+        excel_paths: list[Path] = []
+        csv_paths: list[Path] = []
+        for d in dates:
+            day_ts = pd.to_datetime(d).normalize()
+            day_df = trades_all[trades_all["Date"] == day_ts].copy()
+            day_df = day_df.sort_values(["FilterCode", "Symbol"])
+            day_str = str(day_ts.date())
+            fname = _sanitize_filename(filename_pattern.format(date=day_str))
+            xlsx_path = _handle_overwrite(base_dir / fname, overwrite)
+            writer = pd.ExcelWriter(xlsx_path, engine="xlsxwriter")
+            with writer:
+                day_df.to_excel(writer, sheet_name="SCAN", index=False)
+                summary_df = pd.DataFrame(
+                    {
+                        "N_TRADES": [len(day_df)],
+                        "MEAN_RET": [day_df["ReturnPct"].mean()],
+                        "HIT_RATIO": [day_df["Win"].mean()],
+                    }
+                )
+                summary_df.to_excel(writer, sheet_name="SUMMARY", index=False)
+            excel_paths.append(xlsx_path)
+            if csv_also:
+                csv_name = _sanitize_filename(
+                    csv_filename_pattern.format(date=day_str)
+                )
+                csv_path = _handle_overwrite(base_dir / csv_name, overwrite)
+                day_df.to_csv(csv_path, index=False, encoding="utf-8")
+                csv_paths.append(csv_path)
+        outputs["excel"] = excel_paths
+        if csv_paths:
+            outputs["csv"] = csv_paths
+        return outputs
     if summary_wide is None:
         summary_wide = pd.DataFrame()
     if out_xlsx:
@@ -194,7 +265,7 @@ def write_reports(
             else:
                 warnings.warn(f"Excel yazılamadı: {out_xlsx_path}")
 
-    if out_csv_dir:
+    if out_csv_dir and csv_also:
         out_csv_path = resolve_path(out_csv_dir)
         out_csv_path.mkdir(parents=True, exist_ok=True)
         csv_paths: list[Path] = []

--- a/tests/test_per_day_output.py
+++ b/tests/test_per_day_output.py
@@ -1,0 +1,85 @@
+import pandas as pd
+import pytest
+
+from backtest.reporter import write_reports
+
+def _sample_trades():
+    dates = pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"])
+    return pd.DataFrame(
+        {
+            "FilterCode": ["f1", "f1", "f1"],
+            "Symbol": ["SYM1", "SYM2", "SYM3"],
+            "Date": dates,
+            "EntryClose": [10.0, 11.0, 12.0],
+            "ExitClose": [11.0, 12.0, 13.0],
+            "Side": ["long", "long", "long"],
+            "ReturnPct": [10.0, 9.090909, 8.333333],
+            "Win": [True, True, False],
+            "Reason": [pd.NA, pd.NA, pd.NA],
+        }
+    )
+
+def test_per_day_creates_files(tmp_path):
+    trades = _sample_trades()
+    dates = pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"])
+    summary = pd.DataFrame()
+    outputs = write_reports(
+        trades,
+        dates,
+        summary,
+        out_xlsx=tmp_path,
+        per_day_output=True,
+    )
+    assert len(outputs["excel"]) == 3
+    assert len(outputs.get("csv", [])) == 3
+    for d in dates:
+        assert (tmp_path / f"{d.date()}.xlsx").exists()
+        assert (tmp_path / f"{d.date()}.csv").exists()
+
+def test_per_day_empty_day(tmp_path):
+    trades = _sample_trades().iloc[:1]
+    dates = pd.to_datetime(["2024-01-01", "2024-01-02"])
+    summary = pd.DataFrame()
+    write_reports(
+        trades,
+        dates,
+        summary,
+        out_xlsx=tmp_path,
+        per_day_output=True,
+    )
+    path = tmp_path / "2024-01-02.xlsx"
+    assert path.exists()
+    df = pd.read_excel(path, sheet_name="SUMMARY")
+    assert int(df["N_TRADES"].iloc[0]) == 0
+
+def test_overwrite_policies(tmp_path):
+    trades = _sample_trades().iloc[:1]
+    dates = pd.to_datetime(["2024-01-01"])
+    summary = pd.DataFrame()
+    write_reports(
+        trades,
+        dates,
+        summary,
+        out_xlsx=tmp_path,
+        per_day_output=True,
+    )
+    with pytest.raises(FileExistsError):
+        write_reports(
+            trades,
+            dates,
+            summary,
+            out_xlsx=tmp_path,
+            per_day_output=True,
+            overwrite="fail",
+        )
+    write_reports(
+        trades,
+        dates,
+        summary,
+        out_xlsx=tmp_path,
+        per_day_output=True,
+        overwrite="timestamp",
+    )
+    files = list(tmp_path.glob("*.xlsx"))
+    assert len(files) == 2
+    assert any("_" in f.stem for f in files)

--- a/tests/test_per_day_output.py
+++ b/tests/test_per_day_output.py
@@ -3,6 +3,7 @@ import pytest
 
 from backtest.reporter import write_reports
 
+
 def _sample_trades():
     dates = pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"])
     return pd.DataFrame(
@@ -18,6 +19,7 @@ def _sample_trades():
             "Reason": [pd.NA, pd.NA, pd.NA],
         }
     )
+
 
 def test_per_day_creates_files(tmp_path):
     trades = _sample_trades()
@@ -36,6 +38,7 @@ def test_per_day_creates_files(tmp_path):
         assert (tmp_path / f"{d.date()}.xlsx").exists()
         assert (tmp_path / f"{d.date()}.csv").exists()
 
+
 def test_per_day_empty_day(tmp_path):
     trades = _sample_trades().iloc[:1]
     dates = pd.to_datetime(["2024-01-01", "2024-01-02"])
@@ -51,6 +54,7 @@ def test_per_day_empty_day(tmp_path):
     assert path.exists()
     df = pd.read_excel(path, sheet_name="SUMMARY")
     assert int(df["N_TRADES"].iloc[0]) == 0
+
 
 def test_overwrite_policies(tmp_path):
     trades = _sample_trades().iloc[:1]


### PR DESCRIPTION
## Summary
- support optional per-day report generation with CSV export and configurable overwrite handling
- expose new CLI flags `--per-day-output` and `--csv-also/--no-csv`
- document per-day usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d9aa8826c8325bf222191eccc7366