### PR TITLE
feat(report): add BIST-relative metrics to SUMMARY (+optional BIST_RATIO_SUMMARY sheet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Aşağıdaki tablo bazı sık kullanılan indikatör kolonlarını ve bunlara il
 | EMA20_50 | `ema_20_keser_ema_50_yukari` | Trend | long |
 | RSI30_SHORT | `rsi_14_keser_30p0_asagi` | Momentum | short |
 
+## BIST'e Göre Oranlı Özet
+
+Filtre performansları BIST100'e göre şu metriklerle özetlenir:
+
+| FİLTRE | MEAN_RET | BIST_MEAN_RET | ALPHA_RET | HIT_RATIO | N_TRADES |
+| -----: | --------: | --------------: | ---------: | ---------: | --------: |
+|    T21 |    0.0124 |          0.0080 |     0.0044 |       0.61 |        57 |
+|    T24 |    0.0102 |          0.0091 |     0.0011 |       0.54 |        49 |
+
+`ALPHA_RET = MEAN_RET - BIST_MEAN_RET`
+
 ## Kurulum ve Çalıştırma
 ### Yerel
 ```bash

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -202,6 +202,9 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
             daily_sheet_prefix=cfg.report.daily_sheet_prefix,
             summary_sheet_name=cfg.report.summary_sheet_name,
             percent_fmt=cfg.report.percent_format,
+            with_bist_ratio_summary=getattr(
+                cfg.report, "with_bist_ratio_summary", False
+            ),
             per_day_output=per_day_output,
             csv_also=csv_also,
         )

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -62,6 +62,7 @@ class ReportCfg(BaseModel):
     percent_format: str = "0.00%"
     daily_sheet_prefix: str = "SCAN_"
     summary_sheet_name: str = "SUMMARY"
+    with_bist_ratio_summary: bool = False
 
 
 class RootCfg(BaseModel):

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import logging
 import warnings
 from datetime import date, datetime
 from pathlib import Path
@@ -9,6 +10,83 @@ from typing import Iterable, Mapping, Optional, Literal
 import pandas as pd
 
 from utils.paths import resolve_path
+
+
+logger = logging.getLogger("summary_bist")
+
+
+def _add_bist_columns(
+    summary_wide: pd.DataFrame, xu100_pct: Optional[Mapping]
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return summary with BIST-relative metrics and a compact sheet.
+
+    Parameters
+    ----------
+    summary_wide : pd.DataFrame
+        Wide table with daily returns. May contain ``Ortalama`` and
+        ``TradeCount`` columns which will be replaced by new metric names.
+    xu100_pct : Mapping or None
+        Mapping of date -> BIST100 daily return percentage.
+
+    Returns
+    -------
+    (summary_wide, ratio_summary)
+        ``summary_wide`` augmented with metric columns and ``ratio_summary``
+        containing only metric columns sorted by ``ALPHA_RET``.
+    """
+
+    if summary_wide is None or summary_wide.empty:
+        return summary_wide if summary_wide is not None else pd.DataFrame(), pd.DataFrame()
+
+    day_cols = [c for c in summary_wide.columns if c not in {"Ortalama", "TradeCount"}]
+    sw = summary_wide[day_cols].copy()
+    result = summary_wide.copy()
+
+    result["MEAN_RET"] = sw.mean(axis=1)
+    result["HIT_RATIO"] = (sw > 0).sum(axis=1) / sw.count(axis=1)
+    if "TradeCount" in result.columns:
+        result["N_TRADES"] = result["TradeCount"]
+    else:
+        result["N_TRADES"] = pd.NA
+
+    if xu100_pct is not None:
+        bist_series = pd.Series(dict(xu100_pct), dtype=float).reindex(day_cols)
+        mask = sw.notna() & bist_series.notna()
+        result["BIST_MEAN_RET"] = (
+            mask.astype(float) * bist_series
+        ).sum(axis=1) / mask.sum(axis=1)
+    else:
+        result["BIST_MEAN_RET"] = float("nan")
+
+    result["ALPHA_RET"] = result["MEAN_RET"] - result["BIST_MEAN_RET"]
+
+    # logging per filter/side
+    for idx, row in result.iterrows():
+        n_days = sw.loc[idx].count()
+        miss = len(day_cols) - n_days
+        logger.info(
+            "filter=%s days=%d missing=%d mean=%.6f bist_mean=%.6f",
+            idx,
+            n_days,
+            miss,
+            row["MEAN_RET"],
+            row["BIST_MEAN_RET"],
+        )
+
+    result = result.drop(columns=[c for c in ["Ortalama", "TradeCount"] if c in result.columns])
+
+    metric_cols = [
+        "MEAN_RET",
+        "BIST_MEAN_RET",
+        "ALPHA_RET",
+        "HIT_RATIO",
+        "N_TRADES",
+    ]
+    ordered = [c for c in day_cols if c not in metric_cols] + metric_cols
+    result = result[ordered]
+
+    ratio_summary = result[metric_cols].sort_values("ALPHA_RET", ascending=False)
+    return result, ratio_summary
 
 
 def _ensure_dir(path: Optional[str | Path]):
@@ -53,6 +131,7 @@ def write_reports(
     summary_winrate: Optional[pd.DataFrame] = None,
     validation_summary: Optional[pd.DataFrame] = None,
     validation_issues: Optional[pd.DataFrame] = None,
+    with_bist_ratio_summary: bool = False,
     *,
     per_day_output: bool = False,
     csv_also: bool = True,
@@ -154,6 +233,11 @@ def write_reports(
         return outputs
     if summary_wide is None:
         summary_wide = pd.DataFrame()
+        bist_ratio_summary = pd.DataFrame()
+    else:
+        summary_wide, bist_ratio_summary = _add_bist_columns(summary_wide, xu100_pct)
+
+    metric_cols = ["MEAN_RET", "BIST_MEAN_RET", "ALPHA_RET", "HIT_RATIO", "N_TRADES"]
     if out_xlsx:
         out_xlsx_path = resolve_path(out_xlsx)
         _ensure_dir(out_xlsx_path)
@@ -172,11 +256,17 @@ def write_reports(
 
                 summary_wide.to_excel(writer, sheet_name=summary_sheet_name)
 
+                if with_bist_ratio_summary and not bist_ratio_summary.empty:
+                    bist_ratio_summary.to_excel(
+                        writer, sheet_name="BIST_RATIO_SUMMARY"
+                    )
+
                 if summary_winrate is not None and not summary_winrate.empty:
                     summary_winrate.to_excel(
                         writer, sheet_name=f"{summary_sheet_name}_WINRATE"
                     )
 
+                day_cols = [c for c in summary_wide.columns if c not in metric_cols]
                 if xu100_pct is not None:
                     if isinstance(xu100_pct, pd.Series):
                         xu100_series = xu100_pct.astype(float)
@@ -184,16 +274,11 @@ def write_reports(
                         xu100_series = pd.Series(dict(xu100_pct), dtype=float)
                     else:
                         raise TypeError("xu100_pct must be a mapping or Series")
-                    cols = [
-                        c
-                        for c in summary_wide.columns
-                        if c not in {"Ortalama", "TradeCount"}
-                    ]
-                    if set(cols).issubset(set(xu100_series.index)):
-                        diff = summary_wide.copy()
-                        for c in cols:
+                    if set(day_cols).issubset(set(xu100_series.index)):
+                        diff = summary_wide[day_cols].copy()
+                        for c in day_cols:
                             diff[c] = diff[c] - float(xu100_series.get(c, float("nan")))
-                        diff["Ortalama"] = diff[cols].mean(axis=1)
+                        diff["MEAN_RET"] = diff.mean(axis=1)
                         diff.to_excel(writer, sheet_name=f"{summary_sheet_name}_DIFF")
                     avg = (
                         float(xu100_series.mean())
@@ -202,11 +287,11 @@ def write_reports(
                     )
                     bist = (
                         pd.DataFrame(
-                            [[xu100_series.get(c, float("nan")) for c in cols] + [avg]],
+                            [[xu100_series.get(c, float("nan")) for c in day_cols] + [avg]],
                             index=["BIST"],
-                            columns=cols + ["Ortalama"],
+                            columns=day_cols + ["MEAN_RET"],
                         )
-                        if cols
+                        if day_cols
                         else pd.DataFrame()
                     )
                     if not bist.empty:

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -36,7 +36,10 @@ def _add_bist_columns(
     """
 
     if summary_wide is None or summary_wide.empty:
-        return summary_wide if summary_wide is not None else pd.DataFrame(), pd.DataFrame()
+        return (
+            summary_wide if summary_wide is not None else pd.DataFrame(),
+            pd.DataFrame(),
+        )
 
     day_cols = [c for c in summary_wide.columns if c not in {"Ortalama", "TradeCount"}]
     sw = summary_wide[day_cols].copy()
@@ -52,9 +55,9 @@ def _add_bist_columns(
     if xu100_pct is not None:
         bist_series = pd.Series(dict(xu100_pct), dtype=float).reindex(day_cols)
         mask = sw.notna() & bist_series.notna()
-        result["BIST_MEAN_RET"] = (
-            mask.astype(float) * bist_series
-        ).sum(axis=1) / mask.sum(axis=1)
+        result["BIST_MEAN_RET"] = (mask.astype(float) * bist_series).sum(
+            axis=1
+        ) / mask.sum(axis=1)
     else:
         result["BIST_MEAN_RET"] = float("nan")
 
@@ -73,7 +76,9 @@ def _add_bist_columns(
             row["BIST_MEAN_RET"],
         )
 
-    result = result.drop(columns=[c for c in ["Ortalama", "TradeCount"] if c in result.columns])
+    result = result.drop(
+        columns=[c for c in ["Ortalama", "TradeCount"] if c in result.columns]
+    )
 
     metric_cols = [
         "MEAN_RET",
@@ -257,9 +262,7 @@ def write_reports(
                 summary_wide.to_excel(writer, sheet_name=summary_sheet_name)
 
                 if with_bist_ratio_summary and not bist_ratio_summary.empty:
-                    bist_ratio_summary.to_excel(
-                        writer, sheet_name="BIST_RATIO_SUMMARY"
-                    )
+                    bist_ratio_summary.to_excel(writer, sheet_name="BIST_RATIO_SUMMARY")
 
                 if summary_winrate is not None and not summary_winrate.empty:
                     summary_winrate.to_excel(
@@ -287,7 +290,10 @@ def write_reports(
                     )
                     bist = (
                         pd.DataFrame(
-                            [[xu100_series.get(c, float("nan")) for c in day_cols] + [avg]],
+                            [
+                                [xu100_series.get(c, float("nan")) for c in day_cols]
+                                + [avg]
+                            ],
                             index=["BIST"],
                             columns=day_cols + ["MEAN_RET"],
                         )

--- a/tests/test_bist_summary.py
+++ b/tests/test_bist_summary.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from backtest.reporter import write_reports
+
+
+def _basic_trades():
+    return pd.DataFrame(
+        {
+            "FilterCode": ["F1", "F1", "F1", "F1", "F2", "F2"],
+            "Symbol": ["A", "A", "A", "A", "B", "B"],
+            "Date": pd.to_datetime(
+                ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-03", "2024-01-01", "2024-01-02"]
+            ),
+            "EntryClose": [1, 1, 1, 1, 1, 1],
+            "ExitClose": [1, 1, 1, 1, 1, 1],
+            "Side": ["long", "long", "long", "long", "long", "long"],
+            "ReturnPct": [2.0, -1.0, 3.0, 1.0, 4.0, -2.0],
+            "Win": [True, False, True, True, True, False],
+            "Reason": [pd.NA] * 6,
+        }
+    )
+
+
+def test_summary_contains_bist_columns(tmp_path):
+    trades = _basic_trades()
+    summary = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+    )
+    trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
+    summary = summary.assign(TradeCount=trade_counts)
+    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-02"): -0.5, pd.Timestamp("2024-01-03"): 0.5}
+    out_xlsx = tmp_path / "out.xlsx"
+    write_reports(trades, trades["Date"].unique(), summary, xu, out_xlsx=out_xlsx)
+    df = pd.read_excel(out_xlsx, sheet_name="SUMMARY")
+    for col in ["MEAN_RET", "BIST_MEAN_RET", "ALPHA_RET", "HIT_RATIO", "N_TRADES"]:
+        assert col in df.columns
+        assert df[col].dtype.kind in "fi"
+
+
+def test_alpha_computation_alignment(tmp_path):
+    trades = _basic_trades()
+    summary = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+    )
+    trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
+    summary = summary.assign(TradeCount=trade_counts)
+    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-03"): 0.5}  # missing second day
+    out_xlsx = tmp_path / "out.xlsx"
+    write_reports(trades, trades["Date"].unique(), summary, xu, out_xlsx=out_xlsx)
+    df = pd.read_excel(out_xlsx, sheet_name="SUMMARY")
+    f1 = df[df["FilterCode"] == "F1"].iloc[0]
+    assert np.isclose(f1["BIST_MEAN_RET"], (1.0 + 0.5) / 2)
+    assert np.isclose(f1["ALPHA_RET"], f1["MEAN_RET"] - f1["BIST_MEAN_RET"])
+
+
+def test_optional_bist_ratio_sheet(tmp_path):
+    trades = _basic_trades()
+    summary = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+    )
+    trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
+    summary = summary.assign(TradeCount=trade_counts)
+    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-02"): -0.5, pd.Timestamp("2024-01-03"): 0.5}
+    out_xlsx = tmp_path / "out.xlsx"
+    write_reports(
+        trades,
+        trades["Date"].unique(),
+        summary,
+        xu,
+        out_xlsx=out_xlsx,
+        with_bist_ratio_summary=True,
+    )
+    xl = pd.ExcelFile(out_xlsx)
+    assert "BIST_RATIO_SUMMARY" in xl.sheet_names
+    out_xlsx2 = tmp_path / "out2.xlsx"
+    write_reports(
+        trades,
+        trades["Date"].unique(),
+        summary,
+        xu,
+        out_xlsx=out_xlsx2,
+        with_bist_ratio_summary=False,
+    )
+    xl2 = pd.ExcelFile(out_xlsx2)
+    assert "BIST_RATIO_SUMMARY" not in xl2.sheet_names
+
+
+def test_sorting_and_values(tmp_path):
+    trades = _basic_trades()
+    summary = (
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+    )
+    trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
+    summary = summary.assign(TradeCount=trade_counts)
+    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-02"): -0.5, pd.Timestamp("2024-01-03"): 0.5}
+    out_xlsx = tmp_path / "out.xlsx"
+    write_reports(
+        trades,
+        trades["Date"].unique(),
+        summary,
+        xu,
+        out_xlsx=out_xlsx,
+        with_bist_ratio_summary=True,
+    )
+    sum_df = pd.read_excel(out_xlsx, sheet_name="SUMMARY")
+    ratio_df = pd.read_excel(out_xlsx, sheet_name="BIST_RATIO_SUMMARY")
+    assert ratio_df["ALPHA_RET"].is_monotonic_decreasing
+    merged = ratio_df.merge(sum_df, on="FilterCode", suffixes=("_r", "_s"))
+    assert np.allclose(merged["ALPHA_RET_r"], merged["ALPHA_RET_s"])
+    assert np.allclose(merged["MEAN_RET_r"], merged["MEAN_RET_s"])

--- a/tests/test_bist_summary.py
+++ b/tests/test_bist_summary.py
@@ -12,7 +12,14 @@ def _basic_trades():
             "FilterCode": ["F1", "F1", "F1", "F1", "F2", "F2"],
             "Symbol": ["A", "A", "A", "A", "B", "B"],
             "Date": pd.to_datetime(
-                ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-03", "2024-01-01", "2024-01-02"]
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-01",
+                    "2024-01-02",
+                ]
             ),
             "EntryClose": [1, 1, 1, 1, 1, 1],
             "ExitClose": [1, 1, 1, 1, 1, 1],
@@ -27,11 +34,17 @@ def _basic_trades():
 def test_summary_contains_bist_columns(tmp_path):
     trades = _basic_trades()
     summary = (
-        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
     )
     trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
     summary = summary.assign(TradeCount=trade_counts)
-    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-02"): -0.5, pd.Timestamp("2024-01-03"): 0.5}
+    xu = {
+        pd.Timestamp("2024-01-01"): 1.0,
+        pd.Timestamp("2024-01-02"): -0.5,
+        pd.Timestamp("2024-01-03"): 0.5,
+    }
     out_xlsx = tmp_path / "out.xlsx"
     write_reports(trades, trades["Date"].unique(), summary, xu, out_xlsx=out_xlsx)
     df = pd.read_excel(out_xlsx, sheet_name="SUMMARY")
@@ -43,11 +56,16 @@ def test_summary_contains_bist_columns(tmp_path):
 def test_alpha_computation_alignment(tmp_path):
     trades = _basic_trades()
     summary = (
-        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
     )
     trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
     summary = summary.assign(TradeCount=trade_counts)
-    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-03"): 0.5}  # missing second day
+    xu = {
+        pd.Timestamp("2024-01-01"): 1.0,
+        pd.Timestamp("2024-01-03"): 0.5,
+    }  # missing second day
     out_xlsx = tmp_path / "out.xlsx"
     write_reports(trades, trades["Date"].unique(), summary, xu, out_xlsx=out_xlsx)
     df = pd.read_excel(out_xlsx, sheet_name="SUMMARY")
@@ -59,11 +77,17 @@ def test_alpha_computation_alignment(tmp_path):
 def test_optional_bist_ratio_sheet(tmp_path):
     trades = _basic_trades()
     summary = (
-        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
     )
     trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
     summary = summary.assign(TradeCount=trade_counts)
-    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-02"): -0.5, pd.Timestamp("2024-01-03"): 0.5}
+    xu = {
+        pd.Timestamp("2024-01-01"): 1.0,
+        pd.Timestamp("2024-01-02"): -0.5,
+        pd.Timestamp("2024-01-03"): 0.5,
+    }
     out_xlsx = tmp_path / "out.xlsx"
     write_reports(
         trades,
@@ -91,11 +115,17 @@ def test_optional_bist_ratio_sheet(tmp_path):
 def test_sorting_and_values(tmp_path):
     trades = _basic_trades()
     summary = (
-        trades.groupby(["FilterCode", "Date"])["ReturnPct"].mean().unstack(fill_value=float("nan"))
+        trades.groupby(["FilterCode", "Date"])["ReturnPct"]
+        .mean()
+        .unstack(fill_value=float("nan"))
     )
     trade_counts = trades.groupby(["FilterCode"])["Symbol"].count()
     summary = summary.assign(TradeCount=trade_counts)
-    xu = {pd.Timestamp("2024-01-01"): 1.0, pd.Timestamp("2024-01-02"): -0.5, pd.Timestamp("2024-01-03"): 0.5}
+    xu = {
+        pd.Timestamp("2024-01-01"): 1.0,
+        pd.Timestamp("2024-01-02"): -0.5,
+        pd.Timestamp("2024-01-03"): 0.5,
+    }
     out_xlsx = tmp_path / "out.xlsx"
     write_reports(
         trades,

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -178,5 +178,5 @@ def test_write_reports_includes_trade_count(tmp_path):
         out_xlsx=out_xlsx,
     )
     df = pd.read_excel(out_xlsx, sheet_name="SUMMARY")
-    assert "TradeCount" in df.columns
-    assert set(df["TradeCount"]) == {1}
+    assert "N_TRADES" in df.columns
+    assert set(df["N_TRADES"]) == {1}


### PR DESCRIPTION
## Summary
- augment report generation with BIST-relative metrics and optional BIST_RATIO_SUMMARY sheet
- allow enabling BIST ratio summary via configuration
- document new BIST-relative summary metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d9d2f265883258560fd4f9e239f59