### PR TITLE
Use semicolon delimiter for filters.csv

### DIFF
--- a/filters.csv
+++ b/filters.csv
@@ -1,4 +1,4 @@
-﻿FilterCode;PythonQuery
+FilterCode;PythonQuery
 T2;(relative_volume > 1.0) and (change_1w_percent < 15.0) and (RSI_14 > 50) and (RSI_14 < 65) and (ADX_14 > 30) and (ADX_14 < 60) and (STOCHRSIk_14_14_3_3 < 20.0) and CROSSDOWN(STOCHRSId_14_14_3_3, STOCHRSIk_14_14_3_3)
 T3;(relative_volume > 1.5) and (RSI_14 > 50.0) and (MOM_10 > 1.0) and (SMA_5 < close) and (SMA_10 < close) and (SMA_200 < close)
 T5;(relative_volume > 1.3) and (RSI_14 > 55.0) and (EMA_5 < close) and (EMA_20 < EMA_5) and (EMA_50 < EMA_20) and (CCI_20_0.015 > 100.0) and (VWMA_20 < close) and (ITS_9 < IKS_26)

--- a/io_filters.py
+++ b/io_filters.py
@@ -15,6 +15,20 @@ from utils.paths import resolve_path
 REQUIRED_COLUMNS = {"FilterCode", "PythonQuery"}
 
 
+def read_filters_smart(path: str | Path) -> pd.DataFrame:
+    """Read ``filters.csv`` with strict delimiter but allow fallback detection.
+
+    Primarily attempts to read using semicolon delimiter and UTF-8 encoding. If
+    that fails (e.g., old files using commas), a second attempt with delimiter
+    inference is made using the Python engine.
+    """
+
+    try:
+        return pd.read_csv(path, sep=";", encoding="utf-8")
+    except Exception:
+        return pd.read_csv(path, sep=None, engine="python", encoding="utf-8")
+
+
 def load_filters_csv(path: str | Path) -> pd.DataFrame:
     """Load filters from CSV with validation and basic normalization.
 
@@ -38,7 +52,7 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     if not p.exists():
         raise FileNotFoundError(f"Filters CSV bulunamadı: {p}")
     try:
-        df = pd.read_csv(p, encoding="utf-8", sep=None, engine="python")
+        df = read_filters_smart(p)
     except Exception as exc:
         raise RuntimeError(f"Filters CSV parse edilemedi: {p}") from exc
 
@@ -60,4 +74,4 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
     return df
 
 
-__all__ = ["load_filters_csv"]
+__all__ = ["load_filters_csv", "read_filters_smart"]

--- a/tests/data/filters_empty.csv
+++ b/tests/data/filters_empty.csv
@@ -1,2 +1,2 @@
-FilterCode,PythonQuery,Group
-f1,,A
+FilterCode;PythonQuery;Group
+f1;;A

--- a/tests/data/filters_valid.csv
+++ b/tests/data/filters_valid.csv
@@ -1,3 +1,3 @@
-FilterCode,PythonQuery,Group
-f1,close > 0,A
-f2,volume > 0,B
+FilterCode;PythonQuery;Group
+f1;close > 0;A
+f2;volume > 0;B

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -28,7 +28,7 @@ def test_load_filters_semicolon(tmp_path):
 
 def test_load_filters_parse_error(tmp_path):
     csv_file = tmp_path / "filters.csv"
-    csv_file.write_text('FilterCode,PythonQuery\n"unclosed', encoding="utf-8")
+    csv_file.write_text('FilterCode;PythonQuery\n"unclosed', encoding="utf-8")
     with pytest.raises(RuntimeError):
         load_filters_csv(csv_file)
 
@@ -36,7 +36,7 @@ def test_load_filters_parse_error(tmp_path):
 def test_load_filters_duplicate_codes(tmp_path):
     csv_file = tmp_path / "filters.csv"
     csv_file.write_text(
-        "FilterCode,PythonQuery\nF1,close>0\nF1,close>1\n", encoding="utf-8"
+        "FilterCode;PythonQuery\nF1;close>0\nF1;close>1\n", encoding="utf-8"
     )
     with pytest.raises(RuntimeError):
         load_filters_csv(csv_file)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -77,7 +77,7 @@ data:
         encoding="utf-8",
     )
     (tmp_path / "filters.csv").write_text(
-        "FilterCode,PythonQuery\nF1,close > 0\n", encoding="utf-8"
+        "FilterCode;PythonQuery\nF1;close > 0\n", encoding="utf-8"
     )
     runner = CliRunner()
     result = runner.invoke(
@@ -132,7 +132,7 @@ def test_scan_day_case_insensitive(tmp_path, monkeypatch):
         ),
     )
     (tmp_path / "filters.csv").write_text(
-        "FilterCode,PythonQuery\nF1,close > 0\n", encoding="utf-8"
+        "FilterCode;PythonQuery\nF1;close > 0\n", encoding="utf-8"
     )
     _touch(tmp_path / "2025-03-07.XLSX")
     monkeypatch.setattr(cli, "load_config", lambda _: cfg)


### PR DESCRIPTION
## Summary
- enforce UTF-8 `filters.csv` with semicolon delimiter
- add defensive CSV loader that defaults to `sep=";"`
- update tests and sample CSVs to new delimiter

## Testing
- `pre-commit run --files io_filters.py tests/test_preflight.py tests/test_filters_validation.py`
- `python - <<'PY'
import pandas as pd
df = pd.read_csv("filters.csv", sep=';', encoding='utf-8')
assert {'FilterCode','PythonQuery'}.issubset(df.columns)
assert df.shape[1] == 2, df.columns
print('OK filters.csv:', df.shape)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2650e32708325aeda8fce0f1c35a8