### PR TITLE
Read BIST benchmark from static data file

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+import logging
 import warnings
 from pathlib import Path
 
 import pandas as pd
 
 from utils.paths import resolve_path
+
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_PATH = Path("/content/finansal-analiz-sistemi/data/BIST100.xlsx")
+if not _DEFAULT_PATH.exists():
+    _DEFAULT_PATH = (
+        Path(__file__).resolve().parent.parent / "data" / "BIST100.xlsx"
+    )
 
 
 def _read_csv_any(path: str | Path) -> pd.DataFrame:
@@ -38,41 +49,77 @@ def _read_csv_any(path: str | Path) -> pd.DataFrame:
         raise RuntimeError(f"CSV parse edilemedi: {p}") from e
 
 
-def load_xu100_pct(csv_path: str | Path) -> pd.Series:
-    if not isinstance(csv_path, (str, Path)):
-        raise TypeError("csv_path must be str or Path")
-    df = _read_csv_any(csv_path)
-    # En az iki kolon yoksa tarih ve fiyat ayrılamaz
-    if df.empty or df.shape[1] < 2:
-        warnings.warn(f"Boş CSV: {csv_path}")
+def load_xu100_pct(csv_path: str | Path | None = None) -> pd.Series:
+    """Load BIST100 benchmark returns.
+
+    Parameters
+    ----------
+    csv_path : str | Path | None, optional
+        Optional path to the benchmark file.  If not provided the function
+        uses a statically defined repository path.
+
+    Returns
+    -------
+    pd.Series
+        Daily percentage returns. Empty on failure.
+    """
+
+    path = Path(csv_path) if csv_path is not None else _DEFAULT_PATH
+    try:
+        if path.suffix.lower() == ".csv":
+            df = _read_csv_any(path)
+        elif path.suffix.lower() in {".xlsx", ".xls"}:
+            df = pd.read_excel(path)
+        elif path.suffix.lower() == ".parquet":
+            df = pd.read_parquet(path)
+        else:
+            raise FileNotFoundError
+    except Exception:
+        msg = f"BIST benchmark dosyası okunamadı: {path}"
+        warnings.warn(msg)
+        logger.warning(msg)
         return pd.Series(dtype=float)
+
+    if df.empty or df.shape[1] < 2:
+        warnings.warn(f"Boş CSV: {path}")
+        logger.warning("Boş CSV: %s", path)
+        return pd.Series(dtype=float)
+
     cols = {c.lower().strip(): c for c in df.columns}
-    # date column
-    c_date = cols.get("date") or cols.get("tarih") or list(df.columns)[0]
-    # close-like column
-    cand = (
-        "close",
-        "kapanış",
-        "kapanis",
-        "adjclose",
-        "adj_close",
-        "kapanis_tl",
-        "fiyat",
-    )
-    close_col = None
-    for k in cand:
-        if k in cols:
-            close_col = cols[k]
+    # alias mapping for benchmark column
+    for alias in ["bist", "bist100"]:
+        if alias in cols:
+            df = df.rename(columns={cols[alias]: "bist"})
+            cols = {c.lower().strip(): c for c in df.columns}
             break
-    if close_col is None:
-        # fallback: second column (df has >=2 columns here)
-        close_col = list(df.columns)[1]
-    # parse date tolerant
-    df[c_date] = pd.to_datetime(
-        df[c_date], errors="coerce", dayfirst=True
-    ).dt.normalize()
-    df[close_col] = pd.to_numeric(df[close_col], errors="coerce")
-    df = df.dropna(subset=[c_date, close_col]).sort_values(c_date)
-    pct = df[close_col].pct_change(1) * 100.0
-    pct.index = df[c_date]
+
+    date_col = cols.get("date") or cols.get("tarih") or list(df.columns)[0]
+    value_col = "bist" if "bist" in df.columns else None
+    if value_col is None:
+        cand = (
+            "close",
+            "kapanış",
+            "kapanis",
+            "adjclose",
+            "adj_close",
+            "kapanis_tl",
+            "fiyat",
+        )
+        for k in cand:
+            if k in cols:
+                value_col = cols[k]
+                break
+    if value_col is None and len(df.columns) > 1:
+        value_col = list(df.columns)[1]
+    if value_col is None:
+        msg = f"BIST kolon bulunamadı: {path}"
+        warnings.warn(msg)
+        logger.warning(msg)
+        return pd.Series(dtype=float)
+
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce", dayfirst=True).dt.normalize()
+    df[value_col] = pd.to_numeric(df[value_col], errors="coerce")
+    df = df.dropna(subset=[date_col, value_col]).sort_values(date_col)
+    pct = df[value_col].pct_change(1) * 100.0
+    pct.index = df[date_col]
     return pct

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -168,14 +168,12 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
     else:
         pivot = pd.DataFrame(columns=[*days, "Ortalama", "TradeCount"])
         winrate = pd.DataFrame(columns=[*days, "Ortalama"])
-    xu100_pct = None
-    if cfg.benchmark.xu100_source == "csv" and cfg.benchmark.xu100_csv_path:
-        s = load_xu100_pct(cfg.benchmark.xu100_csv_path)
-        xu100_pct = {
-            d: float(s.get(d, float("nan")))
-            for d in pivot.columns
-            if d not in {"Ortalama", "TradeCount"}
-        }
+    s = load_xu100_pct()
+    xu100_pct = {
+        d: float(s.get(d, float("nan")))
+        for d in pivot.columns
+        if d not in {"Ortalama", "TradeCount"}
+    } if not s.empty else {}
     out_dir = resolve_path(cfg.project.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     if per_day_output:

--- a/tests/test_benchmark_alias.py
+++ b/tests/test_benchmark_alias.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import pytest
+
+from backtest.benchmark import load_xu100_pct
+
+
+def test_alias_handling(tmp_path):
+    df = pd.DataFrame({"Tarih": ["2024-01-01", "2024-01-02"], "BIST100": [100, 110]})
+    xlsx = tmp_path / "bist.xlsx"
+    df.to_excel(xlsx, index=False)
+    series = load_xu100_pct(xlsx)
+    assert len(series) == 2
+    assert series.iloc[1] == pytest.approx(10.0)
+

--- a/tests/test_benchmark_paths.py
+++ b/tests/test_benchmark_paths.py
@@ -5,5 +5,6 @@ from backtest.benchmark import load_xu100_pct
 
 def test_load_xu100_pct_missing_file(tmp_path):
     missing = tmp_path / "missing.csv"
-    with pytest.raises(FileNotFoundError):
-        load_xu100_pct(missing)
+    with pytest.warns(UserWarning):
+        s = load_xu100_pct(missing)
+    assert s.empty


### PR DESCRIPTION
## Summary
- read BIST100 benchmark returns from a repository `data/BIST100.xlsx` file with column aliases
- always attempt to load benchmark in the CLI and fill `xu100_pct` mapping
- warn instead of error when benchmark file or columns are missing
- add tests for missing file, alias handling, and update existing benchmark tests

## Testing
- `pytest tests/test_benchmark_paths.py tests/test_benchmark_delimiter.py tests/test_benchmark_alias.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689faa44b5d08325a8e7cca699d1f999