### PR TITLE
feat(logging): standardize logging to loglar/, add Timer metrics + auto purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,32 @@ data:
 
 `data.excel_dir` ve `data.filters_csv` alanları eksikse komut satırında
 `config.data.* zorunlu; örnek için examples/example_config.yaml` şeklinde
-bir hata mesajı gösterilir.
+
+## Log Standardı
+
+Varsayılan log dizini `loglar/` olarak belirlenmiştir. Her çalışma
+`run_YYYYMMDD-HHMMSS` şeklinde adlandırılan alt klasöre loglarını yazar:
+
+```
+loglar/
+  run_20250307-093015/
+    summary.txt
+    stages.jsonl
+```
+
+`summary.txt` kısa insan okunur özetler içerir. Ayrıntılı bilgiler ise
+JSON Lines biçimindeki `stages.jsonl` dosyasına yazılır:
+
+```json
+{"ts":"2025-03-07T09:30:15.120Z","stage":"load_data","elapsed_ms":215,"rows":48290}
+```
+
+Hatalar `ERROR` seviyesinde loglanır ve aynı klasörde `stage.err` olarak
+stacktrace ile saklanır. Önceki `logs/` dizini tespit edilirse köke
+`migration.txt` bırakılır ve konsola uyarı basılır.
+
+`purge_old_logs(days=7)` fonksiyonu çalıştırıldığında 7 günden eski
+`run_*` klasörleri otomatik olarak silinir.
 
 ### Gösterge Motoru (Politika Kilidi)
 

--- a/backtest/logging_utils.py
+++ b/backtest/logging_utils.py
@@ -196,4 +196,3 @@ def purge_old_logs(days: int = 7, log_dir: str = "loglar") -> list[str]:
         except Exception:  # pragma: no cover - best effort
             pass
     return removed
-

--- a/backtest/logging_utils.py
+++ b/backtest/logging_utils.py
@@ -1,45 +1,159 @@
+"""Logging utilities for backtest package.
+
+This module centralises logging configuration and timing helpers.  It
+implements a simple structured logging scheme where each execution
+creates a dedicated run directory under ``loglar/``.
+
+Example::
+
+    >>> from backtest.logging_utils import setup_logger, Timer
+    >>> logfile = setup_logger(run_id="example")
+    >>> with Timer("stage") as t:
+    ...     t.update(rows=10)
+
+The above snippet will create ``loglar/run_example`` with files such as
+``summary.txt`` and ``stages.jsonl``.
+"""
+
 from __future__ import annotations
 
+import json
 import logging
 import os
+import shutil
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Callable
+
+__all__ = ["Timer", "setup_logger", "purge_old_logs"]
+
 
 _DEF_LEVEL = os.getenv("BIST_LOG_LEVEL", "INFO").upper()
+_DEF_FMT = "%(asctime)s | %(levelname)-7s | %(name)s | %(message)s"
+
+_def_handler: RotatingFileHandler | None = None
+_RUN_DIR: Path | None = None
 
 
 class Timer:
-    def __init__(self, name: str):
-        self.name = name
-        self.t0 = None
+    """Context manager & decorator to measure execution time.
 
-    def __enter__(self):
+    Parameters
+    ----------
+    stage:
+        Name of the stage being timed.
+    extra:
+        Optional initial metrics that will be written to ``stages.jsonl``.
+    """
+
+    def __init__(self, stage: str, *, extra: dict[str, Any] | None = None):
+        self.stage = stage
+        self.extra = extra or {}
+        self.t0: float | None = None
+        self.start: datetime | None = None
+
+    # ------------------------------------------------------------------
+    # Context manager API
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "Timer":  # pragma: no cover - trivial
         self.t0 = time.perf_counter()
-        logging.info(f"▶️  start: {self.name}")
+        self.start = datetime.now(timezone.utc)
+        logging.info("▶️  start: %s", self.stage)
         return self
 
-    def __exit__(self, exc_type, exc, tb):
-        dt = (time.perf_counter() - self.t0) * 1000
-        if exc:
-            logging.exception(f"❌ fail: {self.name} in {dt:.1f} ms")
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        assert self.t0 is not None and self.start is not None
+        end = datetime.now(timezone.utc)
+        dt_ms = int((time.perf_counter() - self.t0) * 1000)
+
+        record = {
+            "ts": end.isoformat(),
+            "stage": self.stage,
+            "elapsed_ms": dt_ms,
+            "start": self.start.isoformat(),
+            "end": end.isoformat(),
+            **self.extra,
+        }
+
+        stages_path = _RUN_DIR / "stages.jsonl" if _RUN_DIR else None
+
+        if exc_type:
+            logging.exception("❌ fail: %s in %d ms", self.stage, dt_ms)
+            record["level"] = "ERROR"
+            if _RUN_DIR:
+                err_file = _RUN_DIR / f"{self.stage}.err"
+                with err_file.open("w", encoding="utf-8") as fh:
+                    import traceback
+
+                    traceback.print_exception(exc_type, exc, tb, file=fh)
         else:
-            logging.info(f"✅ done: {self.name} in {dt:.1f} ms")
+            logging.info("✅ done: %s in %d ms", self.stage, dt_ms)
+            record["level"] = "INFO"
 
+        if stages_path:
+            with stages_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
-_DEF_FMT = "%(asctime)s | %(levelname)-7s | %(name)s | %(message)s"
+        return False  # do not suppress exceptions
 
-_def_handler = None
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def update(self, **metrics: Any) -> None:
+        """Add metrics to be stored when the context exits."""
+
+        self.extra.update(metrics)
+
+    # ------------------------------------------------------------------
+    # Decorator support
+    # ------------------------------------------------------------------
+    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        """Allow ``Timer"`` to be used as a decorator."""
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with Timer(self.stage, extra=self.extra.copy()):
+                return func(*args, **kwargs)
+
+        return wrapper
 
 
 def setup_logger(
-    run_id: str | None = None, level: str = _DEF_LEVEL, log_dir: str = "logs"
+    run_id: str | None = None,
+    level: str = _DEF_LEVEL,
+    log_dir: str = "loglar",
 ) -> str:
-    global _def_handler
-    os.makedirs(log_dir, exist_ok=True)
-    stamp = run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
-    logfile = os.path.join(log_dir, f"colab_run_{stamp}.log")
+    """Initialise root logger and return main log file path.
+
+    A new run directory ``run_<timestamp>`` is created under ``log_dir``.
+    ``summary.txt`` within this directory is used as the main log file.
+    ``setup_logger`` also sets a module level ``_RUN_DIR`` used by
+    :class:`Timer`.
+    """
+
+    global _def_handler, _RUN_DIR
+
+    base = Path(log_dir)
+    base.mkdir(parents=True, exist_ok=True)
+
+    legacy_dir = Path("logs")
+    legacy_exists = legacy_dir.exists() and legacy_dir.is_dir() and legacy_dir != base
+    if legacy_exists:
+        try:
+            (legacy_dir / "migration.txt").write_text(
+                "Log dizini 'loglar/' olarak değişti.\n",
+                encoding="utf-8",
+            )
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    stamp = run_id or datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = base / f"run_{stamp}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    logfile = run_dir / "summary.txt"
 
     root = logging.getLogger()
     root.setLevel(getattr(logging, level, logging.INFO))
@@ -57,5 +171,29 @@ def setup_logger(
     _def_handler.setFormatter(logging.Formatter(_DEF_FMT))
     root.addHandler(_def_handler)
 
-    logging.info(f"Log file: {logfile}")
-    return logfile
+    logging.info("Log dir: %s", run_dir)
+    if legacy_exists:
+        logging.warning("legacy logs/ directory detected; please migrate to loglar/")
+
+    _RUN_DIR = run_dir
+    return str(logfile)
+
+
+def purge_old_logs(days: int = 7, log_dir: str = "loglar") -> list[str]:
+    """Remove run directories older than ``days`` and return removed paths."""
+
+    base = Path(log_dir)
+    if not base.exists():
+        return []
+
+    cutoff = datetime.now() - timedelta(days=days)
+    removed: list[str] = []
+    for d in base.glob("run_*"):
+        try:
+            if d.is_dir() and datetime.fromtimestamp(d.stat().st_mtime) < cutoff:
+                shutil.rmtree(d, ignore_errors=True)
+                removed.append(str(d))
+        except Exception:  # pragma: no cover - best effort
+            pass
+    return removed
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,13 +1,73 @@
+import json
 import logging
 import os
+import time
+from pathlib import Path
 
-from backtest.logging_utils import setup_logger
-from backtest.logging_utils import Timer
+import pytest
+
+from backtest.logging_utils import Timer, purge_old_logs, setup_logger
 
 
-def test_setup_logger_creates_file(tmp_path):
-    log_dir = tmp_path / "logs"
-    path = setup_logger(run_id="test", log_dir=str(log_dir))
-    assert os.path.exists(path)
-    with Timer("unit-step"):
-        logging.info("hello")
+def _run_dir_from_logfile(logfile: str) -> Path:
+    return Path(logfile).parent
+
+
+def test_logs_dir_default(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    logfile = setup_logger(run_id="t1")
+    run_dir = _run_dir_from_logfile(logfile)
+    assert run_dir.parent.name == "loglar"
+    assert run_dir.name.startswith("run_")
+    assert Path(logfile).exists()
+
+
+def test_timer_records_stage(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    logfile = setup_logger(run_id="t2")
+    with Timer("load_data") as t:
+        t.update(rows=1, cols=2)
+    run_dir = _run_dir_from_logfile(logfile)
+    stage_file = run_dir / "stages.jsonl"
+    assert stage_file.exists()
+    data = json.loads(stage_file.read_text().splitlines()[0])
+    assert data["stage"] == "load_data"
+    assert data["rows"] == 1 and data["cols"] == 2
+
+
+def test_error_logging(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    logfile = setup_logger(run_id="t3")
+    with pytest.raises(RuntimeError):
+        with Timer("boom"):
+            raise RuntimeError("boom")
+    run_dir = _run_dir_from_logfile(logfile)
+    err_file = run_dir / "boom.err"
+    assert err_file.exists()
+    stage_line = json.loads((run_dir / "stages.jsonl").read_text().splitlines()[0])
+    assert stage_line["level"] == "ERROR"
+
+
+def test_purge_old_logs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    base = Path("loglar")
+    old_run = base / "run_old"
+    new_run = base / "run_new"
+    old_run.mkdir(parents=True)
+    new_run.mkdir(parents=True)
+    old_time = time.time() - 8 * 24 * 3600
+    os.utime(old_run, (old_time, old_time))
+    removed = purge_old_logs(days=7, log_dir=str(base))
+    assert str(old_run) in removed
+    assert not old_run.exists()
+    assert new_run.exists()
+
+
+def test_migration_warning(tmp_path, caplog, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    Path("logs").mkdir()
+    with caplog.at_level(logging.WARNING):
+        setup_logger(run_id="t4")
+    assert "legacy logs/ directory detected" in caplog.text
+    assert Path("logs/migration.txt").exists()
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -70,4 +70,3 @@ def test_migration_warning(tmp_path, caplog, monkeypatch):
         setup_logger(run_id="t4")
     assert "legacy logs/ directory detected" in caplog.text
     assert Path("logs/migration.txt").exists()
-


### PR DESCRIPTION
## Summary
- centralize logging under `loglar/run_*` directories with optional migration warning
- add `Timer` helper that records stage metrics and error traces to JSONL/err files
- introduce `purge_old_logs` to delete expired run directories

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dafbbbfb08325a8bf322d374ed6b1