### PR TITLE
fix(stage2): DSL normalizer + crossover makroları + canonical isimler (tam geçiş) — filters.csv ile uyumlu, koda göç yolu açık

### DIFF
--- a/backtest/filters/deps.py
+++ b/backtest/filters/deps.py
@@ -2,22 +2,14 @@ from __future__ import annotations
 
 import io
 import keyword
-import os
-import re
 import tokenize
-from typing import Iterable, Set
+from typing import Iterable, List, Set, Tuple
 
 from .normalize_expr import normalize_expr
 
 
 def collect_series(expr: str | Iterable[str]) -> Set[str]:
-    """Collect series tokens referenced in *expr*.
-
-    ``expr`` may be a single expression string or an iterable of expressions.
-    The expression(s) are first normalised via :func:`normalize_expr` and then
-    tokenised.  All ``NAME`` tokens that are not Python keywords are returned
-    as a set of strings.
-    """
+    """Collect series tokens referenced in *expr*."""
 
     if isinstance(expr, str):
         exprs = [expr]
@@ -25,29 +17,30 @@ def collect_series(expr: str | Iterable[str]) -> Set[str]:
         exprs = list(expr)
 
     out: Set[str] = set()
-    cross_funcs = {"crossup", "crossdown"}
-    cross_re = re.compile(
-        r"cross(?:up|down)\(([^,]+),([^\)]+)\)",
-        re.I,
-    )
-    rewrite = os.getenv("CROSS_REWRITE") == "1"
     for e in exprs:
-        norm = normalize_expr(e)
+        norm, _ = normalize_expr(e)
         for tok in tokenize.generate_tokens(io.StringIO(norm).readline):
             if tok.type == tokenize.NAME:
                 name = tok.string
-                if name in keyword.kwlist or name.lower() in cross_funcs:
+                if name in keyword.kwlist or name.upper() in {"CROSSUP", "CROSSDOWN"}:
                     continue
                 out.add(name)
-        if rewrite:
-            # add lag dependencies for cross rewrite
-            norm_orig = normalize_expr(e, rewrite_cross=False)
-            for m in cross_re.finditer(norm_orig):
-                a = m.group(1).strip()
-                b = m.group(2).strip()
-                out.add(f"lag1__{a}")
-                out.add(f"lag1__{b}")
     return out
 
 
-__all__ = ["collect_series"]
+def collect_macros(expr: str | Iterable[str]) -> List[Tuple[str, str, str]]:
+    """Collect CROSSUP/CROSSDOWN macro calls from *expr*."""
+
+    if isinstance(expr, str):
+        exprs = [expr]
+    else:
+        exprs = list(expr)
+
+    macros: List[Tuple[str, str, str]] = []
+    for e in exprs:
+        _, m = normalize_expr(e)
+        macros.extend(m)
+    return macros
+
+
+__all__ = ["collect_series", "collect_macros"]

--- a/backtest/filters/functions.py
+++ b/backtest/filters/functions.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _as_series(df: pd.DataFrame, name: str) -> pd.Series:
+    return df[name]
+
+
+def make_crossup(a: pd.Series, b: pd.Series) -> pd.Series:
+    return (a.shift(1) <= b.shift(1)) & (a > b)
+
+
+def make_crossdown(a: pd.Series, b: pd.Series) -> pd.Series:
+    return (a.shift(1) >= b.shift(1)) & (a < b)
+
+
+__all__ = ["_as_series", "make_crossup", "make_crossdown"]

--- a/backtest/indicators/compute.py
+++ b/backtest/indicators/compute.py
@@ -47,4 +47,15 @@ def ensure_roc(df: pd.DataFrame, n: int) -> pd.DataFrame:
     return df
 
 
-__all__ = ["ensure_stochrsi", "ensure_mom", "ensure_roc"]
+def ensure_cci(df: pd.DataFrame, n: int) -> pd.DataFrame:
+    col = f"cci_{n}"
+    if col in df.columns:
+        return df
+    tp = (df["high"] + df["low"] + df["close"]) / 3
+    sma = tp.rolling(n).mean()
+    md = (tp - sma).abs().rolling(n).mean()
+    df[col] = (tp - sma) / (0.015 * md)
+    return df
+
+
+__all__ = ["ensure_stochrsi", "ensure_mom", "ensure_roc", "ensure_cci"]

--- a/tests/test_batch_runner.py
+++ b/tests/test_batch_runner.py
@@ -27,7 +27,7 @@ def _filters_df():
         {
             "FilterCode": ["F1", "F2"],
             "PythonQuery": [
-                "cross_up(close, ema_20)",
+                "CROSSUP(close, ema_20)",
                 "close > 10 and volume > 100",
             ],
         }

--- a/tests/test_cross_functions.py
+++ b/tests/test_cross_functions.py
@@ -15,9 +15,9 @@ def test_crossup_crossdown(rewrite, monkeypatch):
     df_up = pd.DataFrame({"a": [1, 2, 3, 2], "b": [3, 2, 1, 2]})
     res_up = evaluate(df_up.copy(), "crossup(a, b)")
     expected_up = cross_up(df_up["a"], df_up["b"])
-    pd.testing.assert_series_equal(res_up, expected_up)
+    pd.testing.assert_series_equal(res_up, expected_up, check_names=False)
 
     df_down = pd.DataFrame({"a": [3, 2, 1, 2], "b": [1, 2, 3, 2]})
     res_down = evaluate(df_down.copy(), "crossdown(a, b)")
     expected_down = cross_down(df_down["a"], df_down["b"])
-    pd.testing.assert_series_equal(res_down, expected_down)
+    pd.testing.assert_series_equal(res_down, expected_down, check_names=False)

--- a/tests/test_expr_normalizer.py
+++ b/tests/test_expr_normalizer.py
@@ -2,20 +2,20 @@ from backtest.filters.normalize_expr import normalize_expr
 
 
 def test_decimal_fragment_removed():
-    expr = "cci_20_0 .015 > 100"
-    assert normalize_expr(expr) == "cci_20_0 > 100"
+    expr = 'cci_20_0 .015 > 100'
+    assert normalize_expr(expr)[0] == 'cci_20 > 100'
 
 
 def test_logical_ops_and_or():
-    expr = "a and b or c"
-    assert normalize_expr(expr) == "a & b | c"
+    expr = 'a and b or c'
+    assert normalize_expr(expr)[0] == 'a & b | c'
 
 
 def test_stochrsi_typos():
-    expr = "stochrsik_14_14_3_3 > 0.8"
-    assert normalize_expr(expr) == "stochrsi_k_14_14_3_3 > 0.8"
+    expr = 'stochrsik_14_14_3_3 > 0.8'
+    assert normalize_expr(expr)[0] == 'stochrsi_k_14_14_3_3 > 0.8'
 
 
 def test_string_literals_preserved():
     expr = 'col == "a and b" or flag'
-    assert normalize_expr(expr) == 'col == "a and b" | flag'
+    assert normalize_expr(expr)[0] == 'col == "a and b" | flag'

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from backtest.precompute import Precomputer
 from backtest.pipeline.precompute import precompute_needed
+from backtest.filters.deps import collect_series
 
 idx = pd.date_range("2024-01-01", periods=50, freq="B")
 
@@ -50,7 +51,8 @@ def test_cache_prevents_recompute():
 def test_precompute_stochrsi_mom_roc():
     df = _df()
     exprs = ["stochrsi_k_14_14_3_3 > 0.8", "mom_10 > 0", "roc_12 > 0"]
-    df = precompute_needed(df, exprs)
+    series = collect_series(exprs)
+    df = precompute_needed(df, series)
     assert "stochrsi_k_14_14_3_3" in df.columns
     assert "stochrsi_d_14_14_3_3" in df.columns
     assert "mom_10" in df.columns

--- a/tests/test_precompute_lag.py
+++ b/tests/test_precompute_lag.py
@@ -1,27 +1,9 @@
 import pandas as pd
-import pytest
-
 from backtest.pipeline.precompute import precompute_needed
 
 
-@pytest.mark.parametrize("rewrite", [0, 1])
-def test_precompute_lag(monkeypatch, rewrite):
-    if rewrite:
-        monkeypatch.setenv("CROSS_REWRITE", "1")
-    else:
-        monkeypatch.delenv("CROSS_REWRITE", raising=False)
-
+def test_precompute_no_lag():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
-    exprs = ["crossup(a, b)", "crossdown(a, b)"]
-    df2 = precompute_needed(df.copy(), exprs)
-    assert "lag1__a" in df2.columns and "lag1__b" in df2.columns
-    pd.testing.assert_series_equal(
-        df2["lag1__a"],
-        df["a"].shift(1),
-        check_names=False,
-    )
-    pd.testing.assert_series_equal(
-        df2["lag1__b"],
-        df["b"].shift(1),
-        check_names=False,
-    )
+    df2 = precompute_needed(df.copy(), {"a", "b"})
+    assert "lag1__a" not in df2.columns
+    assert "lag1__b" not in df2.columns

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -213,7 +213,7 @@ def test_safequery_allows_math_funcs():
 
 def test_safequery_allows_cross_up():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
-    q = SafeQuery("cross_up(a, b)")
+    q = SafeQuery("CROSSUP(a, b)")
     assert q.is_safe
     mask = q.get_mask(df)
     assert mask.tolist() == [False, False, True]

--- a/tools/fix_filters_csv.py
+++ b/tools/fix_filters_csv.py
@@ -27,7 +27,7 @@ def lint_file(path: str | Path, inplace: bool = False) -> int:
     if "PythonQuery" not in df.columns:
         raise SystemExit("PythonQuery column missing")
 
-    norm = df["PythonQuery"].map(normalize_expr)
+    norm = df["PythonQuery"].map(lambda s: normalize_expr(s)[0])
     changed = norm != df["PythonQuery"]
     n_changed = int(changed.sum())
     if n_changed and not inplace:


### PR DESCRIPTION
## Summary
- normalize DSL expressions with logical op fixes, alias cleanup and CROSSUP/CROSSDOWN macro extraction
- evaluate filters via macro-expanded temporary series and new crossover helpers
- precompute indicator dependencies including CCI using collected series names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a6b02300832591863bc84d89c0cb