### PR TITLE
feat(cli): add path override precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,22 @@ python -m backtest.cli scan-day --config config/colab_config.yaml --date 2025-03
 python -m backtest.cli scan-range --config config/colab_config.yaml --start 2022-01-03 --end 2025-04-18
 ```
 
-> `--config` **zorunludur**. Pozisyonel argüman **DEĞİLDİR**.
+> `--config` opsiyoneldir (varsayılan: `config_scan.yml`). Pozisyonel argüman **DEĞİLDİR**.
+
+## Yol Öncelik Sırası
+
+`--config` ve `--filters-csv` gibi yol argümanları şu öncelik sırasıyla değerlendirilir:
+
+1. CLI argümanı
+2. YAML config içeriği
+3. Kod içi varsayılan (`config_scan.yml`, `filters.csv`)
+
+Hem mutlak hem göreli yollar desteklenir ve dahili olarak `Path(...).expanduser().resolve()` ile gerçek yola çevrilir.
+
+```bash
+python -m backtest.cli scan-range --filters-csv my/filters.csv
+```
+Yukarıdaki komutta `my/filters.csv` kullanılır; YAML veya varsayılan yol yok sayılır.
 
 ## Test ve Preflight Kontrolü
 
@@ -90,7 +105,7 @@ Filtre dosyasını temizlemek ve alias uyumsuzluklarını raporlamak için yeni 
 ```bash
 python -m backtest.cli scan-range --config config_scan.yml \
   --no-preflight --report-alias \
-  --filters-path config/filters.csv \
+  --filters-csv config/filters.csv \
   --reports-dir raporlar/
 ```
 

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -240,7 +240,13 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
 
 
 @cli.command("scan-range")
-@click.option("--config", "config_path", required=True, help="YAML config yolu")
+@click.option(
+    "--config",
+    "config_path",
+    default="config_scan.yml",
+    show_default=True,
+    help="YAML config yolu (CLI argümanı > varsayılan). Mutlak veya göreli yol",
+)
 @click.option("--start", "start_date", required=False, default=None, help="YYYY-MM-DD")
 @click.option("--end", "end_date", required=False, default=None, help="YYYY-MM-DD")
 @click.option("--holding-period", default=None, type=int)
@@ -267,7 +273,15 @@ def _run_scan(cfg, *, per_day_output: bool = False, csv_also: bool = True) -> No
     default=False,
     help="Dosya adlarında küçük/büyük harf farkını yok say",
 )
-@click.option("--filters-path", default="filters.csv", help="Filters CSV path")
+@click.option(
+    "--filters-csv",
+    "filters_csv",
+    default=None,
+    help=(
+        "Filters CSV yolu. Öncelik: CLI argümanı > YAML config > "
+        "varsayılan 'filters.csv'. Mutlak veya göreli yol"
+    ),
+)
 @click.option(
     "--reports-dir",
     default="raporlar/",
@@ -291,18 +305,19 @@ def scan_range(
     *,
     no_preflight=False,
     case_insensitive=False,
-    filters_path="filters.csv",
+    filters_csv=None,
     reports_dir="raporlar/",
     report_alias=False,
 ):
     set_name_normalization(name_normalization)
     try:
-        cfg = load_config(config_path)
+        cfg_path = Path(config_path).expanduser().resolve()
+        cfg = load_config(cfg_path)
     except Exception as exc:  # kullanıcı dostu mesaj
         logging.error(str(exc))
         raise click.ClickException(str(exc))
-    if filters_path:
-        cfg.data.filters_csv = filters_path
+    fc = filters_csv or getattr(cfg.data, "filters_csv", None) or "filters.csv"
+    cfg.data.filters_csv = str(Path(fc).expanduser().resolve())
     if report_alias:
         filters_df = load_filters(cfg.data.filters_csv)
         df_clean, report_df = clean_filters(filters_df)
@@ -357,10 +372,25 @@ def scan_range(
 
 
 @cli.command("scan-day")
-@click.option("--config", "config_path", required=True)
+@click.option(
+    "--config",
+    "config_path",
+    default="config_scan.yml",
+    show_default=True,
+    help="YAML config yolu (CLI argümanı > varsayılan). Mutlak veya göreli yol",
+)
 @click.option("--date", "date_str", required=True, help="YYYY-MM-DD")
 @click.option("--holding-period", default=None, type=int)
 @click.option("--transaction-cost", default=None, type=float)
+@click.option(
+    "--filters-csv",
+    "filters_csv",
+    default=None,
+    help=(
+        "Filters CSV yolu. Öncelik: CLI argümanı > YAML config > "
+        "varsayılan 'filters.csv'. Mutlak veya göreli yol"
+    ),
+)
 @click.option(
     "--no-preflight",
     is_flag=True,
@@ -379,14 +409,18 @@ def scan_day(
     holding_period,
     transaction_cost,
     *,
+    filters_csv=None,
     no_preflight=False,
     case_insensitive=False,
 ):
     try:
-        cfg = load_config(config_path)
+        cfg_path = Path(config_path).expanduser().resolve()
+        cfg = load_config(cfg_path)
     except Exception as exc:  # kullanıcı dostu mesaj
         logging.error(str(exc))
         raise click.ClickException(str(exc))
+    fc = filters_csv or getattr(cfg.data, "filters_csv", None) or "filters.csv"
+    cfg.data.filters_csv = str(Path(fc).expanduser().resolve())
     cfg.project.single_date = date_str
     cfg.project.run_mode = "single"
     if holding_period is not None:

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -26,7 +26,7 @@ class ProjectCfg(BaseModel):
 
 class DataCfg(BaseModel):
     excel_dir: str
-    filters_csv: str
+    filters_csv: str = "filters.csv"
     enable_cache: bool = False
     cache_parquet_path: Optional[str] = None
     corporate_actions_csv: Optional[str] = None
@@ -125,7 +125,7 @@ def load_config(path: str | Path) -> RootCfg:
     if isinstance(proj, dict) and proj.get("out_dir"):
         proj["out_dir"] = _join(proj.get("out_dir"))
     data = cfg.get("data", {}) if isinstance(cfg, dict) else {}
-    for req_key in ("excel_dir", "filters_csv"):
+    for req_key in ("excel_dir",):
         if not data.get(req_key):
             raise ValueError(
                 f"config.data.{req_key} zorunlu; "

--- a/tests/e2e/test_scan_range.py
+++ b/tests/e2e/test_scan_range.py
@@ -100,7 +100,7 @@ report:
                 str(cfg_path),
                 "--no-preflight",
                 "--report-alias",
-                "--filters-path",
+                "--filters-csv",
                 str(filters_csv),
                 "--reports-dir",
                 str(tmp_path),

--- a/tests/smoke/test_cli_entrypoints.py
+++ b/tests/smoke/test_cli_entrypoints.py
@@ -24,7 +24,7 @@ def test_scan_range_help_shows_options() -> None:
         env=env,
     )
     assert "--report-alias" in result.stdout
-    assert "--filters-path" in result.stdout
+    assert "--filters-csv" in result.stdout
 
 
 def test_scan_range_dry_run(tmp_path: Path) -> None:

--- a/tests/test_filters_cleanup.py
+++ b/tests/test_filters_cleanup.py
@@ -100,7 +100,7 @@ def test_cli_reports(tmp_path, monkeypatch, sample_filters_csv):
             "dummy.yml",
             "--no-preflight",
             "--report-alias",
-            "--filters-path",
+            "--filters-csv",
             str(filters_path),
             "--reports-dir",
             str(tmp_path),

--- a/tests/test_filters_csv_override.py
+++ b/tests/test_filters_csv_override.py
@@ -76,4 +76,3 @@ def test_filters_csv_cli_overrides_yaml(tmp_path):
         ],
     )
     assert res_cli.exit_code == 0, res_cli.output
-

--- a/tests/test_filters_csv_override.py
+++ b/tests/test_filters_csv_override.py
@@ -1,0 +1,79 @@
+import textwrap
+
+import pandas as pd
+from click.testing import CliRunner
+
+from backtest import cli
+
+
+def _write_cfg(tmp_path, filters_path):
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            project:
+              out_dir: {str(tmp_path)}
+              run_mode: range
+              start_date: '2024-01-01'
+              end_date: '2024-01-01'
+              holding_period: 1
+              transaction_cost: 0.0
+            data:
+              excel_dir: {str(tmp_path)}
+              filters_csv: {str(filters_path)}
+              enable_cache: false
+            calendar:
+              tplus1_mode: price
+            indicators:
+              engine: none
+              params: {{}}
+            benchmark:
+              source: none
+            report:
+              percent_format: '0.00%'
+              daily_sheet_prefix: 'SCAN_'
+              summary_sheet_name: 'SUMMARY'
+            """,
+        ),
+        encoding="utf-8",
+    )
+    return cfg_path
+
+
+def test_filters_csv_cli_overrides_yaml(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Tarih": ["2024-01-01"],
+            "Açılış": [10],
+            "Yüksek": [10],
+            "Düşük": [10],
+            "Kapanış": [10],
+            "Hacim": [100],
+        }
+    )
+    df.to_excel(tmp_path / "AAA.xlsx", index=False)
+    filters_yaml = tmp_path / "yaml.csv"
+    filters_yaml.write_text("FilterCode;PythonQuery\nF1;close > 0\n", encoding="utf-8")
+    filters_cli = tmp_path / "cli.csv"
+    filters_cli.write_text("FilterCode;PythonQuery\nF2;close > 0\n", encoding="utf-8")
+
+    cfg_yaml = _write_cfg(tmp_path, filters_yaml)
+    runner = CliRunner()
+    res_yaml = runner.invoke(
+        cli.scan_range, ["--config", str(cfg_yaml), "--no-preflight"]
+    )
+    assert res_yaml.exit_code == 0, res_yaml.output
+
+    cfg_bad = _write_cfg(tmp_path, tmp_path / "missing.csv")
+    res_cli = runner.invoke(
+        cli.scan_range,
+        [
+            "--config",
+            str(cfg_bad),
+            "--no-preflight",
+            "--filters-csv",
+            str(filters_cli),
+        ],
+    )
+    assert res_cli.exit_code == 0, res_cli.output
+


### PR DESCRIPTION
## Summary
- allow overriding config and filters CSV paths with CLI options
- resolve paths with Path.expanduser().resolve()
- document precedence of CLI > YAML > defaults and add tests

## Testing
- `pre-commit run --files backtest/cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a506d9bfa08325b88484d7de134d59