### PR TITLE
Fix pytest imports by packaging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ pip install -r requirements.txt
 python -m backtest.cli --help
 ```
 
+## Testleri Çalıştırma
+
+```bash
+pytest -q
+```
+
 ## Veri ve Filtre Dosyaları
 
 * **Excel klasörü**: `Veri/` (proje kökünde)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-q -ra"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
-import os
 import sys
+from pathlib import Path
 
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if ROOT not in sys.path:
-    sys.path.append(ROOT)
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- mark `tests` as a package and ensure root path is available via conftest
- configure pytest paths in `pyproject.toml`
- document running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4f608b2bc832598d01940b7f984f9