### PR TITLE
Handle SystemExit logging level

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -358,5 +358,11 @@ if __name__ == "__main__":
     try:
         cli()
     except SystemExit as exc:
-        logging.exception("SystemExit: %s", exc)
+        code = getattr(exc, "code", 1)
+        if code == 0:
+            logging.info("Program başarıyla tamamlandı.")
+        else:
+            logging.error(
+                "Program %s kodu ile hata vererek sonlandı.", code
+            )
         raise


### PR DESCRIPTION
## Summary
- Avoid logging successful exits as errors in CLI entrypoint
- Emit info message for exit code 0 and error message for non-zero exits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689faf3090148325b7183912df9bc327