### PR TITLE
Make preflight optional and canonicalize Excel columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ python -m backtest.cli scan-range --config config/colab_config.yaml --start 2022
 
 > `--config` **zorunludur**. Pozisyonel argüman **DEĞİLDİR**.
 
+## Test ve Preflight Kontrolü
+
+Kod değişikliklerinden sonra hızlı bir kontrol için aşağıdaki testi çalıştır:
+
+```bash
+pytest tests/smoke/test_loader_and_preflight.py -q
+```
+
+Preflight doğrulamasını atlamak için CLI'da `--no-preflight` bayrağını veya
+config dosyasında `preflight: false` ayarını kullanabilirsin:
+
+```bash
+python -m backtest.cli scan-range \
+  --config config_scan.yml \
+  --no-preflight \
+  --start 2024-01-02 --end 2024-01-05
+```
+
 ## Rapor ve Log Dizini
 
 Komutlar çalıştığında çıktı dosyaları `raporlar/` klasörüne, loglar ise her çalıştırma için ayrı bir alt klasör oluşturularak `loglar/` içine yazılır.

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -254,7 +254,10 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
 )
 @click.option("--csv-also/--no-csv", default=True, help="CSV de yaz")
 @click.option(
-    "--no-preflight", is_flag=True, default=False, help="Preflight kontrolünü atla"
+    "--no-preflight",
+    is_flag=True,
+    default=False,
+    help="Preflight kontrolünü atla (veya config'te preflight: false)",
 )
 @click.option(
     "--case-insensitive",
@@ -292,7 +295,8 @@ def scan_range(
     cfg.project.run_mode = "range"
     if case_insensitive:
         cfg.data.case_sensitive = False
-    if not no_preflight and cfg.project.start_date and cfg.project.end_date:
+    skip_preflight = no_preflight or not getattr(cfg, "preflight", True)
+    if not skip_preflight and cfg.project.start_date and cfg.project.end_date:
         start = pd.to_datetime(cfg.project.start_date).date()
         end = pd.to_datetime(cfg.project.end_date).date()
         days = [start + timedelta(days=i) for i in range((end - start).days + 1)]
@@ -322,7 +326,10 @@ def scan_range(
 @click.option("--holding-period", default=None, type=int)
 @click.option("--transaction-cost", default=None, type=float)
 @click.option(
-    "--no-preflight", is_flag=True, default=False, help="Preflight kontrolünü atla"
+    "--no-preflight",
+    is_flag=True,
+    default=False,
+    help="Preflight kontrolünü atla (veya config'te preflight: false)",
 )
 @click.option(
     "--case-insensitive",
@@ -352,7 +359,8 @@ def scan_day(
         cfg.project.transaction_cost = transaction_cost
     if case_insensitive:
         cfg.data.case_sensitive = False
-    if not no_preflight:
+    skip_preflight = no_preflight or not getattr(cfg, "preflight", True)
+    if not skip_preflight:
         d = pd.to_datetime(date_str).date()
         rep = preflight(
             cfg.data.excel_dir,

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -76,6 +76,7 @@ class ReportCfg(BaseModel):
 
 
 class RootCfg(BaseModel):
+    preflight: bool = True
     project: ProjectCfg
     data: DataCfg
     calendar: CalendarCfg = Field(default_factory=CalendarCfg)

--- a/config_scan.yml
+++ b/config_scan.yml
@@ -1,3 +1,4 @@
+preflight: false
 project:
   out_dir: raporlar
   run_mode: range

--- a/tests/smoke/test_loader_and_preflight.py
+++ b/tests/smoke/test_loader_and_preflight.py
@@ -1,0 +1,100 @@
+import pandas as pd
+from click.testing import CliRunner
+
+from backtest.data_loader import canonicalize_columns, read_excels_long
+from backtest import cli
+
+
+def test_duplicate_columns_collapsed():
+    df = pd.DataFrame(
+        {
+            "BBM_20_2.0": [1, 2, 3],
+            "BBM_20_2.1": [1, 2, 3],
+        }
+    )
+    out = canonicalize_columns(df)
+    assert "BBM_20_2" in out.columns
+    assert list(out.columns).count("BBM_20_2") == 1
+
+
+def test_alias_columns():
+    df = pd.DataFrame(
+        {
+            "CCI_20_0": [1, 2],
+            "PSARl_0": [3, 4],
+        }
+    )
+    out = canonicalize_columns(df)
+    assert "CCI_20_0.015" in out.columns
+    assert "PSARl_0.02_0.2" in out.columns
+
+
+def test_relative_volume_preserved(tmp_path):
+    data = pd.DataFrame(
+        {
+            "Tarih": ["2024-01-02"],
+            "Open": [1.0],
+            "High": [1.5],
+            "Low": [0.5],
+            "Close": [1.2],
+            "Volume": [1000],
+            "relative_volume": [1.1],
+        }
+    )
+    fpath = tmp_path / "sample.xlsx"
+    data.to_excel(fpath, sheet_name="AAA", index=False)
+    df = read_excels_long(tmp_path)
+    assert "relative_volume" in df.columns
+
+
+def test_no_preflight_flag(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "cfg.yml"
+    excel_dir = tmp_path / "data"
+    excel_dir.mkdir()
+    filters = tmp_path / "filters.csv"
+    filters.write_text("FilterCode;PythonQuery\n")
+    cfg_path.write_text(
+        (
+            "project:\n"
+            '  start_date: "2024-01-02"\n'
+            '  end_date: "2024-01-05"\n'
+            f"  out_dir: {tmp_path / 'out'}\n"
+            f"data:\n"
+            f"  excel_dir: {excel_dir}\n"
+            f"  filters_csv: {filters}\n"
+        )
+    )
+    runner = CliRunner()
+    monkeypatch.setattr(
+        cli,
+        "_run_scan",
+        lambda *a, **k: None,
+    )
+    called = {"flag": False}
+
+    def _pf(*a, **k):
+        called["flag"] = True
+
+        class Dummy:
+            warnings = ["Eksik dosyalar: ..."]
+            errors = []
+            suggestions = []
+
+        return Dummy()
+
+    monkeypatch.setattr(cli, "preflight", _pf)
+    result = runner.invoke(
+        cli.scan_range,
+        [
+            "--config",
+            str(cfg_path),
+            "--no-preflight",
+            "--start",
+            "2024-01-02",
+            "--end",
+            "2024-01-05",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Eksik dosyalar" not in result.output
+    assert called["flag"] is False


### PR DESCRIPTION
## Summary
- Add `preflight` config toggle and `--no-preflight` flag integration to skip preflight checks
- Remove Excel column filtering and normalize all column names with alias handling
- Wrap long lines in smoke test to satisfy flake8 max line length

## Testing
- `pre-commit run --all-files`
- `pytest tests/smoke/test_loader_and_preflight.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b218ce1c832598ca24cf3175dd49