### PR TITLE
Consolidate logging under `loglar/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ __pycache__/
 *.pyc
 .ipynb_checkpoints/
 raporlar/
-logs/*
-!logs/.gitkeep
+loglar/*
+!loglar/.gitkeep

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ JSON Lines biçimindeki `stages.jsonl` dosyasına yazılır:
 ```
 
 Hatalar `ERROR` seviyesinde loglanır ve aynı klasörde `stage.err` olarak
-stacktrace ile saklanır. Önceki `logs/` dizini tespit edilirse köke
-`migration.txt` bırakılır ve konsola uyarı basılır.
+stacktrace ile saklanır.
 
 `purge_old_logs(days=7)` fonksiyonu çalıştırıldığında 7 günden eski
 `run_*` klasörleri otomatik olarak silinir.

--- a/README_COLAB.md
+++ b/README_COLAB.md
@@ -17,9 +17,9 @@ Aşağıdaki hücreler Colab ortamında projeyi kurar, ortamı doğrular ve örn
 import logging
 from backtest.logging_utils import setup_logger
 setup_logger()
-!echo "Kurulum başlıyor" | tee -a logs/colab_shell.log
-!pip install -r requirements_colab.txt 2>&1 | tee -a logs/colab_shell.log
-!pytest -q 2>&1 | tee -a logs/colab_shell.log
+!echo "Kurulum başlıyor" | tee -a loglar/colab_shell.log
+!pip install -r requirements_colab.txt 2>&1 | tee -a loglar/colab_shell.log
+!pytest -q 2>&1 | tee -a loglar/colab_shell.log
 ```
 
 > `tee -a` komutu hem ekrana hem dosyaya yazdırır.

--- a/backtest/logging_utils.py
+++ b/backtest/logging_utils.py
@@ -138,17 +138,6 @@ def setup_logger(
     base = Path(log_dir)
     base.mkdir(parents=True, exist_ok=True)
 
-    legacy_dir = Path("logs")
-    legacy_exists = legacy_dir.exists() and legacy_dir.is_dir() and legacy_dir != base
-    if legacy_exists:
-        try:
-            (legacy_dir / "migration.txt").write_text(
-                "Log dizini 'loglar/' olarak değişti.\n",
-                encoding="utf-8",
-            )
-        except Exception:  # pragma: no cover - best effort
-            pass
-
     stamp = run_id or datetime.now().strftime("%Y%m%d-%H%M%S")
     run_dir = base / f"run_{stamp}"
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -172,8 +161,6 @@ def setup_logger(
     root.addHandler(_def_handler)
 
     logging.info("Log dir: %s", run_dir)
-    if legacy_exists:
-        logging.warning("legacy logs/ directory detected; please migrate to loglar/")
 
     _RUN_DIR = run_dir
     return str(logfile)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -63,10 +63,10 @@ def test_purge_old_logs(tmp_path, monkeypatch):
     assert new_run.exists()
 
 
-def test_migration_warning(tmp_path, caplog, monkeypatch):
+def test_legacy_logs_dir_ignored(tmp_path, caplog, monkeypatch):
     monkeypatch.chdir(tmp_path)
     Path("logs").mkdir()
     with caplog.at_level(logging.WARNING):
         setup_logger(run_id="t4")
-    assert "legacy logs/ directory detected" in caplog.text
-    assert Path("logs/migration.txt").exists()
+    assert "legacy logs/ directory detected" not in caplog.text
+    assert not Path("logs/migration.txt").exists()


### PR DESCRIPTION
## Summary
- remove legacy `logs/` handling and warnings
- update tests and docs for unified `loglar/` directory
- adjust ignore rules and add `loglar/.gitkeep`

## Testing
- `pre-commit run --files .gitignore README.md README_COLAB.md backtest/logging_utils.py tests/test_logging.py loglar/.gitkeep`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fb9797a2483259c6cfa3ffd82b980