### PR TITLE
Configure pytest for deterministic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ make colab-setup
 python -m backtest.cli --help
 ```
 
-## Testleri Çalıştırma
+## Testler Nasıl Çalıştırılır?
 
 ```bash
-make tests
+pytest -q
 ```
 
 ## Veri ve Filtre Dosyaları

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,5 @@ classifiers = [
 testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "-q -ra"
+python_files = ["test_*.py"]
+python_functions = ["test_*"]

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -1,22 +1,26 @@
 import pytest
+from pathlib import Path
 
 from io_filters import load_filters_csv
 
 
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
 def test_load_filters_ok():
-    df = load_filters_csv("tests/data/filters_valid.csv")
+    df = load_filters_csv(DATA_DIR / "filters_valid.csv")
     assert list(df.columns) == ["FilterCode", "PythonQuery", "Group"]
     assert len(df) == 2
 
 
 def test_load_filters_empty_query():
     with pytest.raises(RuntimeError):
-        load_filters_csv("tests/data/filters_empty.csv")
+        load_filters_csv(DATA_DIR / "filters_empty.csv")
 
 
 def test_load_filters_missing_column():
     with pytest.raises(RuntimeError):
-        load_filters_csv("tests/data/filters_missing_col.csv")
+        load_filters_csv(DATA_DIR / "filters_missing_col.csv")
 
 
 def test_load_filters_semicolon(tmp_path):


### PR DESCRIPTION
## Summary
- ensure pytest loads tests deterministically from any directory
- update filters validation tests to resolve data paths relative to file
- document running tests via `pytest -q`

## Testing
- `pytest -q`
- `(cd tests && pytest -q)`

------
https://chatgpt.com/codex/tasks/task_e_68a5a9bcf698832582fdfcd79502e6b2