### PR TITLE
fix(stage1): canonical indicators/columns + expr normalizer + preflight FR001 (stochrsi & mom)

### DIFF
--- a/backtest/filters/__init__.py
+++ b/backtest/filters/__init__.py
@@ -1,3 +1,0 @@
-from .engine import evaluate
-
-__all__ = ["evaluate"]

--- a/backtest/filters/deps.py
+++ b/backtest/filters/deps.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import io
+import keyword
+import tokenize
+from typing import Iterable, Set
+
+from .normalize_expr import normalize_expr
+
+
+def collect_series(expr: str | Iterable[str]) -> Set[str]:
+    """Collect series tokens referenced in *expr*.
+
+    ``expr`` may be a single expression string or an iterable of expressions.
+    The expression(s) are first normalised via :func:`normalize_expr` and then
+    tokenised.  All ``NAME`` tokens that are not Python keywords are returned as
+    a set of strings.
+    """
+
+    if isinstance(expr, str):
+        exprs = [expr]
+    else:
+        exprs = list(expr)
+
+    out: Set[str] = set()
+    for e in exprs:
+        norm = normalize_expr(e)
+        for tok in tokenize.generate_tokens(io.StringIO(norm).readline):
+            if tok.type == tokenize.NAME and tok.string not in keyword.kwlist:
+                out.add(tok.string)
+    return out
+
+
+__all__ = ["collect_series"]

--- a/backtest/filters/normalize_expr.py
+++ b/backtest/filters/normalize_expr.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+
+
+_LOGICAL = {"and": "&", "or": "|"}
+_COMPARATORS = {"<", ">", "<=", ">=", "==", "!="}
+
+
+def _collapse_underscores(s: str) -> str:
+    return re.sub(r"__+", "_", s)
+
+
+def normalize_expr(expr: str) -> str:
+    """Normalise a filter expression string.
+
+    * Convert logical operators ``and``/``or`` to ``&``/``|``
+      while preserving string literals.
+    * Fix common StochRSI token typos.
+    * Remove stray decimal fragments like ``name .015`` that may appear
+      before a comparison operator.
+    * Collapse multiple underscores.
+    """
+
+    tokens = list(tokenize.generate_tokens(io.StringIO(expr).readline))
+    out_tokens: list[tokenize.TokenInfo] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.type == tokenize.NAME:
+            val = tok.string
+            # logical ops
+            if val in _LOGICAL:
+                new_tok = tokenize.TokenInfo(
+                    type=tokenize.OP,
+                    string=_LOGICAL[val],
+                    start=tok.start,
+                    end=tok.end,
+                    line=tok.line,
+                )
+                out_tokens.append(new_tok)
+                i += 1
+                continue
+            # stochrsi typos
+            if val.startswith("stochrsik_"):
+                val = val.replace("stochrsik_", "stochrsi_k_")
+            elif val.startswith("stochrsid_"):
+                val = val.replace("stochrsid_", "stochrsi_d_")
+            tok = tok._replace(string=val)
+            out_tokens.append(tok)
+            # handle trailing .number fragments
+            if (
+                i + 1 < len(tokens)
+                and tokens[i + 1].type == tokenize.NUMBER
+                and tokens[i + 1].string.startswith(".")
+            ):
+                j = i + 2
+                while j < len(tokens) and tokens[j].type in (tokenize.NL, tokenize.NEWLINE, tokenize.INDENT, tokenize.DEDENT):
+                    j += 1
+                if j < len(tokens) and tokens[j].type == tokenize.OP and tokens[j].string in _COMPARATORS:
+                    i += 2
+                    continue
+        else:
+            out_tokens.append(tok)
+        i += 1
+
+    normalised = tokenize.untokenize(out_tokens)
+    normalised = _collapse_underscores(normalised)
+    normalised = re.sub(r"\s+(?=[<>]=?|==|!=)", " ", normalised)
+    return normalised
+
+
+__all__ = ["normalize_expr"]

--- a/backtest/filters/normalize_expr.py
+++ b/backtest/filters/normalize_expr.py
@@ -57,9 +57,18 @@ def normalize_expr(expr: str) -> str:
                 and tokens[i + 1].string.startswith(".")
             ):
                 j = i + 2
-                while j < len(tokens) and tokens[j].type in (tokenize.NL, tokenize.NEWLINE, tokenize.INDENT, tokenize.DEDENT):
+                while j < len(tokens) and tokens[j].type in (
+                    tokenize.NL,
+                    tokenize.NEWLINE,
+                    tokenize.INDENT,
+                    tokenize.DEDENT,
+                ):
                     j += 1
-                if j < len(tokens) and tokens[j].type == tokenize.OP and tokens[j].string in _COMPARATORS:
+                if (
+                    j < len(tokens)
+                    and tokens[j].type == tokenize.OP
+                    and tokens[j].string in _COMPARATORS
+                ):
                     i += 2
                     continue
         else:

--- a/backtest/indicators/compute.py
+++ b/backtest/indicators/compute.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def ensure_stochrsi(
+    df: pd.DataFrame, rsi_len: int, k: int, d: int, smooth: int
+) -> pd.DataFrame:
+    """Ensure StochRSI %K and %D columns exist on ``df``.
+
+    The resulting column names follow the pattern
+    ``stochrsi_k_{rsi_len}_{k}_{d}_{smooth}`` and ``stochrsi_d_{rsi_len}_{k}_{d}_{smooth}``.
+    """
+
+    k_col = f"stochrsi_k_{rsi_len}_{k}_{d}_{smooth}"
+    d_col = f"stochrsi_d_{rsi_len}_{k}_{d}_{smooth}"
+    if k_col in df.columns and d_col in df.columns:
+        return df
+
+    close = df["close"]
+    rsi = close.diff().pipe(
+        lambda s: s.clip(lower=0).ewm(alpha=1 / rsi_len).mean()
+        / (-s.clip(upper=0).ewm(alpha=1 / rsi_len).mean())
+    )
+    rsi = 100 - (100 / (1 + rsi))
+    min_rsi = rsi.rolling(k).min()
+    max_rsi = rsi.rolling(k).max()
+    stoch = (rsi - min_rsi) / (max_rsi - min_rsi)
+    stoch_k = stoch.rolling(smooth).mean()
+    stoch_d = stoch_k.rolling(d).mean()
+    df[k_col] = stoch_k
+    df[d_col] = stoch_d
+    return df
+
+
+def ensure_mom(df: pd.DataFrame, n: int) -> pd.DataFrame:
+    col = f"mom_{n}"
+    if col not in df.columns:
+        df[col] = df["close"].diff(n)
+    return df
+
+
+def ensure_roc(df: pd.DataFrame, n: int) -> pd.DataFrame:
+    col = f"roc_{n}"
+    if col not in df.columns:
+        df[col] = df["close"].pct_change(n)
+    return df
+
+
+__all__ = ["ensure_stochrsi", "ensure_mom", "ensure_roc"]

--- a/backtest/naming/__init__.py
+++ b/backtest/naming/__init__.py
@@ -7,6 +7,57 @@ from .normalize import (
 )
 from .legacy import *  # noqa: F401,F403
 
+import pandas as pd
+import warnings
+
+
+def canonicalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of ``df`` with canonicalised column names.
+
+    All column names are normalised to lower ``snake_case`` using
+    :func:`normalize_name` from the legacy naming helpers.  Duplicate columns
+    are handled carefully:
+
+    * If two columns normalise to the same name and contain identical data the
+      duplicate is dropped.
+    * If the data differs, the later column is suffixed with ``_2``, ``_3`` …
+      and a :class:`UserWarning` is emitted.
+    """
+
+    rename_map = {col: normalize_name(col) for col in df.columns}
+    out = df.rename(columns=rename_map).copy()
+
+    seen: dict[str, pd.Series] = {}
+    drops: list[int] = []
+    new_names = list(out.columns)
+    for i, col in enumerate(list(out.columns)):
+        if col not in seen:
+            seen[col] = out.iloc[:, i]
+            continue
+        first = seen[col]
+        current = out.iloc[:, i]
+        if first.equals(current):
+            drops.append(i)
+            continue
+        suffix = 2
+        new_name = f"{col}_{suffix}"
+        while new_name in seen:
+            suffix += 1
+            new_name = f"{col}_{suffix}"
+        warnings.warn(
+            f"duplicate column '{col}' renamed to '{new_name}'",
+            UserWarning,
+            stacklevel=2,
+        )
+        new_names[i] = new_name
+        seen[new_name] = current
+
+    keep = [i for i in range(len(new_names)) if i not in drops]
+    out = out.iloc[:, keep]
+    out.columns = [new_names[i] for i in keep]
+    return out
+
+
 __all__ = [
     "CANONICAL_BASE",
     "CANONICAL_SET",
@@ -15,4 +66,5 @@ __all__ = [
     "to_snake",
     "normalize_indicator_token",
     "normalize_dataframe_columns",
+    "canonicalize_columns",
 ]

--- a/backtest/pipeline/precompute.py
+++ b/backtest/pipeline/precompute.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+import pandas as pd
+
+from backtest.filters.deps import collect_series
+from backtest.indicators.compute import ensure_stochrsi, ensure_mom, ensure_roc
+
+_STOCHRSI_RE = re.compile(r"stochrsi_[kd]_(\d+)_(\d+)_(\d+)_(\d+)")
+_MOM_RE = re.compile(r"mom_(\d+)")
+_ROC_RE = re.compile(r"roc_(\d+)")
+
+
+def precompute_needed(df: pd.DataFrame, exprs: Iterable[str]) -> pd.DataFrame:
+    """Compute indicator series required by *exprs*.
+
+    Only a very small subset of indicators are supported (StochRSI, MOM and ROC)
+    to keep the dependency footprint minimal.
+    """
+
+    needed = collect_series(exprs)
+    for name in needed:
+        m = _STOCHRSI_RE.fullmatch(name)
+        if m:
+            rsi_len, k, d, smooth = map(int, m.groups())
+            df = ensure_stochrsi(df, rsi_len, k, d, smooth)
+            continue
+        m = _MOM_RE.fullmatch(name)
+        if m:
+            df = ensure_mom(df, int(m.group(1)))
+            continue
+        m = _ROC_RE.fullmatch(name)
+        if m:
+            df = ensure_roc(df, int(m.group(1)))
+            continue
+    return df
+
+
+__all__ = ["precompute_needed"]

--- a/backtest/preflight.py
+++ b/backtest/preflight.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import difflib
+from typing import Iterable
+
+import pandas as pd
+
+from backtest.filters.deps import collect_series
+
+
+class UnknownSeriesError(SystemExit):
+    pass
+
+
+def check_unknown_series(df: pd.DataFrame, exprs: Iterable[str]) -> None:
+    """Fail with FR001 if an expression references unknown series names."""
+
+    needed = collect_series(exprs)
+    missing = sorted(name for name in needed if name not in df.columns)
+    if not missing:
+        return
+
+    suggestions = {}
+    universe = list(df.columns)
+    for name in missing:
+        suggestions[name] = difflib.get_close_matches(name, universe, n=3)
+
+    lines = ["FR001: unknown series -> " + ", ".join(missing)]
+    for name, sugg in suggestions.items():
+        if sugg:
+            lines.append(f"  {name}: did you mean {', '.join(sugg)}?")
+    raise UnknownSeriesError("\n".join(lines))
+
+
+__all__ = ["check_unknown_series", "UnknownSeriesError"]

--- a/tests/test_expr_normalizer.py
+++ b/tests/test_expr_normalizer.py
@@ -1,0 +1,21 @@
+from backtest.filters.normalize_expr import normalize_expr
+
+
+def test_decimal_fragment_removed():
+    expr = "cci_20_0 .015 > 100"
+    assert normalize_expr(expr) == "cci_20_0 > 100"
+
+
+def test_logical_ops_and_or():
+    expr = "a and b or c"
+    assert normalize_expr(expr) == "a & b | c"
+
+
+def test_stochrsi_typos():
+    expr = "stochrsik_14_14_3_3 > 0.8"
+    assert normalize_expr(expr) == "stochrsi_k_14_14_3_3 > 0.8"
+
+
+def test_string_literals_preserved():
+    expr = 'col == "a and b" or flag'
+    assert normalize_expr(expr) == 'col == "a and b" | flag'

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -4,7 +4,11 @@ import pandas as pd
 import pandera as pa
 import pytest
 
-from backtest.naming import normalize_name, validate_columns_schema, canonicalize_columns
+from backtest.naming import (
+    normalize_name,
+    validate_columns_schema,
+    canonicalize_columns,
+)
 
 
 def test_alias_normalization_basic():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pandera as pa
 import pytest
 
-from backtest.naming import normalize_name, validate_columns_schema
+from backtest.naming import normalize_name, validate_columns_schema, canonicalize_columns
 
 
 def test_alias_normalization_basic():
@@ -49,3 +49,14 @@ def test_auto_fix_mode():
     assert skipped == ["ema_2_o"]
     assert "close" in fixed.columns
     assert "ema_2_o" not in fixed.columns
+
+
+def test_canonicalize_columns_drops_duplicates():
+    df = pd.DataFrame(
+        {
+            "BBM_20_2": [1, 2, 3],
+            "bbm_20_2": [1, 2, 3],
+        }
+    )
+    out = canonicalize_columns(df)
+    assert list(out.columns) == ["bbm_20_2"]

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 from backtest.precompute import Precomputer
+from backtest.pipeline.precompute import precompute_needed
 
 idx = pd.date_range("2024-01-01", periods=50, freq="B")
 
@@ -44,3 +45,13 @@ def test_cache_prevents_recompute():
     out2 = pc.precompute(out1, {"ema_20"})
     # cache çalıştığı için ikinci sefer hata/yeniden hesaplama olmamalı
     assert "ema_20" in out2.columns
+
+
+def test_precompute_stochrsi_mom_roc():
+    df = _df()
+    exprs = ["stochrsi_k_14_14_3_3 > 0.8", "mom_10 > 0", "roc_12 > 0"]
+    df = precompute_needed(df, exprs)
+    assert "stochrsi_k_14_14_3_3" in df.columns
+    assert "stochrsi_d_14_14_3_3" in df.columns
+    assert "mom_10" in df.columns
+    assert "roc_12" in df.columns


### PR DESCRIPTION
## Summary
- enforce lowercase snake_case indicator names and resolve duplicate columns
- normalize filter expressions and precompute required StochRSI, MOM and ROC series
- add preflight check for unknown series with did-you-mean suggestions

## Testing
- `pytest tests/test_expr_normalizer.py tests/test_precompute.py::test_precompute_stochrsi_mom_roc tests/test_preflight.py::test_unknown_series_detection tests/test_naming.py::test_canonicalize_columns_drops_duplicates -q`


------
https://chatgpt.com/codex/tasks/task_e_68a882b7e2b8832590ea1486fc966176