### PR TITLE
Fix test utility imports

### DIFF
--- a/tests/e2e/test_scan_range.py
+++ b/tests/e2e/test_scan_range.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
-import pandas as pd
-from click.testing import CliRunner
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
-from backtest import cli as bt_cli
-from tests._utils.synth_data import make_price_frame
+import pandas as pd
+from click.testing import CliRunner
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from backtest import cli as bt_cli  # noqa: E402
+from tests._utils.synth_data import make_price_frame  # noqa: E402
 
 
 def test_scan_range_creates_alias_report(tmp_path: Path) -> None:

--- a/tests/smoke/test_cli_entrypoints.py
+++ b/tests/smoke/test_cli_entrypoints.py
@@ -9,8 +9,13 @@ from unittest.mock import patch
 
 import pandas as pd
 from click.testing import CliRunner
-from tests._utils.synth_data import make_price_frame
-from backtest import cli as bt_cli
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from tests._utils.synth_data import make_price_frame  # noqa: E402
+from backtest import cli as bt_cli  # noqa: E402
 
 
 def test_scan_range_help_shows_options() -> None:


### PR DESCRIPTION
## Summary
- ensure test modules can locate helper utilities regardless of CWD
- stabilize CLI entrypoint test imports

## Testing
- `pre-commit run --files tests/e2e/test_scan_range.py tests/smoke/test_cli_entrypoints.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a450ad7ae48325966bc668506b5f9b