### PR TITLE
Read indicators directly from data files

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -243,7 +243,14 @@ def read_excels_long(
             with pd.ExcelFile(fpath, engine=engine_to_use) as xls:
                 for sheet in xls.sheet_names:
                     try:
-                        df = xls.parse(sheet_name=sheet, header=0)
+                        try:
+                            df = xls.parse(
+                                sheet_name=sheet,
+                                header=0,
+                                dtype_backend="numpy_nullable",
+                            )
+                        except TypeError:
+                            df = xls.parse(sheet_name=sheet, header=0)
                         if df is None or df.empty:
                             continue
                         df = normalize_columns(df, price_schema=price_schema)

--- a/backtest/indicators.py
+++ b/backtest/indicators.py
@@ -38,5 +38,6 @@ def compute_indicators(
         raise ValueError(
             "Gösterge hesaplaması politika gereği devre dışı (engine='none')."
         )
-    logger.info("indicators: engine=none (policy lock), no computation")
+    logger.info("indicators: using-from-data")
+    logger.info("indicators: engine=none (using-from-data)")
     return df

--- a/backtest/naming.py
+++ b/backtest/naming.py
@@ -35,10 +35,33 @@ _ALIAS_PAIRS: Dict[str, List[str]] = {
     "adx_14": ["ADX14", "ADX_14"],
     "dmp_14": ["positivedirectionalindicator_14"],
     "dmn_14": ["negativedirectionalindicator_14"],
-    "stoch_k": ["STOCHK", "STOCH_k", "stochK"],
-    "stoch_d": ["STOCHD", "stochD"],
-    "stochrsi_k": ["STOCHRSIk", "STOCHRSI_k"],
-    "stochrsi_d": ["STOCHRSId", "STOCHRSI_d"],
+    "stoch_k": ["STOCHK", "STOCH_k", "stochK", "stoch %k", "stoch%k"],
+    "stoch_d": ["STOCHD", "stochD", "stoch %d", "stoch%d"],
+    "stochrsi_k": ["STOCHRSIk", "STOCHRSI_k", "stochrsi %k", "stochrsi%k"],
+    "stochrsi_d": ["STOCHRSId", "STOCHRSI_d", "stochrsi %d", "stochrsi%d"],
+    "macd_line": ["MACD", "MACD_12_26_9", "MACD 12,26,9", "macd12269", "macd 12 26 9"],
+    "macd_signal": [
+        "MACDS",
+        "MACDS_12_26_9",
+        "MACD_SIGNAL",
+        "MACD Signal",
+        "macds 12,26,9",
+    ],
+    "bbm": ["BOLLINGER", "BOLLINGER_M", "Bollinger", "Bollinger_M", "bb_m"],
+    "bbu": [
+        "BOLLINGER_UPPER",
+        "Bollinger_Upper",
+        "BOLLINGERHIGH",
+        "bb_u",
+        "bb_upper",
+    ],
+    "bbl": [
+        "BOLLINGER_LOWER",
+        "Bollinger_Lower",
+        "BOLLINGERLOW",
+        "bb_l",
+        "bb_lower",
+    ],
 }
 
 

--- a/backtest/screener.py
+++ b/backtest/screener.py
@@ -277,6 +277,7 @@ def run_screener(
     if sides is None:
         sides = [None] * len(filters_df)
     valids = []
+    missing_cols_total: set[str] = set()
     for code, expr, grp, side in zip(
         filters_df["FilterCode"], filters_df["expr"], groups, sides
     ):
@@ -317,10 +318,16 @@ def run_screener(
                     missing=sorted(missing_cols),
                 )
                 raise ValueError(msg)
+            for col in sorted(missing_cols):
+                if col not in missing_cols_total:
+                    logger.warning("missing_column:{}", col)
+                    missing_cols_total.add(col)
             missing = ", ".join(sorted(missing_cols))
             logger.warning("skip filter: missing column {}", missing, code=code)
             continue
         valids.append((code, grp, side_norm, sq))
+    if missing_cols_total:
+        logger.info("missing_column_total: {}", len(missing_cols_total))
     out_frames = []
     for code, grp, side_norm, sq in valids:
         try:


### PR DESCRIPTION
## Summary
- preserve all spreadsheet columns when loading data, retrying without `dtype_backend` if needed
- map many indicator aliases (MACD, Bollinger Bands, Stoch, StochRSI) to normalized names
- log source-only indicator usage and track missing filter columns for concise warnings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fad7723588325b5102ff9cdccdfd2