### PR TITLE
Add cross_up/down alias support and resilient filter loading

### DIFF
--- a/backtest/eval_env.py
+++ b/backtest/eval_env.py
@@ -6,7 +6,13 @@ from .cross import cross_up, cross_down, cross_over, cross_under
 def build_env(df: pd.DataFrame):
     env = {
         "CROSSUP": lambda a, b: cross_up(df[a], df[b]),
+        "crossup": lambda a, b: cross_up(df[a], df[b]),
         "CROSSDOWN": lambda a, b: cross_down(df[a], df[b]),
+        "crossdown": lambda a, b: cross_down(df[a], df[b]),
+        "CROSS_UP": lambda a, b: cross_up(df[a], df[b]),
+        "cross_up": lambda a, b: cross_up(df[a], df[b]),
+        "CROSS_DOWN": lambda a, b: cross_down(df[a], df[b]),
+        "cross_down": lambda a, b: cross_down(df[a], df[b]),
         "CROSSOVER": lambda a, level: cross_over(df[a], level),
         "CROSSUNDER": lambda a, level: cross_under(df[a], level),
     }

--- a/backtest/expr.py
+++ b/backtest/expr.py
@@ -14,6 +14,8 @@ from .cross import cross_down, cross_up
 ALLOWED_FUNCS: Dict[str, Callable[[pd.Series, pd.Series], pd.Series]] = {
     "CROSSUP": cross_up,
     "CROSSDOWN": cross_down,
+    "CROSS_UP": cross_up,
+    "CROSS_DOWN": cross_down,
 }
 
 COMPARATORS: Dict[type, Callable[[Any, Any], Any]] = {

--- a/backtest/query_parser.py
+++ b/backtest/query_parser.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from backtest.naming import normalize_name
+from .cross import cross_up, cross_down, cross_over, cross_under
 
 
 class SafeQuery:
@@ -48,9 +49,17 @@ class SafeQuery:
         "floor",
         "ceil",
         "CROSSUP",
+        "crossup",
         "CROSSDOWN",
+        "crossdown",
         "CROSSOVER",
+        "crossover",
         "CROSSUNDER",
+        "crossunder",
+        "CROSS_UP",
+        "cross_up",
+        "CROSS_DOWN",
+        "cross_down",
     }
 
     def __init__(self, expr: str):
@@ -120,6 +129,18 @@ class SafeQuery:
                 "exp": np.exp,
                 "floor": np.floor,
                 "ceil": np.ceil,
+                "CROSSUP": lambda a, b: cross_up(a, b),
+                "crossup": lambda a, b: cross_up(a, b),
+                "CROSSDOWN": lambda a, b: cross_down(a, b),
+                "crossdown": lambda a, b: cross_down(a, b),
+                "CROSSOVER": lambda a, level: cross_over(a, level),
+                "crossover": lambda a, level: cross_over(a, level),
+                "CROSSUNDER": lambda a, level: cross_under(a, level),
+                "crossunder": lambda a, level: cross_under(a, level),
+                "CROSS_UP": lambda a, b: cross_up(a, b),
+                "cross_up": lambda a, b: cross_up(a, b),
+                "CROSS_DOWN": lambda a, b: cross_down(a, b),
+                "cross_down": lambda a, b: cross_down(a, b),
             }
         )
         mask = pd.eval(self.expr, engine="python", parser="pandas", local_dict=env)

--- a/config/filters_config.py
+++ b/config/filters_config.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import csv
 from pathlib import Path
+
+from io_filters import read_filters_smart
 
 # Path to the filters definition file relative to the repository root
 _FILTERS_CSV = Path(__file__).resolve().parent.parent / "filters.csv"
@@ -17,11 +18,10 @@ def _load_filter_codes() -> list[str]:
     """
     if not _FILTERS_CSV.exists():
         return []
-    with _FILTERS_CSV.open(encoding="utf-8") as f:
-        reader = csv.DictReader(f, delimiter=";")
-        if "FilterCode" not in (reader.fieldnames or []):
-            raise ValueError("filters.csv missing 'FilterCode' column")
-        return [row["FilterCode"] for row in reader if row.get("FilterCode")]
+    df = read_filters_smart(_FILTERS_CSV)
+    if "FilterCode" not in df.columns:
+        raise ValueError("filters.csv missing 'FilterCode' column")
+    return df["FilterCode"].dropna().astype(str).tolist()
 
 
 FILTER_LIST: list[str] = _load_filter_codes()

--- a/io_filters.py
+++ b/io_filters.py
@@ -25,7 +25,10 @@ def read_filters_smart(path: str | Path) -> pd.DataFrame:
     """
 
     try:
-        return pd.read_csv(path, sep=";", encoding="utf-8")
+        df = pd.read_csv(path, sep=";", encoding="utf-8")
+        if {"FilterCode", "PythonQuery"}.issubset(df.columns):
+            return df
+        raise ValueError("incorrect delimiter")
     except Exception:
         return pd.read_csv(path, sep=None, engine="python", encoding="utf-8")
 

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -16,6 +16,12 @@ def test_crossdown():
     assert mask.tolist() == [False, False, True]
 
 
+def test_cross_up_alias():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
+    mask = evaluate(df, "cross_up(a, b)")
+    assert mask.tolist() == [False, False, True]
+
+
 def test_operators_series_series():
     df = pd.DataFrame({"ema_10": [1, 3, 2], "close": [2, 1, 2]})
     mask = evaluate(df, "EMA_10 > close")

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -211,6 +211,14 @@ def test_safequery_allows_math_funcs():
     assert out["x"].tolist() == [1.0, 2.0, 3.0]
 
 
+def test_safequery_allows_cross_up():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
+    q = SafeQuery("cross_up(a, b)")
+    assert q.is_safe
+    mask = q.get_mask(df)
+    assert mask.tolist() == [False, False, True]
+
+
 def test_filter_parser_normalization():
     q = SafeQuery("EMA20 > Close")
     assert q.names == {"ema_20", "close"}


### PR DESCRIPTION
## Summary
- allow `cross_up`/`cross_down` aliases in expression engine and query parser
- support comma-delimited `filters.csv` files via smart reader
- add regression tests for the new aliases

## Testing
- `pre-commit run --files backtest/query_parser.py io_filters.py config/filters_config.py backtest/expr.py backtest/eval_env.py tests/test_expr.py tests/test_query_parser.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a650d878a083258183eee5616ed701