### PR TITLE
eval: add walk-forward / time-series CV harness (+ tests, make target, CI smoke)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,8 @@ perf-report: bench bench-cli profile mem
 .PHONY: quality
 quality:
 	python tools/validate_data_quality.py
+
+
+.PHONY: walk-forward
+walk-forward:
+	python tools/walk_forward_eval.py

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ make profile
 make mem
 ```
 
+## Walk-Forward / Time-Series CV
+
+```bash
+# Varsayılan kısa smoke
+make walk-forward
+
+# Parametrelerle
+WF_START=2025-03-01 \
+WF_END=2025-03-31 \
+WF_TRAIN_DAYS=10 \
+WF_TEST_DAYS=2 \
+WF_STEP_DAYS=2 \
+make walk-forward
+```
+
+Tasarım notu: Bu PR yalnız iskelet sağlar; metrik/portföy sonuçlarını toplama PR-13’te detaylandırılır.
+
 ## Golden Güncelleme
 
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -72,3 +72,20 @@ Kuralları ve toleransları değiştirmek için `contracts/data_quality.yaml`
 dosyasını düzenleyin. Şema ve mantık ihlalleri aracı başarısız kılar; tolerans
 aşımları yalnızca uyarı üretir.
 
+## Walk-Forward / Time-Series CV
+
+```bash
+# Varsayılan kısa smoke
+make walk-forward
+
+# Parametrelerle
+WF_START=2025-03-01 \
+WF_END=2025-03-31 \
+WF_TRAIN_DAYS=10 \
+WF_TEST_DAYS=2 \
+WF_STEP_DAYS=2 \
+make walk-forward
+```
+
+Tasarım notu: Bu PR yalnız iskelet sağlar; metrik/portföy sonuçlarını toplama PR-13’te detaylandırılır.
+

--- a/backtest/eval/__init__.py
+++ b/backtest/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation utilities."""

--- a/backtest/eval/walk_forward.py
+++ b/backtest/eval/walk_forward.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+import json
+
+ISO = "%Y-%m-%d"
+
+
+@dataclass
+class WfParams:
+    start: str  # ISO tarih
+    end: str  # ISO tarih (dahil)
+    train_days: int
+    test_days: int
+    step_days: int | None = None  # None => test_days
+    min_train_days: int | None = None  # None => train_days
+
+    def normalized(self) -> "WfParams":
+        step = self.step_days or self.test_days
+        mtrain = self.min_train_days or self.train_days
+        return WfParams(
+            self.start, self.end, self.train_days, self.test_days, step, mtrain
+        )
+
+
+def _d(s: str) -> datetime:
+    return datetime.strptime(s, ISO)
+
+
+def _iso(d: datetime) -> str:
+    return d.strftime(ISO)
+
+
+def generate_folds(p: WfParams) -> list[dict]:
+    p = p.normalized()
+    ds = _d(p.start)
+    de = _d(p.end)
+    if de < ds:
+        raise ValueError("end < start")
+
+    folds: list[dict] = []
+    # test penceresi kayarak ilerler; train her adımda geriye doğru
+    # p.train_days
+    cur_test_start = ds + timedelta(days=p.train_days)  # ilk testin başlangıcı
+    # min train koşulu için en erken test başlangıcı:
+    min_test_start = ds + timedelta(days=p.min_train_days)
+    if cur_test_start < min_test_start:
+        cur_test_start = min_test_start
+
+    while True:
+        test_start = cur_test_start
+        test_end = test_start + timedelta(days=p.test_days - 1)
+        if test_start > de:
+            break
+        if test_end > de:
+            test_end = de
+        train_end = test_start - timedelta(days=1)
+        train_start = max(ds, train_end - timedelta(days=p.train_days - 1))
+        if train_end < train_start:
+            break
+        folds.append(
+            {
+                "train_start": _iso(train_start),
+                "train_end": _iso(train_end),
+                "test_start": _iso(test_start),
+                "test_end": _iso(test_end),
+            }
+        )
+        cur_test_start = test_start + timedelta(days=p.step_days)
+        if test_start >= de:
+            break
+    return folds
+
+
+def save_folds(folds: list[dict], outdir: Path) -> Path:
+    outdir.mkdir(parents=True, exist_ok=True)
+    p = outdir / "folds.json"
+    p.write_text(json.dumps(folds, indent=2), encoding="utf-8")
+    return p

--- a/tests/integration/test_walk_forward_cli.py
+++ b/tests/integration/test_walk_forward_cli.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_walk_forward_smoke():
+    env = dict(
+        **os.environ,
+        WF_START="2025-03-07",
+        WF_END="2025-03-11",
+        WF_TRAIN_DAYS="2",
+        WF_TEST_DAYS="1",
+        WF_STEP_DAYS="1",
+        WF_SKIP_SCAN="1",
+    )
+    res = subprocess.run(
+        [sys.executable, "tools/walk_forward_eval.py"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, res.stderr[-400:]
+    assert Path("artifacts/wf/summary.json").exists()

--- a/tests/property/test_walk_forward_props.py
+++ b/tests/property/test_walk_forward_props.py
@@ -1,0 +1,20 @@
+from hypothesis import given, strategies as st
+from backtest.eval.walk_forward import WfParams, generate_folds
+
+
+@given(
+    train=st.integers(min_value=1, max_value=10),
+    test=st.integers(min_value=1, max_value=5),
+    step=st.integers(min_value=1, max_value=5),
+)
+def test_no_leakage(train, test, step):
+    p = WfParams(
+        "2025-03-01",
+        "2025-03-20",
+        train_days=train,
+        test_days=test,
+        step_days=step,
+    )
+    folds = generate_folds(p)
+    for f in folds:
+        assert f["train_end"] < f["test_start"]

--- a/tests/unit/test_walk_forward_split.py
+++ b/tests/unit/test_walk_forward_split.py
@@ -1,0 +1,22 @@
+from backtest.eval.walk_forward import WfParams, generate_folds
+
+
+def test_basic_splits():
+    p = WfParams(
+        "2025-03-07",
+        "2025-03-11",
+        train_days=2,
+        test_days=1,
+        step_days=1,
+    )
+    folds = generate_folds(p)
+    assert folds, "no folds generated"
+    # Sıralı ve sızma yok
+    for f in folds:
+        assert f["train_start"] <= f["train_end"]
+        assert f["train_end"] < f["test_start"]
+        assert f["test_start"] <= f["test_end"]
+
+    # step_days=1 ise test başlangıçları ardışık
+    starts = [f["test_start"] for f in folds]
+    assert sorted(starts) == starts

--- a/tools/walk_forward_eval.py
+++ b/tools/walk_forward_eval.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from backtest.eval.walk_forward import (  # noqa: E402
+    WfParams,
+    generate_folds,
+    save_folds,
+)
+
+OUTDIR = Path("artifacts/wf")
+OUTDIR.mkdir(parents=True, exist_ok=True)
+ENV = dict(os.environ, EXCEL_DIR="veri_guncel_fix")
+
+# Basit CLI parametreleri (env veya default)
+start = os.getenv("WF_START", "2025-03-07")
+end = os.getenv("WF_END", "2025-03-11")
+train_days = int(os.getenv("WF_TRAIN_DAYS", "2"))
+test_days = int(os.getenv("WF_TEST_DAYS", "1"))
+step_days = int(os.getenv("WF_STEP_DAYS", "1"))
+skip_scan = os.getenv("WF_SKIP_SCAN") == "1"
+
+p = WfParams(start, end, train_days, test_days, step_days)
+folds = generate_folds(p)
+save_folds(folds, OUTDIR)
+
+results_path = OUTDIR / "results.jsonl"
+with results_path.open("w", encoding="utf-8") as w:
+    for i, f in enumerate(folds):
+        cmd = [
+            sys.executable,
+            "-m",
+            "backtest.cli",
+            "scan-range",
+            "--config",
+            "config_scan.yml",
+            "--filters-csv",
+            "tests/data/filters_valid.csv",
+            "--no-preflight",
+            "--start",
+            f["train_start"],
+            "--end",
+            f["test_end"],
+        ]
+        # Not: İstersek ayrı ayrı train/test koşuluna ayrıştırırız;
+        # burada smoke/örnek için tek komut yeterli
+        res = (
+            subprocess.CompletedProcess(cmd, 0, "", "")
+            if skip_scan
+            else subprocess.run(cmd, env=ENV, capture_output=True, text=True)
+        )
+        rec = {
+            "fold": i,
+            "train": [f["train_start"], f["train_end"]],
+            "test": [f["test_start"], f["test_end"]],
+            "cmd": " ".join(cmd),
+            "returncode": res.returncode,
+            "stderr_tail": res.stderr[-300:],
+        }
+        w.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        if res.returncode != 0:
+            print(res.stderr)
+            sys.exit(res.returncode)
+
+# Özet
+summary = {
+    "fold_count": len(folds),
+}
+(Path(OUTDIR / "summary.json")).write_text(
+    json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+)
+print(json.dumps(summary, indent=2, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- add walk-forward parameter dataclass and fold generator
- provide `tools/walk_forward_eval.py` harness with optional skip flag
- document new `make walk-forward` target and usage examples

## Testing
- `pre-commit run --files backtest/eval/__init__.py backtest/eval/walk_forward.py tools/walk_forward_eval.py Makefile tests/unit/test_walk_forward_split.py tests/property/test_walk_forward_props.py tests/integration/test_walk_forward_cli.py README.md USAGE.md`
- `pytest tests/unit/test_walk_forward_split.py tests/property/test_walk_forward_props.py tests/integration/test_walk_forward_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9d0f326448325a75825dee52c88d8