### PR TITLE
fix(stage1b): DSL crossup/crossdown desteği + safe-eval fallback + lag precompute

### DIFF
--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -1,0 +1,7 @@
+# Troubleshoot
+
+## "xxx" is not a supported function
+
+Bu hata, ifade içinde desteklenmeyen bir DSL fonksiyonu kullanıldığında görülür.
+Fonksiyon adını kontrol edin ve örneğin `crossup` veya `crossdown` gibi
+Desteklenen DSL fonksiyonlarını kullandığınızdan emin olun.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,6 @@
+# Usage
+
+## DSL Fonksiyonları
+
+- `crossup(a, b)`: `a` serisi `b` serisini aşağıdan yukarı kestiğinde `True` döner.
+- `crossdown(a, b)`: `a` serisi `b` serisini yukarıdan aşağı kestiğinde `True` döner.

--- a/backtest/filters/deps.py
+++ b/backtest/filters/deps.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import keyword
+import os
+import re
 import tokenize
 from typing import Iterable, Set
 
@@ -13,8 +15,8 @@ def collect_series(expr: str | Iterable[str]) -> Set[str]:
 
     ``expr`` may be a single expression string or an iterable of expressions.
     The expression(s) are first normalised via :func:`normalize_expr` and then
-    tokenised.  All ``NAME`` tokens that are not Python keywords are returned as
-    a set of strings.
+    tokenised.  All ``NAME`` tokens that are not Python keywords are returned
+    as a set of strings.
     """
 
     if isinstance(expr, str):
@@ -23,11 +25,28 @@ def collect_series(expr: str | Iterable[str]) -> Set[str]:
         exprs = list(expr)
 
     out: Set[str] = set()
+    cross_funcs = {"crossup", "crossdown"}
+    cross_re = re.compile(
+        r"cross(?:up|down)\(([^,]+),([^\)]+)\)",
+        re.I,
+    )
+    rewrite = os.getenv("CROSS_REWRITE") == "1"
     for e in exprs:
         norm = normalize_expr(e)
         for tok in tokenize.generate_tokens(io.StringIO(norm).readline):
-            if tok.type == tokenize.NAME and tok.string not in keyword.kwlist:
-                out.add(tok.string)
+            if tok.type == tokenize.NAME:
+                name = tok.string
+                if name in keyword.kwlist or name.lower() in cross_funcs:
+                    continue
+                out.add(name)
+        if rewrite:
+            # add lag dependencies for cross rewrite
+            norm_orig = normalize_expr(e, rewrite_cross=False)
+            for m in cross_re.finditer(norm_orig):
+                a = m.group(1).strip()
+                b = m.group(2).strip()
+                out.add(f"lag1__{a}")
+                out.add(f"lag1__{b}")
     return out
 
 

--- a/backtest/pipeline/precompute.py
+++ b/backtest/pipeline/precompute.py
@@ -6,18 +6,20 @@ from typing import Iterable
 import pandas as pd
 
 from backtest.filters.deps import collect_series
+from backtest.filters.normalize_expr import normalize_expr
 from backtest.indicators.compute import ensure_stochrsi, ensure_mom, ensure_roc
 
 _STOCHRSI_RE = re.compile(r"stochrsi_[kd]_(\d+)_(\d+)_(\d+)_(\d+)")
 _MOM_RE = re.compile(r"mom_(\d+)")
 _ROC_RE = re.compile(r"roc_(\d+)")
+_CROSS_RE = re.compile(r"cross(?:up|down)\(([^,]+),([^\)]+)\)", re.I)
 
 
 def precompute_needed(df: pd.DataFrame, exprs: Iterable[str]) -> pd.DataFrame:
     """Compute indicator series required by *exprs*.
 
-    Only a very small subset of indicators are supported (StochRSI, MOM and ROC)
-    to keep the dependency footprint minimal.
+    Only a very small subset of indicators are supported (StochRSI, MOM and
+    ROC) to keep the dependency footprint minimal.
     """
 
     needed = collect_series(exprs)
@@ -35,6 +37,18 @@ def precompute_needed(df: pd.DataFrame, exprs: Iterable[str]) -> pd.DataFrame:
         if m:
             df = ensure_roc(df, int(m.group(1)))
             continue
+
+    cross_args = set()
+    for expr in exprs:
+        norm = normalize_expr(expr, rewrite_cross=False)
+        for m in _CROSS_RE.finditer(norm):
+            a = m.group(1).strip()
+            b = m.group(2).strip()
+            cross_args.update([a, b])
+    for s in cross_args:
+        col = f"lag1__{s}"
+        if col not in df.columns:
+            df[col] = df[s].shift(1)
     return df
 
 

--- a/tests/test_cross_functions.py
+++ b/tests/test_cross_functions.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from backtest.cross import cross_up, cross_down
+from backtest.filters.engine import evaluate
+
+
+@pytest.mark.parametrize("rewrite", [0, 1])
+def test_crossup_crossdown(rewrite, monkeypatch):
+    if rewrite:
+        monkeypatch.setenv("CROSS_REWRITE", "1")
+    else:
+        monkeypatch.delenv("CROSS_REWRITE", raising=False)
+
+    df_up = pd.DataFrame({"a": [1, 2, 3, 2], "b": [3, 2, 1, 2]})
+    res_up = evaluate(df_up.copy(), "crossup(a, b)")
+    expected_up = cross_up(df_up["a"], df_up["b"])
+    pd.testing.assert_series_equal(res_up, expected_up)
+
+    df_down = pd.DataFrame({"a": [3, 2, 1, 2], "b": [1, 2, 3, 2]})
+    res_down = evaluate(df_down.copy(), "crossdown(a, b)")
+    expected_down = cross_down(df_down["a"], df_down["b"])
+    pd.testing.assert_series_equal(res_down, expected_down)

--- a/tests/test_precompute_lag.py
+++ b/tests/test_precompute_lag.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from backtest.pipeline.precompute import precompute_needed
+
+
+@pytest.mark.parametrize("rewrite", [0, 1])
+def test_precompute_lag(monkeypatch, rewrite):
+    if rewrite:
+        monkeypatch.setenv("CROSS_REWRITE", "1")
+    else:
+        monkeypatch.delenv("CROSS_REWRITE", raising=False)
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
+    exprs = ["crossup(a, b)", "crossdown(a, b)"]
+    df2 = precompute_needed(df.copy(), exprs)
+    assert "lag1__a" in df2.columns and "lag1__b" in df2.columns
+    pd.testing.assert_series_equal(
+        df2["lag1__a"],
+        df["a"].shift(1),
+        check_names=False,
+    )
+    pd.testing.assert_series_equal(
+        df2["lag1__b"],
+        df["b"].shift(1),
+        check_names=False,
+    )


### PR DESCRIPTION
Kapsam & İşler:

filters/normalize_expr.py

crossup(a,b) ve crossdown(a,b) çağrılarını tokenize et.

(Stage2 için) opsiyon: crossup(a,b) → (__lag1_a <= __lag1_b) & (a > b) şeklinde ifade dönüştürme (şimdilik off-by-default; feature-flag CROSS_REWRITE=1).

filters/deps.py

collect_series(expr) içine cross argümanlarını ekle (a, b).

Rewrite aktifse __lag1_a, __lag1_b’yi de dependency olarak döndür.

pipeline/precompute.py

precompute_needed(df, exprs) içinde cross argümanlarına ait lag(1) kolonlarını üret:

İsim: lag1__{series} (örn. lag1__close, lag1__ema_20)

Uygulama: df[f"lag1__{s}"] = df[s].shift(1)

filters/engine.py

(Bu Colab’ta verdiğim) safe-eval fallback: ifade cross* içeriyorsa eval(..., env={columns, crossup, crossdown}), aksi halde df.eval (engine="python").

Flag ile rewrite yolu açıksa, fallback’e gerek kalmadan doğrudan dönüştürülen ifade df.eval ile çalışır.

Testler

tests/test_cross_functions.py

Sentetik seriyle crossup ve crossdown beklenen sonuç üretir.

Rewrite açık/kapalı iki modda da yeşil.

tests/test_precompute_lag.py

lag1__* kolonları doğru ve NaN kaydırması beklenen.

Belge

USAGE.md → DSL fonksiyonları bölümüne crossup/crossdown ekle.

TROUBLESHOOT.md → “"xxx" is not a supported function” hatasının çözümü.

Kabul Kriteri:

Cross içeren filtre setiyle BIST30 kısa demo yeşil (preflight açık).

Rewrite açık & kapalı modda tüm testler yeşil.

Güvenlik: safe-eval sadece cross* çağrıları için; __builtins__ kapalı.

------
https://chatgpt.com/codex/tasks/task_e_68a893b57b908325819a072185a12e72