### PR TITLE
Add synthetic dataset utilities and CLI scan tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Kod değişikliklerinden sonra hızlı bir kontrol için aşağıdaki testi çal
 
 ```bash
 pytest tests/smoke/test_loader_and_preflight.py -q
+pytest tests/e2e/test_scan_range.py -q
+pytest tests/smoke/test_cli_entrypoints.py -q
 ```
 
 Preflight doğrulamasını atlamak için CLI'da `--no-preflight` bayrağını veya
@@ -85,6 +87,9 @@ python -m backtest.cli scan-range --config config_scan.yml \
   --filters-path config/filters.csv \
   --reports-dir raporlar/
 ```
+
+Örnek tarama çok-gün bir Excel üzerinde çalışır, isteğe bağlı olarak preflight
+kontrolü atlanabilir ve `alias_uyumsuzluklar.csv` dosyasına alias raporu yazılır.
 
 ## Rapor ve Log Dizini
 

--- a/tests/_utils/synth_data.py
+++ b/tests/_utils/synth_data.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def make_price_frame(n: int = 10) -> pd.DataFrame:
+    """Return a deterministic price DataFrame.
+
+    Parameters
+    ----------
+    n:
+        Number of rows. Defaults to 10.
+    """
+    seq = list(range(1, n + 1))
+    dates = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": seq,
+            "high": seq,
+            "low": seq,
+            "close": seq,
+            "volume": seq,
+            "EMA_10": seq,
+            "RSI_14": seq,
+            "relative_volume": seq,
+            "BBM_20_2.0": seq,
+            "BBU_20_2.1": seq,
+        }
+    )
+    return df

--- a/tests/e2e/test_scan_range.py
+++ b/tests/e2e/test_scan_range.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import pandas as pd
+from click.testing import CliRunner
+from pathlib import Path
+from unittest.mock import patch
+
+from backtest import cli as bt_cli
+from tests._utils.synth_data import make_price_frame
+
+
+def test_scan_range_creates_alias_report(tmp_path: Path) -> None:
+    df = make_price_frame()
+    df.to_excel(tmp_path / "Veriler.xlsx", index=False)
+
+    filters_csv = tmp_path / "filters.csv"
+    filters_df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "expr": [
+                "EMA_10 > close",
+                "CROSSUP(EMA_10, close)",
+                "RSI_14 >= 5",
+                "BBM_20_2.0 < BBU_20_2.1",
+            ],
+            "FilterCode": ["F1", "F2", "F3", "F4"],
+            "PythonQuery": [
+                "EMA_10 > close",
+                "CROSSUP(EMA_10, close)",
+                "RSI_14 >= 5",
+                "BBM_20_2.0 < BBU_20_2.1",
+            ],
+        }
+    )
+    filters_df.to_csv(filters_csv, index=False)
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text(
+        f"""
+project:
+  out_dir: {tmp_path}
+  run_mode: range
+  start_date: '2024-01-01'
+  end_date: '2024-01-10'
+  holding_period: 1
+  transaction_cost: 0.0
+  stop_on_filter_error: false
+data:
+  excel_dir: {tmp_path}
+  filters_csv: {filters_csv}
+  enable_cache: false
+  price_schema:
+    date: ['date']
+    open: ['open']
+    high: ['high']
+    low: ['low']
+    close: ['close']
+    volume: ['volume']
+calendar:
+  tplus1_mode: price
+  holidays_source: none
+  holidays_csv_path: ''
+indicators:
+  engine: none
+  params: {{}}
+benchmark:
+  source: none
+  excel_path: ''
+  excel_sheet: BIST
+  csv_path: ''
+  column_date: date
+  column_close: close
+report:
+  percent_format: '0.00%'
+  daily_sheet_prefix: 'SCAN_'
+  summary_sheet_name: 'SUMMARY'
+""",
+        encoding="utf-8",
+    )
+
+    def _compile(src, dst):
+        df = pd.read_csv(src, sep=None, engine="python")
+        df = df.rename(columns={"id": "FilterCode", "expr": "PythonQuery"})
+        df = df[["FilterCode", "PythonQuery"]]
+        df.to_csv(dst, sep=";", index=False)
+
+    runner = CliRunner()
+    with patch("backtest.cli.compile_filters", _compile):
+        result = runner.invoke(
+            bt_cli.cli,
+            [
+                "scan-range",
+                "--config",
+                str(cfg_path),
+                "--no-preflight",
+                "--report-alias",
+                "--filters-path",
+                str(filters_csv),
+                "--reports-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0, result.stderr
+    report_file = tmp_path / "alias_uyumsuzluklar.csv"
+    assert report_file.exists()
+    report_txt = report_file.read_text()
+    assert "BBM_20_2.0" in report_txt and "BBM_20_2" in report_txt

--- a/tests/smoke/test_cli_entrypoints.py
+++ b/tests/smoke/test_cli_entrypoints.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+from click.testing import CliRunner
+from tests._utils.synth_data import make_price_frame
+from backtest import cli as bt_cli
+
+
+def test_scan_range_help_shows_options() -> None:
+    root = Path(__file__).resolve().parents[2]
+    env = {**os.environ, "PYTHONPATH": str(root)}
+    result = subprocess.run(
+        [sys.executable, "-m", "backtest.cli", "scan-range", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert "--report-alias" in result.stdout
+    assert "--filters-path" in result.stdout
+
+
+def test_scan_range_dry_run(tmp_path: Path) -> None:
+    df = make_price_frame(1)
+    df.to_excel(tmp_path / "AAA.xlsx", index=False)
+    filters_csv = tmp_path / "filters.csv"
+    pd.DataFrame(
+        {
+            "id": [1],
+            "expr": ["close > 0"],
+            "FilterCode": ["F1"],
+            "PythonQuery": ["close > 0"],
+        }
+    ).to_csv(filters_csv, index=False)
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            project:
+              out_dir: {tmp_path}
+              run_mode: range
+              start_date: '2024-01-01'
+              end_date: '2024-01-01'
+              holding_period: 1
+              transaction_cost: 0.0
+              stop_on_filter_error: false
+            data:
+              excel_dir: {tmp_path}
+              filters_csv: {filters_csv}
+              enable_cache: false
+            calendar:
+              tplus1_mode: price
+            indicators:
+              engine: none
+              params: {{}}
+            benchmark:
+              source: none
+              excel_path: ''
+              excel_sheet: BIST
+              csv_path: ''
+              column_date: date
+              column_close: close
+            report:
+              percent_format: '0.00%'
+              daily_sheet_prefix: 'SCAN_'
+              summary_sheet_name: 'SUMMARY'
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    def _compile(src, dst):
+        df = pd.read_csv(src, sep=None, engine="python")
+        df = df.rename(columns={"id": "FilterCode", "expr": "PythonQuery"})
+        df = df[["FilterCode", "PythonQuery"]]
+        df.to_csv(dst, sep=";", index=False)
+
+    runner = CliRunner()
+    with patch("backtest.cli.compile_filters", _compile):
+        result = runner.invoke(
+            bt_cli.cli,
+            ["scan-range", "--config", str(cfg_path), "--no-preflight"],
+        )
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add deterministic synthetic price frame builder
- cover scan-range CLI with alias report in end-to-end test
- add smoke tests for scan-range help and dry run options
- document new tests and alias reporting in README

## Testing
- `pre-commit run --files tests/e2e/test_scan_range.py tests/smoke/test_cli_entrypoints.py tests/_utils/synth_data.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4344ef2288325b3ea4068d00b9f67