### PR TITLE
docs: README/USAGE/FAQ/TROUBLESHOOT + make check target (fixtures+preflight+lint+tests)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,21 @@
+# FAQ
+
+## Excel nereye konur?
+Excel dosyaları proje kökünde `Veri/` klasörüne yerleştirilir. Farklı bir konum kullanmak için `config` dosyasındaki `excel_dir` alanını veya `EXCEL_DIR` ortam değişkenini ayarlayın.
+
+## Fixtures nasıl üretilir?
+Test için küçük örnek veri setlerini oluşturmak üzere:
+
+```bash
+make fixtures
+```
+
+## Alias neden uyarı veriyor?
+Legacy kolon adları kullanıldığında, sistem bunları [docs/ALIAS_POLICY.md](docs/ALIAS_POLICY.md) politikasına göre kanonikleştirir ve uyarı mesajı gösterir.
+
+## Golden nasıl güncellenir?
+Test checksum'larını güncellemek için:
+
+```bash
+make golden
+```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: fixtures preflight test golden lint
+.PHONY: fixtures preflight test golden lint check dev
+actions = fixtures preflight lint test
+
 fixtures:
 	python tools/make_excel_fixtures.py
 preflight:
@@ -12,3 +14,10 @@ golden:
 
 lint:
 	python tools/lint_filters.py
+
+check:
+	$(MAKE) $(actions)
+
+dev:
+	pip install -r requirements.txt || true
+	pip install -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 Bu proje, BIST verileri üzerinde filtre bazlı tarama yaparak raporlar üretir.
 
+Kullanım için [USAGE.md](USAGE.md), sık sorular için [FAQ.md](FAQ.md) ve hata çözümü için [TROUBLESHOOT.md](TROUBLESHOOT.md) dosyalarına bakın.
+
 ## Hızlı Başlangıç (Lokal)
 
 ```bash
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
-make colab-setup
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
 python -m backtest.cli --help
 ```
 
@@ -22,9 +25,13 @@ python -m backtest.cli --help
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
-make fixtures preflight test
+make fixtures
+make preflight
+make test
 # Golden güncelleme gerektiğinde:
 make golden
+# Hepsini bir arada çalıştırmak için:
+make check
 ```
 
 ## Veri ve Filtre Dosyaları
@@ -118,6 +125,8 @@ Filtre motoru DataFrame kolonlarını bire bir kullanır ve her kolonun
 lower-case kopyasını otomatik olarak sağlar. Legacy isimler için aşağıdaki
 alias haritası geçerlidir; bu alias'lar kullanıldığında uyarı verilir ve
 değerlendirme kanonik isimler üzerinden yapılır:
+
+Detaylar için [docs/ALIAS_POLICY.md](docs/ALIAS_POLICY.md) ve kanonik kolon listesi için [docs/canonical_names.md](docs/canonical_names.md) dosyalarına bakın.
 
 * `its_9` → `ichimoku_conversionline`
 * `iks_26` → `ichimoku_baseline`

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -1,7 +1,21 @@
 # Troubleshoot
 
-## "xxx" is not a supported function
+## PermissionError: '/content'
+Colab'a özgü `/content` yolu yerel veya CI ortamında yazılabilir değildir. `paths.py` içindeki mantık gereği `EXCEL_DIR`'i ayarla ya da `CI=true` ortam değişkeni ile depo kökündeki `veri_guncel_fix/` dizini kullan.
 
-Bu hata, ifade içinde desteklenmeyen bir DSL fonksiyonu kullanıldığında görülür.
-Fonksiyon adını kontrol edin ve örneğin `crossup` veya `crossdown` gibi
-Desteklenen DSL fonksiyonlarını kullandığınızdan emin olun.
+## ModuleNotFoundError: hypothesis
+Testler sırasında `hypothesis` modülü bulunamazsa geliştirme bağımlılıklarını yükleyin:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+## filters.csv bulunamadı
+Filtre dosyası yol çözümü şu önceliği izler: CLI argümanı > YAML config > depo kökündeki `filters.csv`.
+
+```bash
+python -m backtest.cli scan-range --filters-csv config/filters.csv
+```
+
+## Preflight Unknown tokens
+Preflight raporu bilinmeyen token'lar gösteriyorsa filtre ifadelerindeki kolon adlarını kontrol edin. Alias kullanımının nasıl kanonikleştirildiği için [docs/ALIAS_POLICY.md](docs/ALIAS_POLICY.md) dosyasına bakın.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,45 @@
 # Usage
 
-## DSL Fonksiyonları
+## 1. Kurulum
 
-- `crossup(a, b)`: `a` serisi `b` serisini aşağıdan yukarı kestiğinde `True` döner.
-- `crossdown(a, b)`: `a` serisi `b` serisini yukarıdan aşağı kestiğinde `True` döner.
+```bash
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+## 2. Fixture üretimi
+
+```bash
+make fixtures
+```
+
+Bu komut `veri_guncel_fix/` altındaki Excel dosyalarından test için küçük örnekler oluşturur.
+
+## 3. Preflight
+
+```bash
+make preflight
+```
+
+Preflight, `filters.csv` içindeki token'ların Excel kolonlarıyla uyuştuğunu doğrular. Gerekirse CLI'da `--no-preflight` bayrağı veya YAML'da `preflight: false` ile atlanabilir.
+
+## 4. Taramayı çalıştır
+
+```bash
+python -m backtest.cli scan-range --config config_scan.yml --start 2025-03-07 --end 2025-03-11
+```
+
+### Filtre dosyası yol çözümü
+
+Yol önceliği: CLI argümanı > YAML config > proje varsayılanı (`filters.csv`).
+
+```bash
+python -m backtest.cli scan-range --filters-csv config/filters.csv --start 2025-03-07 --end 2025-03-11
+```
+
+`--filters-csv my/filters.csv` kullanıldığında YAML içeriği yok sayılır ve belirtilen dosya kullanılır.
+
+## 5. Sonuçlar
+
+Çalışma tamamlandığında raporlar `raporlar/` dizinine, loglar `loglar/` dizinine yazılır.

--- a/docs/ALIAS_POLICY.md
+++ b/docs/ALIAS_POLICY.md
@@ -1,0 +1,21 @@
+# Alias Policy
+
+Legacy indicator names are normalized to canonical forms before filter evaluation. Using a legacy alias emits a warning and the canonical name is used in computations.
+
+## Supported Legacy Names
+
+| Legacy | Canonical |
+| --- | --- |
+| its_9 | ichimoku_conversionline |
+| iks_26 | ichimoku_baseline |
+| macd_12_26_9 | macd_line |
+| macds_12_26_9 | macd_signal |
+| bbm_20 2 | bbm_20_2 |
+| bbu_20 2 | bbu_20_2 |
+| bbl_20 2 | bbl_20_2 |
+| CCI_20_0 | CCI_20 |
+| PSARL_0 | PSARL_0_02_0_2 |
+| AROONU_<n> | AROON_UP_<n> |
+| AROOND_<n> | AROON_DOWN_<n> |
+
+See [canonical_names.md](canonical_names.md) for the full list of canonical columns.


### PR DESCRIPTION
## Summary
- document setup and workflow in README, USAGE, FAQ and TROUBLESHOOT, with an alias policy table
- add Makefile check target to run fixtures, preflight, lint and tests together

## Testing
- `make check` *(fails: unknown tokens in filters.csv)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9a4c4bb2c8325a06305499c0f30b6