### PR TITLE
fix: ensure tests import utilities correctly

### DIFF
--- a/tests/_utils/__init__.py
+++ b/tests/_utils/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["synth_data"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
-from __future__ import annotations
-
+import os
 import sys
-from pathlib import Path
 
-# Ensure the project root is on sys.path for imports
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.append(ROOT)

--- a/tests_utils/__init__.py
+++ b/tests_utils/__init__.py
@@ -1,0 +1,3 @@
+from tests._utils.synth_data import make_price_frame
+
+__all__ = ["make_price_frame"]


### PR DESCRIPTION
## Summary
- add package module for test utilities
- add back-compat shim for `tests_utils`
- simplify test path handling for pytest

## Testing
- `pre-commit run --files tests/_utils/__init__.py tests_utils/__init__.py tests/conftest.py tests/e2e/test_scan_range.py tests/smoke/test_cli_entrypoints.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a43f0b1868832595b5b9e549c8da8a