### PR TITLE
quality: add data contracts (schema & rules) + validator + CI report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
       - run: pip install -r requirements.txt || true
       - run: pip install -r requirements-dev.txt
 
-      # Fixtures + golden verification + preflight + test
-      - run: make fixtures
-      - run: make golden-verify
-      - run: PREFLIGHT_ALIAS_MODE=allow PREFLIGHT_ALLOW_UNKNOWN=1 make preflight
-      - run: make test
+        # Fixtures + golden verification + quality + preflight + test
+        - run: make fixtures
+        - run: make golden-verify
+        - run: make quality
+        - run: PREFLIGHT_ALIAS_MODE=allow PREFLIGHT_ALLOW_UNKNOWN=1 make preflight
+        - run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ mem:
 	python tools/memory_snapshot.py
 
 perf-report: bench bench-cli profile mem
+
+.PHONY: quality
+quality:
+	python tools/validate_data_quality.py

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ make golden
 make golden && git add tests/golden/checksums.json && git commit -m "update golden checksums"
 ```
 
+## Veri Kalitesi Sözleşmeleri
+
+```bash
+# Sözleşme kontrolü (lokalde)
+make quality
+# Rapor → artifacts/quality/report.json
+```
+
+Kurallar ve tolerans değerleri `contracts/data_quality.yaml` dosyasından
+güncellenebilir. Şema ihlalleri ve mantıksal hatalar kritik kabul edilir ve
+araç çıkış kodunu sıfırdan farklı yapar; tolerans aşımı uyarı olarak raporlanır.
+
 ## Veri ve Filtre Dosyaları
 
 * **Excel klasörü**: `Veri/` (proje kökünde)

--- a/USAGE.md
+++ b/USAGE.md
@@ -59,3 +59,16 @@ make golden
 # CI’de hata aldıysanız (out-of-date)
 make golden && git add tests/golden/checksums.json && git commit -m "update golden checksums"
 ```
+
+## Veri Kalitesi Sözleşmeleri
+
+```bash
+# Sözleşme kontrolü (lokalde)
+make quality
+# Rapor → artifacts/quality/report.json
+```
+
+Kuralları ve toleransları değiştirmek için `contracts/data_quality.yaml`
+dosyasını düzenleyin. Şema ve mantık ihlalleri aracı başarısız kılar; tolerans
+aşımları yalnızca uyarı üretir.
+

--- a/contracts/data_quality.yaml
+++ b/contracts/data_quality.yaml
@@ -1,0 +1,27 @@
+# Zorunlu kolonlar ve tipler
+required_columns:
+  date: datetime64[ns]
+  open: float64
+  high: float64
+  low: float64
+  close: float64
+  volume: float64
+
+# Mantıksal kurallar (hepsi opsiyonel, sağlanırsa doğrulanır)
+rules:
+  date_unique: true            # aynı tarihten birden fazla olmasın
+  date_sorted_asc: true        # tarih artan
+  non_negative_volume: true    # volume >= 0
+  ohlc_bounds: true            # low <= min(open,close,high) & high >= max(...)
+  no_full_nan_rows: true       # satırın tamamı NaN olmasın
+
+# Toleranslar (yüzde olarak)
+tolerances:
+  max_nan_ratio_per_column: 0.02    # %2
+  max_duplicate_ratio: 0.0
+
+# Hangi dosyalar taranacak (boş ise EXCEL_DIR altındaki tüm .xlsx)
+include:
+  - "**/*.xlsx"
+exclude:
+  - "**/~$*.xlsx"     # geçici dosyaları dışla

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pre-commit>=3.7
 pytest-benchmark>=4.0
 pyinstrument>=4.6
 memory-profiler>=0.61
+pandera>=0.20

--- a/tests/contracts/test_quality_smoke.py
+++ b/tests/contracts/test_quality_smoke.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+
+def test_quality_tool_exits_zero():
+    res = subprocess.run([sys.executable, "tools/validate_data_quality.py"])
+    assert res.returncode in (0,), res.returncode

--- a/tools/validate_data_quality.py
+++ b/tools/validate_data_quality.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+import re
+import sys
+
+import pandas as pd
+import pandera as pa
+from pandera import Column, DataFrameSchema
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from backtest.paths import EXCEL_DIR  # noqa: E402
+
+CFG = Path("contracts/data_quality.yaml")
+assert CFG.exists(), "missing contracts/data_quality.yaml"
+cfg = yaml.safe_load(CFG.read_text())
+
+# Şema
+req = cfg.get("required_columns", {})
+schema = DataFrameSchema(
+    {
+        "date": Column("datetime64[ns]"),
+        "open": Column(float, nullable=False),
+        "high": Column(float, nullable=False),
+        "low": Column(float, nullable=False),
+        "close": Column(float, nullable=False),
+        "volume": Column(float, nullable=False),
+    },
+    coerce=True,
+)
+
+# Kurallar
+rules = cfg.get("rules", {})
+
+
+def validate_df(df: pd.DataFrame) -> list[dict]:
+    problems: list[dict] = []
+    # tip/zorunlu kolon
+    try:
+        schema.validate(df, lazy=True)
+    except pa.errors.SchemaErrors as e:
+        for err in e.failure_cases.to_dict("records"):
+            reason = (
+                f"{err.get('check')} at {err.get('column')} "
+                f"-> {err.get('failure_case')}"
+            )
+            problems.append({"type": "schema", "reason": reason})
+
+    # date alanını üret
+    is_dt = pd.api.types.is_datetime64_any_dtype
+    if "date" in df.columns and not is_dt(df["date"]):
+        try:
+            df = df.copy()
+            df["date"] = pd.to_datetime(df["date"])
+        except Exception as ex:
+            problems.append(
+                {
+                    "type": "schema",
+                    "reason": f"date parse failed: {ex}",
+                }
+            )
+            return problems
+
+    # Mantıksal kurallar
+    if rules.get("date_unique"):
+        dups = df["date"].duplicated().sum()
+        if dups > 0:
+            problems.append(
+                {
+                    "type": "logic",
+                    "reason": f"duplicate dates: {dups}",
+                }
+            )
+    if rules.get("date_sorted_asc"):
+        if not df["date"].is_monotonic_increasing:
+            problems.append(
+                {
+                    "type": "logic",
+                    "reason": "date not sorted ascending",
+                }
+            )
+    if rules.get("non_negative_volume") and "volume" in df:
+        if (df["volume"] < 0).any():
+            problems.append(
+                {
+                    "type": "logic",
+                    "reason": "negative volume detected",
+                }
+            )
+    if rules.get("ohlc_bounds"):
+        mn = df[["open", "close", "low", "high"]].min(axis=1)
+        mx = df[["open", "close", "low", "high"]].max(axis=1)
+        if (df["low"] > mn).any() or (df["high"] < mx).any():
+            problems.append(
+                {
+                    "type": "logic",
+                    "reason": "OHLC bounds violated",
+                }
+            )
+    if rules.get("no_full_nan_rows"):
+        if df.isna().all(axis=1).any():
+            problems.append(
+                {
+                    "type": "logic",
+                    "reason": "full-NaN rows present",
+                }
+            )
+
+    # Toleranslar
+    tol = cfg.get("tolerances", {})
+    max_nan = float(tol.get("max_nan_ratio_per_column", 0.0))
+    if max_nan > 0:
+        ratio = df.isna().mean().max()
+        if ratio > max_nan:
+            reason = f"max nan ratio exceeded: {ratio:.3f} > {max_nan:.3f}"
+            problems.append({"type": "tolerance", "reason": reason})
+
+    max_dup = float(tol.get("max_duplicate_ratio", 0.0))
+    if max_dup >= 0:
+        # duplicate ratio tarih alanına göre
+        if "date" in df.columns:
+            dup_ratio = df["date"].duplicated().mean()
+            if dup_ratio > max_dup:
+                reason = f"duplicate ratio {dup_ratio:.3f} > {max_dup:.3f}"
+                problems.append({"type": "tolerance", "reason": reason})
+
+    return problems
+
+
+# Hedef dosyalar
+includes = cfg.get("include") or ["**/*.xlsx"]
+excludes = cfg.get("exclude") or []
+
+
+def should_include(p: Path) -> bool:
+    s = str(p)
+    inc = (
+        any(
+            Path(EXCEL_DIR, "").joinpath(p).match(pattern)
+            or re.fullmatch(pattern.replace("**/", ".*"), s)
+            for pattern in includes
+        )
+        if includes
+        else True
+    )
+    exc = any(
+        Path(EXCEL_DIR, "").joinpath(p).match(pattern)
+        or re.fullmatch(pattern.replace("**/", ".*"), s)
+        for pattern in excludes
+    )
+    return inc and not exc
+
+
+files = [Path(p) for p in EXCEL_DIR.rglob("*.xlsx") if should_include(p)]
+
+report = {"root": str(EXCEL_DIR), "files": []}
+for f in files:
+    try:
+        # İlk sheet
+        df = pd.ExcelFile(f).parse(0)
+        probs = validate_df(df)
+        report["files"].append(
+            {"file": str(f.relative_to(EXCEL_DIR)), "problems": probs}
+        )
+    except Exception as e:
+        report["files"].append(
+            {
+                "file": str(f.relative_to(EXCEL_DIR)),
+                "problems": [{"type": "io", "reason": str(e)}],
+            }
+        )
+
+out_dir = Path("artifacts/quality")
+out_dir.mkdir(parents=True, exist_ok=True)
+(Path(out_dir / "report.json")).write_text(
+    json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+)
+
+# Konsol özeti
+criticals = []
+warnings = []
+for item in report["files"]:
+    for p in item["problems"]:
+        if p["type"] in {"schema", "logic"}:
+            criticals.append((item["file"], p["reason"]))
+        else:
+            warnings.append((item["file"], p["reason"]))
+
+if warnings:
+    print("WARNINGS:")
+    for w in warnings:
+        print(" -", w[0], "→", w[1])
+
+if criticals:
+    print("CRITICALS:")
+    for c in criticals:
+        print(" -", c[0], "→", c[1])
+    raise SystemExit(2)
+
+print("data quality validation passed")


### PR DESCRIPTION
## Summary
- add YAML-based data quality contract with required columns, rules, and tolerances
- implement validator tool that scans Excel files and emits JSON report
- wire `make quality` into Makefile, CI pipeline, and smoke tests

## Testing
- `make quality`
- `pytest tests/contracts/test_quality_smoke.py -q`
- `pre-commit run --files requirements-dev.txt contracts/data_quality.yaml tools/validate_data_quality.py Makefile .github/workflows/ci.yml README.md USAGE.md tests/contracts/test_quality_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9c4f2812c8325bcf52462877c8e4a