### PR TITLE
docs: note comma delimiter for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ make check
 ## Veri ve Filtre Dosyaları
 
 * **Excel klasörü**: `Veri/` (proje kökünde)
-* **filters.csv**: proje kökünde, ayracı `;`, başlıklar: `FilterCode;PythonQuery`
+* **filters.csv**: proje kökünde, ayracı `,` (otomatik algılama `;`'yi de kabul eder), başlıklar: `FilterCode,PythonQuery`
 
 Örnek satırlar:
 
 ```
-FilterCode;PythonQuery
-EX1; ichimoku_conversionline > ichimoku_baseline
-EX2; macd_line > macd_signal
+FilterCode,PythonQuery
+EX1, ichimoku_conversionline > ichimoku_baseline
+EX2, macd_line > macd_signal
 ```
 
 Excel klasör yolu config dosyasından okunur; CLI'da `--excel-dir` parametresi bulunmaz.

--- a/docs/colab.md
+++ b/docs/colab.md
@@ -20,7 +20,7 @@ print("OK: Kurulum bitti. Eğer NumPy/Pandas yükseldiyse Runtime → Restart ru
 !mkdir -p raporlar loglar config Veri cache
 from pathlib import Path
 if not Path("filters.csv").exists():
-    Path("filters.csv").write_text("FilterCode;PythonQuery\nEXAMPLE_01; (rsi_14 > 50) & (ema_20 > ema_50)\n", encoding="utf-8")
+    Path("filters.csv").write_text("FilterCode,PythonQuery\nEXAMPLE_01, (rsi_14 > 50) & (ema_20 > ema_50)\n", encoding="utf-8")
     print("⚠️ filters.csv örneği oluşturuldu. Kendi dosyanla değiştir.")
 ```
 


### PR DESCRIPTION
## Summary
- clarify that `filters.csv` uses comma delimiter and auto-detects semicolons
- update Colab bootstrap snippet accordingly

## Testing
- `pytest -q`
- `pre-commit run --files README.md docs/colab.md`

------
https://chatgpt.com/codex/tasks/task_e_68a9b9c992c88325a654a23d0ea59e55