### PR TITLE
feat(io): add preflight checks for excel_dir & date patterns (+smart suggestions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,22 @@ CSV istemiyorsanız `--no-csv` bayrağını ekleyin.
 ```
 SCAN 2024-01-02: 24 satır, ort. %1.2
 ```
+
+## Ön Kontrol (Preflight)
+
+Tarama başlamadan önce belirtilen klasör ve tarih aralığı için dosya varlığı
+kontrol edilir. Eksik dosyalar raporlanır ve sık yapılan hatalar için öneriler
+sunulur. Gerekirse `--no-preflight` ile kontrolü atlayabilir ya da
+`--case-insensitive` bayrağıyla dosya adlarında küçük/büyük harf farkını yok
+sayabilirsiniz.
+
+Örnek çıktı:
+
+```
+preflight: scanned=4, found=3, missing=1, dir=Veri, pattern={date}.xlsx
+Eksik dosyalar: 2025-03-10
+Öneri: Klasörü 'veri/' altında buldum. Config'te 'excel_dir: veri' yapmayı dener misin?
+```
 ## Test Çalıştırma (isteğe bağlı)
 ```bash
 pip install -r requirements_dev.txt -c constraints.txt --only-binary=:all: --no-binary=pandas-ta

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import logging
 import click
 import pandas as pd
+from datetime import timedelta
 
 from io_filters import load_filters_csv
 from utils.paths import resolve_path
+from .io.preflight import preflight
 
 from .backtester import run_1g_returns
 from .benchmark import load_xu100_pct
@@ -229,6 +231,15 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
     "--per-day-output", is_flag=True, default=False, help="Günlük dosya çıktısı"
 )
 @click.option("--csv-also/--no-csv", default=True, help="CSV de yaz")
+@click.option(
+    "--no-preflight", is_flag=True, default=False, help="Preflight kontrolünü atla"
+)
+@click.option(
+    "--case-insensitive",
+    is_flag=True,
+    default=False,
+    help="Dosya adlarında küçük/büyük harf farkını yok say",
+)
 def scan_range(
     config_path,
     start_date,
@@ -238,6 +249,9 @@ def scan_range(
     name_normalization="smart",
     per_day_output=False,
     csv_also=True,
+    *,
+    no_preflight=False,
+    case_insensitive=False,
 ):
     set_name_normalization(name_normalization)
     try:
@@ -254,6 +268,25 @@ def scan_range(
     if transaction_cost is not None:
         cfg.project.transaction_cost = transaction_cost
     cfg.project.run_mode = "range"
+    if case_insensitive:
+        cfg.data.case_sensitive = False
+    if not no_preflight and cfg.project.start_date and cfg.project.end_date:
+        start = pd.to_datetime(cfg.project.start_date).date()
+        end = pd.to_datetime(cfg.project.end_date).date()
+        days = [start + timedelta(days=i) for i in range((end - start).days + 1)]
+        rep = preflight(
+            cfg.data.excel_dir,
+            days,
+            cfg.data.filename_pattern,
+            date_format=cfg.data.date_format,
+            case_sensitive=cfg.data.case_sensitive,
+        )
+        if rep.errors:
+            raise click.ClickException("; ".join(rep.errors))
+        for msg in rep.warnings:
+            logging.warning(msg)
+        for msg in rep.suggestions:
+            logging.info(msg)
     try:
         _run_scan(cfg, per_day_output=per_day_output, csv_also=csv_also)
     except Exception:
@@ -266,7 +299,24 @@ def scan_range(
 @click.option("--date", "date_str", required=True, help="YYYY-MM-DD")
 @click.option("--holding-period", default=None, type=int)
 @click.option("--transaction-cost", default=None, type=float)
-def scan_day(config_path, date_str, holding_period, transaction_cost):
+@click.option(
+    "--no-preflight", is_flag=True, default=False, help="Preflight kontrolünü atla"
+)
+@click.option(
+    "--case-insensitive",
+    is_flag=True,
+    default=False,
+    help="Dosya adlarında küçük/büyük harf farkını yok say",
+)
+def scan_day(
+    config_path,
+    date_str,
+    holding_period,
+    transaction_cost,
+    *,
+    no_preflight=False,
+    case_insensitive=False,
+):
     try:
         cfg = load_config(config_path)
     except Exception as exc:  # kullanıcı dostu mesaj
@@ -278,6 +328,23 @@ def scan_day(config_path, date_str, holding_period, transaction_cost):
         cfg.project.holding_period = holding_period
     if transaction_cost is not None:
         cfg.project.transaction_cost = transaction_cost
+    if case_insensitive:
+        cfg.data.case_sensitive = False
+    if not no_preflight:
+        d = pd.to_datetime(date_str).date()
+        rep = preflight(
+            cfg.data.excel_dir,
+            [d],
+            cfg.data.filename_pattern,
+            date_format=cfg.data.date_format,
+            case_sensitive=cfg.data.case_sensitive,
+        )
+        if rep.errors:
+            raise click.ClickException("; ".join(rep.errors))
+        for msg in rep.warnings:
+            logging.warning(msg)
+        for msg in rep.suggestions:
+            logging.info(msg)
     try:
         _run_scan(cfg)
     except Exception:

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -28,6 +28,10 @@ class DataCfg(BaseModel):
     enable_cache: bool = False
     cache_parquet_path: Optional[str] = None
     corporate_actions_csv: Optional[str] = None
+    filename_pattern: str = "{date}.xlsx"
+    date_format: str = "%Y-%m-%d"
+    case_sensitive: bool = True
+    suggestions: bool = True
     price_schema: Dict[str, List[str]] = Field(
         default_factory=lambda: {
             "date": ["Tarih", "Date", "tarih"],

--- a/backtest/io/__init__.py
+++ b/backtest/io/__init__.py
@@ -1,0 +1,4 @@
+"""I/O utilities including preflight checks."""
+from .preflight import PreflightReport, preflight
+
+__all__ = ["PreflightReport", "preflight"]

--- a/backtest/io/preflight.py
+++ b/backtest/io/preflight.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Iterable, List
+from difflib import get_close_matches
+
+from utils.paths import resolve_path
+
+
+@dataclass
+class PreflightReport:
+    """Results of running a preflight check over expected Excel files."""
+
+    searched_dir: Path
+    glob_pattern: str
+    found_files: List[Path] = field(default_factory=list)
+    missing_dates: List[date] = field(default_factory=list)
+    suggestions: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+
+def preflight(
+    excel_dir: Path | str,
+    date_range: Iterable[date],
+    pattern: str,
+    *,
+    date_format: str = "%Y-%m-%d",
+    case_sensitive: bool = True,
+) -> PreflightReport:
+    """Check that expected Excel files exist before scanning.
+
+    Parameters
+    ----------
+    excel_dir:
+        Directory that should contain Excel files.
+    date_range:
+        Iterable of :class:`datetime.date` objects to check.
+    pattern:
+        Filename pattern that includes ``{date}`` placeholder.
+    date_format:
+        ``strftime`` format used for ``date`` substitution.
+    case_sensitive:
+        Whether filename matching should be case-sensitive.
+    """
+
+    dates = list(date_range)
+    searched_dir = resolve_path(excel_dir)
+    report = PreflightReport(
+        searched_dir=searched_dir,
+        glob_pattern=pattern.replace("{date}", "*"),
+    )
+
+    if not searched_dir.exists():
+        report.errors.append(f"Excel klasörü bulunamadı: {searched_dir}")
+        parent = searched_dir.parent
+        if parent.exists():
+            cand = [
+                p.name
+                for p in parent.iterdir()
+                if p.is_dir() and p.name.lower() == searched_dir.name.lower()
+            ]
+            for c in cand:
+                if c != searched_dir.name:
+                    report.suggestions.append(
+                        (
+                            f"Klasörü '{c}/' altında buldum. "
+                            f"Config'te 'excel_dir: {c}' yapmayı dener misin?"
+                        )
+                    )
+        return report
+
+    files_in_dir = {p.name: p for p in searched_dir.iterdir() if p.is_file()}
+    lower_map = {name.lower(): p for name, p in files_in_dir.items()}
+
+    for d in dates:
+        ds = d.strftime(date_format)
+        expected = pattern.format(date=ds)
+        if case_sensitive:
+            fp = files_in_dir.get(expected)
+        else:
+            fp = lower_map.get(expected.lower())
+        if fp:
+            report.found_files.append(fp)
+            continue
+        report.missing_dates.append(d)
+        # suggestions based on near matches
+        near = get_close_matches(
+            expected if case_sensitive else expected.lower(),
+            list(files_in_dir.keys() if case_sensitive else lower_map.keys()),
+            n=3,
+            cutoff=0.6,
+        )
+        for n in near:
+            # if case insensitive, 'n' may be lower-case key
+            sug = files_in_dir.get(n) or lower_map.get(n)
+            if sug:
+                report.suggestions.append(f"Benzer dosya: {sug.name}")
+
+    if report.missing_dates:
+        miss = ", ".join(d.strftime("%Y-%m-%d") for d in report.missing_dates)
+        report.warnings.append(f"Eksik dosyalar: {miss}")
+
+    return report
+
+
+__all__ = ["PreflightReport", "preflight"]

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -19,7 +19,13 @@ def _cfg():
             transaction_cost=0.0,
             raise_on_error=False,
         ),
-        data=SimpleNamespace(filters_csv="dummy.csv"),
+        data=SimpleNamespace(
+            filters_csv="dummy.csv",
+            excel_dir=".",
+            filename_pattern="{date}.xlsx",
+            date_format="%Y-%m-%d",
+            case_sensitive=True,
+        ),
         calendar=SimpleNamespace(
             tplus1_mode="price", holidays_source="none", holidays_csv_path=None
         ),

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+fake_pa = types.ModuleType("pandera")
+fake_pa.errors = types.SimpleNamespace(SchemaError=Exception)
+fake_pa.DataFrameSchema = lambda *a, **k: None
+fake_pa.Column = lambda *a, **k: None
+sys.modules.setdefault("pandera", fake_pa)
+
+from backtest.io.preflight import preflight  # noqa: E402
+from backtest import cli  # noqa: E402
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def test_preflight_all_found(tmp_path):
+    dates = [date(2025, 3, 7), date(2025, 3, 10)]
+    for d in dates:
+        _touch(tmp_path / f"{d}.xlsx")
+    rep = preflight(tmp_path, dates, "{date}.xlsx")
+    assert not rep.errors
+    assert not rep.missing_dates
+    assert len(rep.found_files) == len(dates)
+
+
+def test_preflight_missing_some(tmp_path):
+    dates = [date(2025, 3, 7), date(2025, 3, 8)]
+    _touch(tmp_path / "2025-03-07.xlsx")
+    rep = preflight(tmp_path, dates, "{date}.xlsx")
+    assert rep.missing_dates == [date(2025, 3, 8)]
+    assert rep.warnings
+
+
+def test_preflight_case_suggestion(tmp_path):
+    real_dir = tmp_path / "veri"
+    real_dir.mkdir()
+    rep = preflight(tmp_path / "Veri", [date(2025, 3, 7)], "{date}.xlsx")
+    assert rep.errors
+    assert any("veri" in s.lower() for s in rep.suggestions)
+
+
+def test_preflight_filename_near_match(tmp_path):
+    d = date(2025, 3, 7)
+    _touch(tmp_path / "2025_03_07.xlsx")
+    rep = preflight(tmp_path, [d], "{date}.xlsx")
+    assert rep.missing_dates == [d]
+    assert any("2025_03_07.xlsx" in s for s in rep.suggestions)
+
+
+def test_preflight_fail_fast_on_errors(tmp_path):
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(
+        """
+project:
+  out_dir: out
+  run_mode: single
+  single_date: "2025-03-07"
+  holding_period: 1
+  transaction_cost: 0
+
+data:
+  excel_dir: {}  # missing
+  filters_csv: {}
+""".format(
+            tmp_path / "missing", tmp_path / "filters.csv"
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "filters.csv").write_text(
+        "FilterCode,PythonQuery\nF1,close > 0\n", encoding="utf-8"
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.scan_day, ["--config", str(cfg_path), "--date", "2025-03-07"]
+    )
+    assert result.exit_code != 0
+    assert "Excel klasörü" in result.output
+
+
+def test_scan_day_no_preflight(monkeypatch):
+    cfg = SimpleNamespace(
+        project=SimpleNamespace(
+            run_mode="single",
+            single_date=None,
+            holding_period=1,
+            transaction_cost=0,
+        ),
+        data=SimpleNamespace(
+            excel_dir=".",
+            filename_pattern="{date}.xlsx",
+            date_format="%Y-%m-%d",
+            case_sensitive=True,
+        ),
+    )
+    monkeypatch.setattr(cli, "load_config", lambda _: cfg)
+    called = False
+
+    def _pf(*args, **kwargs):  # pragma: no cover - should not run
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli, "preflight", _pf)
+    monkeypatch.setattr(cli, "_run_scan", lambda cfg: None)
+    cli.scan_day.callback("cfg.yml", "2025-03-07", None, None, no_preflight=True)
+    assert not called
+
+
+def test_scan_day_case_insensitive(tmp_path, monkeypatch):
+    cfg = SimpleNamespace(
+        project=SimpleNamespace(
+            run_mode="single",
+            single_date=None,
+            holding_period=1,
+            transaction_cost=0,
+        ),
+        data=SimpleNamespace(
+            excel_dir=tmp_path,
+            filename_pattern="{date}.xlsx",
+            date_format="%Y-%m-%d",
+            case_sensitive=True,
+            filters_csv=tmp_path / "filters.csv",
+        ),
+    )
+    (tmp_path / "filters.csv").write_text(
+        "FilterCode,PythonQuery\nF1,close > 0\n", encoding="utf-8"
+    )
+    _touch(tmp_path / "2025-03-07.XLSX")
+    monkeypatch.setattr(cli, "load_config", lambda _: cfg)
+    monkeypatch.setattr(cli, "_run_scan", lambda cfg: None)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.scan_day,
+        ["--config", "cfg.yml", "--date", "2025-03-07", "--case-insensitive"],
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add `PreflightReport` and `preflight` util for upfront Excel presence validation
- wire preflight into `scan-day` and `scan-range` with CLI flags
- document preflight workflow and add tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689da4503e5c83258c84c3b39842c31e