### PR TITLE
Add reproducible setup with constraints and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: colab-setup tests
+
+colab-setup:
+	pip install -r requirements.txt -c constraints.txt
+
+tests:
+	pytest -q

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Bu proje, BIST verileri üzerinde filtre bazlı tarama yaparak raporlar üretir.
 
 ```bash
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
-pip install -r requirements.txt
+make colab-setup
 python -m backtest.cli --help
 ```
 
 ## Testleri Çalıştırma
 
 ```bash
-pytest -q
+make tests
 ```
 
 ## Veri ve Filtre Dosyaları

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,13 @@
-numpy<2.0.0
+pandas==2.1.4
+numpy==1.26.4
+pandas-ta==0.3.14b0
+pandera==0.19.3
+loguru==0.7.3
+xlsxwriter==3.2.5
+typing-inspect==0.9.0
+pyarrow==21.0.0
+openpyxl==3.1.5
+tqdm==4.67.1
+python-dateutil==2.9.0.post0
+PyYAML==6.0.2
+click==8.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
-pandas==2.1.4
-numpy==1.26.4
-pyarrow>=14
-openpyxl>=3.1
-xlsxwriter>=3.2
-tqdm>=4.66
-python-dateutil>=2.8
-pandera>=0.18,<0.20
-loguru>=0.7
-PyYAML>=6.0.1
-click>=8.1
-pandas-ta==0.3.14b0
+-c constraints.txt
+pandas<3
+numpy<2
+pandas-ta<0.4
+pandera<0.20
+loguru<0.8
+xlsxwriter<4
+typing-inspect<1
+pyarrow<22
+openpyxl<4
+tqdm<5
+python-dateutil<3
+PyYAML<7
+click<9


### PR DESCRIPTION
## Summary
- Pin dependencies via constraints.txt and reference from requirements.txt
- Provide Makefile for environment setup and running tests
- Document make-based workflow in README

## Testing
- `make colab-setup`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68a5247e091c83258a65c7be070b8f2b