### PR TITLE
feat(preflight): CLI preflight validator + alias warnings + canonicalize tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
       - run: pip install openpyxl
       - run: pip install hypothesis
       - run: python tools/make_excel_fixtures.py
+      - run: python - <<'PY'
+from backtest.paths import EXCEL_DIR
+from backtest.filters.preflight import validate_filters
+from pathlib import Path
+validate_filters(Path('filters.csv') if Path('filters.csv').exists() else Path('config/filters.csv'), EXCEL_DIR)
+print('preflight passed')
+PY
       - name: Verify environment
         run: python tools/verify_env.py
       - name: Show versions

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ pytest tests/e2e/test_scan_range.py -q
 pytest tests/smoke/test_cli_entrypoints.py -q
 ```
 
-Preflight doğrulamasını atlamak için CLI'da `--no-preflight` bayrağını veya
-config dosyasında `preflight: false` ayarını kullanabilirsin:
+Preflight doğrulaması varsayılan olarak açıktır. İstersen CLI'da `--no-preflight`
+bayrağını veya config dosyasında `preflight: false` ayarını kullanabilirsin:
 
 ```bash
 python -m backtest.cli scan-range \
@@ -136,6 +136,14 @@ python -m backtest.cli scan-range --config config_scan.yml \
 
 Örnek tarama çok-gün bir Excel üzerinde çalışır, isteğe bağlı olarak preflight
 kontrolü atlanabilir ve `alias_uyumsuzluklar.csv` dosyasına alias raporu yazılır.
+
+## Filtre Kanonikleştirme Aracı
+
+`filters.csv` içindeki legacy alias'ları kanonik isimlere dönüştürmek için:
+
+```bash
+python tools/canonicalize_filters.py filters.csv filters_canonical.csv
+```
 
 ## Rapor ve Log Dizini
 

--- a/backtest/config/config.py
+++ b/backtest/config/config.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 from types import SimpleNamespace as NS
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 import copy
 import logging
 import warnings
 
 try:
     import yaml
-except Exception:  # pragma: no cover - yaml yoksa minik parser yerine hata verelim
+except Exception:  # pragma: no cover
+    # yaml yoksa minik parser yerine hata verelim
     yaml = None
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ _DEFAULT = {
         "daily_sheet_prefix": "SCAN_",
         "summary_sheet_name": "SUMMARY",
     },
+    "preflight": True,
 }
 
 
@@ -108,7 +110,8 @@ def _expand_paths(doc: dict, base: Path) -> dict:
     if doc.get("data", {}).get("filters_csv"):
         doc["data"]["filters_csv"] = _norm(doc["data"]["filters_csv"])
     if doc.get("data", {}).get("cache_parquet_path"):
-        doc["data"]["cache_parquet_path"] = _norm(doc["data"]["cache_parquet_path"])
+        cpp = doc["data"]["cache_parquet_path"]
+        doc["data"]["cache_parquet_path"] = _norm(cpp)
     if doc.get("calendar", {}).get("holidays_csv_path"):
         doc["calendar"]["holidays_csv_path"] = _norm(
             doc["calendar"]["holidays_csv_path"]

--- a/backtest/filters/preflight.py
+++ b/backtest/filters/preflight.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from pathlib import Path
+import csv
+import re
+import warnings
+import pandas as pd
+
+ALIAS = {
+    "its_9": "ichimoku_conversionline",
+    "iks_26": "ichimoku_baseline",
+    "macd_12_26_9": "macd_line",
+    "macds_12_26_9": "macd_signal",
+    "bbm_20 2": "bbm_20_2",
+    "bbu_20 2": "bbu_20_2",
+    "bbl_20 2": "bbl_20_2",
+}
+ALLOW_FUNCS = {"cross_up", "cross_down"}
+
+
+def _dataset_columns(excel_dir: Path) -> set[str]:
+    xls = sorted([p for p in (excel_dir).rglob("*.xlsx")])
+    assert xls, f"Preflight: Excel bulunamadı: {excel_dir}"
+    df = pd.ExcelFile(xls[0]).parse(0, nrows=0)
+    cols = set(map(str, df.columns))
+    return cols | {c.lower() for c in cols}
+
+
+def _tokens(expr: str) -> list[str]:
+    return re.findall(r"[A-Za-z_][A-Za-z0-9_]*", expr or "")
+
+
+def validate_filters(filters_csv: Path, excel_dir: Path) -> None:
+    cols = _dataset_columns(excel_dir)
+    bad: dict[str, set[str]] = {}
+    alias_used: dict[str, set[str]] = {}
+    with open(filters_csv, encoding="utf-8") as f:
+        rdr = csv.DictReader(f)
+        for row in rdr:
+            code = (row.get("FilterCode") or "").strip() or "<NO_CODE>"
+            expr = (row.get("PythonQuery") or "").strip()
+            toks = _tokens(expr)
+            for t in toks:
+                if t in ALIAS:
+                    alias_used.setdefault(code, set()).add(f"{t}->{ALIAS[t]}")
+                    continue
+                if t in ALLOW_FUNCS:
+                    continue
+                if t not in cols:
+                    bad.setdefault(code, set()).add(t)
+
+    if alias_used:
+        for k, vs in alias_used.items():
+            msg = f"Preflight: legacy alias in {k}: {sorted(vs)}"
+            warnings.warn(msg)
+
+    if bad:
+        msgs = [f"{k}: {sorted(v)}" for k, v in bad.items()]
+        msg = "Preflight failed. Unknown tokens:\n  " + "\n  ".join(msgs)
+        raise SystemExit(msg)

--- a/backtest/paths.py
+++ b/backtest/paths.py
@@ -1,4 +1,7 @@
+import os
 from pathlib import Path
+
+EXCEL_DIR = Path(os.getenv("EXCEL_DIR", "veri_guncel_fix"))
 
 
 def project_root_from_config(config_path: str | Path) -> Path:
@@ -10,7 +13,10 @@ def project_root_from_config(config_path: str | Path) -> Path:
     )
 
 
-def resolve_under_root(config_path: str | Path, maybe_path: str | Path) -> Path:
+def resolve_under_root(
+    config_path: str | Path,
+    maybe_path: str | Path,
+) -> Path:
     p = Path(maybe_path)
     if p.is_absolute():
         return p
@@ -18,4 +24,4 @@ def resolve_under_root(config_path: str | Path, maybe_path: str | Path) -> Path:
     return (root / p).resolve()
 
 
-__all__ = ["project_root_from_config", "resolve_under_root"]
+__all__ = ["project_root_from_config", "resolve_under_root", "EXCEL_DIR"]

--- a/config/colab_config.yaml
+++ b/config/colab_config.yaml
@@ -35,3 +35,4 @@ range:
 
 single:
   date: "2025-03-07"
+preflight: true

--- a/tests/integration/test_cli_preflight_flag.py
+++ b/tests/integration/test_cli_preflight_flag.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import backtest.cli as cli
+
+
+def test_cli_preflight_flag(monkeypatch, tmp_path):
+    df = pd.DataFrame({"close": [1]}, index=pd.to_datetime(["2025-03-07"]))
+    monkeypatch.setattr(cli, "read_excels_long", lambda src: df)
+    called = {}
+
+    def fake_validate(filters_csv, excel_dir):
+        called["preflight"] = True
+
+    monkeypatch.setattr(cli, "preflight_validate_filters", fake_validate)
+    monkeypatch.setattr(cli, "run_scan_range", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "list_output_files", lambda *a, **k: [])
+    args = [
+        "scan-range",
+        "--config",
+        "config/colab_config.yaml",
+        "--start",
+        "2025-03-07",
+        "--end",
+        "2025-03-09",
+        "--no-preflight",
+        "--out",
+        str(tmp_path),
+    ]
+    import pytest
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(args)
+    assert exc.value.code == 0
+    assert "preflight" not in called

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from pathlib import Path
+from backtest.filters.preflight import validate_filters
+
+
+def test_preflight_ok(tmp_path):
+    df = pd.DataFrame({"close": [1], "volume": [2]})
+    excel_dir = tmp_path / "excels"
+    excel_dir.mkdir()
+    df.to_excel(excel_dir / "sample.xlsx", index=False)
+    filters = Path("tests/data/filters_valid.csv")
+    validate_filters(filters, excel_dir)

--- a/tools/canonicalize_filters.py
+++ b/tools/canonicalize_filters.py
@@ -1,0 +1,33 @@
+import csv
+import re
+import sys
+from pathlib import Path
+
+ALIAS = {
+    "its_9": "ichimoku_conversionline",
+    "iks_26": "ichimoku_baseline",
+    "macd_12_26_9": "macd_line",
+    "macds_12_26_9": "macd_signal",
+    "bbm_20 2": "bbm_20_2",
+    "bbu_20 2": "bbu_20_2",
+    "bbl_20 2": "bbl_20_2",
+}
+
+
+def canonicalize_expr(expr: str) -> str:
+    out = expr or ""
+    for k, v in sorted(ALIAS.items(), key=lambda x: -len(x[0])):
+        out = re.sub(rf"\b{re.escape(k)}\b", v, out)
+    return out
+
+
+src = Path(sys.argv[1] if len(sys.argv) > 1 else "filters.csv")
+dst = Path(sys.argv[2] if len(sys.argv) > 2 else "filters_canonical.csv")
+rows = list(csv.DictReader(open(src, encoding="utf-8")))
+for r in rows:
+    r["PythonQuery"] = canonicalize_expr(r.get("PythonQuery", ""))
+with open(dst, "w", encoding="utf-8", newline="") as f:
+    w = csv.DictWriter(f, fieldnames=rows[0].keys())
+    w.writeheader()
+    w.writerows(rows)
+print(f"Canonical filters written to {dst}")


### PR DESCRIPTION
## Summary
- validate filter expressions against Excel columns before running scans
- warn on legacy filter aliases and provide canonicalization helper
- wire preflight checks into CLI and CI

## Testing
- `pre-commit run --files backtest/paths.py backtest/filters/preflight.py backtest/cli.py backtest/filters/engine.py tools/canonicalize_filters.py .github/workflows/ci.yml config/colab_config.yaml backtest/config/config.py tests/unit/test_preflight.py tests/integration/test_cli_preflight_flag.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a99e355f4883259c623b2c3ba52021