### PR TITLE
ops: daily incremental runner (Istanbul TZ) + scheduled CI + webhook notifications

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,41 @@
+name: daily
+on:
+  workflow_dispatch:
+    inputs:
+      days_back:
+        description: "Kaç gün geriden çalıştırılsın"
+        required: false
+        default: "1"
+  schedule:
+    - cron: '0 4 * * *'  # 07:00 (Istanbul, DST döneminde) ≈ 04:00 UTC
+
+jobs:
+  run-daily:
+    runs-on: ubuntu-latest
+    env:
+      BACKTEST_WORKDIR: ${{ github.workspace }}
+      ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+      EXCEL_DIR: ${{ github.workspace }}/veri_guncel_fix
+      CACHE_DIR: ${{ github.workspace }}/artifacts/cache
+      DAYS_BACK: ${{ inputs.days_back || '1' }}
+      CONFIG: config/colab_config.yaml
+      WEBHOOK_URL: ${{ secrets.DAILY_WEBHOOK_URL }}
+      MESSAGE_PREFIX: "[daily:${{ github.ref_name }}]"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt || true
+      - run: pip install -r requirements-dev.txt
+      - run: make fixtures
+      - run: make preflight
+      - run: python tools/daily_incremental.py
+      - run: make report || true
+      - name: Upload daily artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-${{ github.run_id }}
+          path: |
+            artifacts/daily
+            artifacts/report

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,8 @@ portfolio-sim:
 .PHONY: report
 report:
 	python tools/build_html_report.py
+
+.PHONY: daily
+# Istanbul takvimine göre dünü tarar
+daily:
+	python tools/daily_incremental.py

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ make report
 
 CI koşuları sonunda rapor `html-report` artefaktı olarak yüklenir; Actions sekmesinden indirip `index.html` dosyasını açabilirsiniz.
 
+## Günlük Artırımlı Çalıştırıcı
+
+```bash
+# Yerelde dünü çalıştır
+make daily
+# Başka günler için
+DAYS_BACK=2 make daily
+```
+
+CI kullanımı:
+- Settings → Secrets → Actions altına `DAILY_WEBHOOK_URL` (opsiyonel) ekle.
+- Actions sekmesinden `daily` workflow'unu **Run workflow** ile manuel tetikleyebilir, `days_back` girebilirsin.
+
+
 ## Walk-Forward / Time-Series CV
 
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -115,3 +115,17 @@ python -m backtest.cli portfolio-sim --config config/colab_config.yaml --portfol
 
 Çıktılar `artifacts/portfolio/` klasörüne `trades.csv` ve `daily_equity.csv` olarak yazılır.
 
+
+## Günlük Artırımlı Çalıştırıcı
+
+```bash
+# Yerelde dünü çalıştır
+make daily
+# Başka günler için
+DAYS_BACK=2 make daily
+```
+
+CI kullanımı:
+- Settings → Secrets → Actions altına `DAILY_WEBHOOK_URL` (opsiyonel) ekle.
+- Actions sekmesinden `daily` workflow'unu **Run workflow** ile manuel tetikleyebilir, `days_back` girebilirsin.
+

--- a/tools/daily_incremental.py
+++ b/tools/daily_incremental.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from zoneinfo import ZoneInfo
+from datetime import datetime, timedelta
+from pathlib import Path
+import os, subprocess, sys, json
+
+IST = ZoneInfo("Europe/Istanbul")
+
+# Parametreler (env ile override edilebilir)
+DAYS_BACK = int(os.getenv("DAYS_BACK", "1"))   # kaç gün geriye bakılacak (varsayılan 1 = dün)
+CONFIG = os.getenv("CONFIG", "config/colab_config.yaml")
+WEBHOOK = os.getenv("WEBHOOK_URL")  # opsiyonel
+MSG_PREFIX = os.getenv("MESSAGE_PREFIX", "[daily]")
+
+# Hedef tarih (İstanbul takvimine göre dün)
+now_tr = datetime.now(tz=IST)
+target = (now_tr - timedelta(days=DAYS_BACK)).date().isoformat()
+
+# Çıktı klasörü (tarihe göre)
+OUTDIR = Path(f"artifacts/daily/{target}")
+OUTDIR.mkdir(parents=True, exist_ok=True)
+
+# Komut: sadece bir gün tarıyoruz
+CMD = [sys.executable, "-m", "backtest.cli", "scan-range",
+       "--config", CONFIG,
+       "--start", target, "--end", target]
+
+res = subprocess.run(CMD, capture_output=True, text=True)
+rec = {
+    "ts": now_tr.isoformat(),
+    "target_date": target,
+    "cmd": " ".join(CMD),
+    "returncode": res.returncode,
+    "stdout_tail": res.stdout[-400:],
+    "stderr_tail": res.stderr[-400:],
+}
+(OUTDIR/"run.json").write_text(json.dumps(rec, indent=2, ensure_ascii=False), encoding="utf-8")
+
+# Basit bildirim (opsiyonel webhook; generic JSON POST formatı)
+if WEBHOOK:
+    try:
+        import urllib.request, json as _json
+        payload = {
+            "text": f"{MSG_PREFIX} {target} return={res.returncode}",
+            "details": rec,
+        }
+        req = urllib.request.Request(WEBHOOK, data=_json.dumps(payload).encode("utf-8"), headers={"Content-Type":"application/json"})
+        urllib.request.urlopen(req, timeout=10).read()
+    except Exception as _:
+        pass
+
+print(json.dumps(rec, indent=2, ensure_ascii=False))
+sys.exit(res.returncode)


### PR DESCRIPTION
## Summary
- add Istanbul time zone daily incremental runner with optional webhook
- schedule daily GitHub Actions workflow that uploads artifacts
- document and expose `make daily` target

## Testing
- `pytest`
- `make preflight` *(fails: unknown tokens)*
- `python tools/daily_incremental.py` *(fails: Excel klasörü bulunamadı)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc4898948325b68216cb2ed25b72