### PR TITLE
Standardize path error messages and stage logging

### DIFF
--- a/backtest/benchmark.py
+++ b/backtest/benchmark.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import pandas as pd
-
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 
 class BenchmarkLoader:
@@ -36,12 +33,22 @@ class BenchmarkLoader:
             path = Path(self.cfg.get("excel_path", ""))
             sheet = self.cfg.get("excel_sheet", "BIST")
             if not path.exists():
-                raise FileNotFoundError(f"benchmark excel not found: {path}")
+                msg = (
+                    f"benchmark excel not found: {path}. "
+                    "Config'te 'benchmark.excel_path' ayarını kontrol edin."
+                )
+                logger.error(msg)
+                raise FileNotFoundError(msg)
             df = pd.read_excel(path, sheet_name=sheet)
         elif src == "csv":
             path = Path(self.cfg.get("csv_path", ""))
             if not path.exists():
-                raise FileNotFoundError(f"benchmark csv not found: {path}")
+                msg = (
+                    f"benchmark csv not found: {path}. "
+                    "Config'te 'benchmark.csv_path' ayarını kontrol edin."
+                )
+                logger.error(msg)
+                raise FileNotFoundError(msg)
             df = pd.read_csv(path)
         else:
             raise ValueError(f"unknown benchmark source: {src}")
@@ -56,7 +63,7 @@ class BenchmarkLoader:
         if df.empty:
             raise ValueError("benchmark data empty")
         logger.info(
-            "benchmark loaded rows=%d first=%s last=%s",
+            "benchmark loaded rows={} first={} last={}",
             len(df),
             df["date"].iloc[0],
             df["date"].iloc[-1],

--- a/backtest/calendars.py
+++ b/backtest/calendars.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable, Optional, Set
 
 import pandas as pd
+from loguru import logger
 
 from utils.paths import resolve_path
 
@@ -30,7 +31,12 @@ def load_holidays_csv(path: str | Path) -> Set[pd.Timestamp]:
         raise TypeError("path must be a string or Path")
     p = resolve_path(path)
     if not p.exists():
-        raise FileNotFoundError(f"Tatil CSV bulunamadı: {p}")
+        msg = (
+            f"Tatil CSV bulunamadı: {p}. "
+            "Config'te 'calendar.holidays_csv_path' ayarını kontrol edin."
+        )
+        logger.error(msg)
+        raise FileNotFoundError(msg)
     try:
         h = pd.read_csv(p, encoding="utf-8")
     except Exception as e:

--- a/backtest/config.py
+++ b/backtest/config.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Literal
 import yaml
 from pydantic import BaseModel, Field
 import warnings
+from loguru import logger
 
 from utils.paths import resolve_path
 from .paths import resolve_under_root
@@ -88,7 +89,12 @@ class RootCfg(BaseModel):
 def load_config(path: str | Path) -> RootCfg:
     p = resolve_path(path)
     if not p.exists():
-        raise FileNotFoundError(f"Config bulunamadı: {p}")
+        msg = (
+            f"Config bulunamadı: {p}. "
+            "'--config' ile yol belirtin veya config şablonunu kontrol edin."
+        )
+        logger.error(msg)
+        raise FileNotFoundError(msg)
     with p.open("r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     if not isinstance(cfg, dict):

--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -297,7 +297,13 @@ def read_excels_long(
         cache_dir = excel_dir / ".cache"
 
     if not excel_dir or not excel_dir.exists():
-        raise FileNotFoundError(f"Excel klasörü bulunamadı: {excel_dir}")
+        msg = (
+            f"Excel klasörü bulunamadı: {excel_dir}. "
+            "Config'te 'data.excel_dir' yolunu kontrol edin "
+            "veya '--excel-dir' ile belirtin."
+        )
+        logger.error(msg)
+        raise FileNotFoundError(msg)
     if not excel_files:
         raise RuntimeError(f"'{excel_dir}' altında .xlsx bulunamadı.")
 

--- a/io_filters.py
+++ b/io_filters.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+from loguru import logger
 
 from utils.paths import resolve_path
 
@@ -50,7 +51,13 @@ def load_filters_csv(path: str | Path) -> pd.DataFrame:
 
     p = resolve_path(path)
     if not p.exists():
-        raise FileNotFoundError(f"Filters CSV bulunamadı: {p}")
+        msg = (
+            f"Filters CSV bulunamadı: {p}. "
+            "'--filters-csv' ile yol belirtin veya "
+            "config'te 'data.filters_csv' ayarını kontrol edin."
+        )
+        logger.error(msg)
+        raise FileNotFoundError(msg)
     try:
         df = read_filters_smart(p)
     except Exception as exc:

--- a/tests/test_benchmark_loader.py
+++ b/tests/test_benchmark_loader.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import pytest
 
+from loguru import logger
+
 from backtest.benchmark import BenchmarkLoader
 
 
@@ -16,6 +18,7 @@ def test_load_excel(tmp_path, caplog):
         "column_close": "close",
     }
     with caplog.at_level("INFO"):
+        logger.add(caplog.handler, level="INFO")
         loaded = BenchmarkLoader(cfg).load()
     assert list(loaded.columns) == ["date", "close"]
     assert len(loaded) == 2

--- a/tests/test_error_logs.py
+++ b/tests/test_error_logs.py
@@ -1,0 +1,39 @@
+import pytest
+from loguru import logger
+
+from io_filters import load_filters_csv
+from backtest.data_loader import read_excels_long
+from backtest.config import load_config
+
+
+def test_load_filters_csv_missing_logs(tmp_path, caplog):
+    missing = tmp_path / "missing.csv"
+    logger.add(caplog.handler, level="ERROR")
+    with pytest.raises(FileNotFoundError) as exc:
+        load_filters_csv(missing)
+    msg = str(exc.value)
+    assert str(missing) in msg
+    assert "--filters-csv" in msg
+    assert str(missing) in caplog.text
+
+
+def test_read_excels_long_missing_dir_logs(tmp_path, caplog):
+    missing_dir = tmp_path / "nope"
+    logger.add(caplog.handler, level="ERROR")
+    with pytest.raises(FileNotFoundError) as exc:
+        read_excels_long(str(missing_dir))
+    msg = str(exc.value)
+    assert str(missing_dir) in msg
+    assert "--excel-dir" in msg
+    assert str(missing_dir) in caplog.text
+
+
+def test_load_config_missing_logs(tmp_path, caplog):
+    missing = tmp_path / "cfg.yml"
+    logger.add(caplog.handler, level="ERROR")
+    with pytest.raises(FileNotFoundError) as exc:
+        load_config(missing)
+    msg = str(exc.value)
+    assert str(missing.resolve()) in msg
+    assert "--config" in msg
+    assert str(missing) in caplog.text


### PR DESCRIPTION
## Summary
- add loguru-based Timer with per-stage logging and total runtime summary
- clarify file path errors with actionable guidance for config, filters, holidays and data loading
- cover new logging behavior with tests for missing paths

## Testing
- `pre-commit run --files backtest/logging_utils.py io_filters.py backtest/calendars.py backtest/config.py backtest/data_loader.py backtest/benchmark.py backtest/cli.py tests/test_error_logs.py tests/test_benchmark_loader.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a51c34bec48325b8e896c0c8dfce7d