### PR TITLE
ci/dev: automate golden checksum updates (make + pre-commit) and verify in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
       - run: pip install -r requirements.txt || true
       - run: pip install -r requirements-dev.txt
 
-      # Fixtures + preflight + test
+      # Fixtures + golden verification + preflight + test
       - run: make fixtures
+      - run: make golden-verify
       - run: PREFLIGHT_ALIAS_MODE=allow PREFLIGHT_ALLOW_UNKNOWN=1 make preflight
       - run: make test
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,12 @@ repos:
         types: [python]
         additional_dependencies: [pyflakes==3.4.0]
         language_version: python3.11
+  - repo: local
+    hooks:
+      - id: golden-update
+        name: golden-update (update tests/golden/checksums.json)
+        entry: python tools/update_golden_checksums.py
+        language: system
+        pass_filenames: false
+        stages: [commit]
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: fixtures preflight test golden lint check dev
-actions = fixtures preflight lint test
+.PHONY: fixtures preflight test golden golden-verify lint check dev
+actions = fixtures preflight lint test golden-verify
 
 fixtures:
 	python tools/make_excel_fixtures.py
@@ -11,6 +11,9 @@ test:
 
 golden:
 	python tools/update_golden_checksums.py
+
+golden-verify: golden
+	git diff --exit-code -- tests/golden/checksums.json || (echo "Golden checksums out-of-date. Run: make golden" && exit 1)
 
 lint:
 	python tools/lint_filters.py

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ make golden
 make check
 ```
 
+## Golden Güncelleme
+
+```bash
+# İlk kurulum (bir kere)
+pip install -r requirements-dev.txt
+pre-commit install
+
+# Manuel güncelleme
+make golden
+
+# CI’de hata aldıysanız (out-of-date)
+make golden && git add tests/golden/checksums.json && git commit -m "update golden checksums"
+```
+
 ## Veri ve Filtre Dosyaları
 
 * **Excel klasörü**: `Veri/` (proje kökünde)

--- a/USAGE.md
+++ b/USAGE.md
@@ -43,3 +43,17 @@ python -m backtest.cli scan-range --filters-csv config/filters.csv --start 2025-
 ## 5. Sonuçlar
 
 Çalışma tamamlandığında raporlar `raporlar/` dizinine, loglar `loglar/` dizinine yazılır.
+
+## Golden Güncelleme
+
+```bash
+# İlk kurulum (bir kere)
+pip install -r requirements-dev.txt
+pre-commit install
+
+# Manuel güncelleme
+make golden
+
+# CI’de hata aldıysanız (out-of-date)
+make golden && git add tests/golden/checksums.json && git commit -m "update golden checksums"
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest>=8
 hypothesis>=6.98
 openpyxl>=3.1
 pyyaml>=6
+pre-commit>=3.7


### PR DESCRIPTION
## Summary
- add pre-commit with golden checksum updater
- wire up golden/golden-verify targets and check helper
- verify golden checksums ahead of tests in CI

## Testing
- `pre-commit run --files requirements-dev.txt .pre-commit-config.yaml README.md USAGE.md`
- `pre-commit run --files Makefile`
- `pre-commit run --files .github/workflows/ci.yml`
- `PREFLIGHT_ALIAS_MODE=allow PREFLIGHT_ALLOW_UNKNOWN=1 make check` *(fails: ModuleNotFoundError: No module named 'backtest')*

------
https://chatgpt.com/codex/tasks/task_e_68a9bb33e4e883259ffb3e1f6ea66677