### PR TITLE
filters/crossover: canonicalize to cross_up/down; normalize aliases

### DIFF
--- a/README_STAGE1.md
+++ b/README_STAGE1.md
@@ -82,7 +82,7 @@ from backtest.filters_compile import compile_expression
 import pandas as pd
 
 df = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
-fn = compile_expression("CROSSUP(a,b)")
+fn = compile_expression("cross_up(a,b)")
 print(fn(df))
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -69,7 +69,7 @@ from backtest.filters_compile import compile_expression, compile_filters
 import pandas as pd
 
 df = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
-fn = compile_expression("CROSSUP(a,b)")
+fn = compile_expression("cross_up(a,b)")
 mask = fn(df)  # bool Series döner
 
 funcs = compile_filters(["a > b", "b > a"])

--- a/backtest/filters/engine.py
+++ b/backtest/filters/engine.py
@@ -44,7 +44,21 @@ def _build_locals(df: pd.DataFrame) -> dict[str, pd.Series]:
     env = {}
     for c in df.columns:
         env[normalize_token(c)] = df[c]
-    env.update({"cross_up": cross_up, "cross_down": cross_down})
+    env.update(
+        {
+            # canonical
+            "cross_up": cross_up,
+            "cross_down": cross_down,
+            # legacy aliases
+            "CROSSUP": cross_up,
+            "CROSSDOWN": cross_down,
+            "crossOver": cross_up,
+            "crossUnder": cross_down,
+            # optional Turkish aliases
+            "keser_yukari": cross_up,
+            "keser_asagi": cross_down,
+        }
+    )
     return env
 
 

--- a/tests/test_cross_normalization.py
+++ b/tests/test_cross_normalization.py
@@ -1,0 +1,65 @@
+import pandas as pd
+
+from backtest.filters.engine import evaluate
+
+
+def _df():
+    s = pd.Series([0, 1, 2, 1, 2, 3])
+    return pd.DataFrame(
+        {
+            "a": s,
+            "b": s.shift(1).fillna(0),
+            "macd_line": [0.1, -0.2, 0.3, -0.1, 0.2, 0.5],
+        }
+    )
+
+
+def test_aliases_equivalent():
+    df = _df()
+    exprs_up = [
+        "cross_up(a,b)",
+        "CROSSUP(a,b)",
+        "crossOver(a,b)",
+        "keser_yukari(a,b)",
+        "cross_over(a,b)",
+    ]
+    masks = [evaluate(df, e) for e in exprs_up]
+    for m in masks[1:]:
+        assert m.equals(masks[0])
+
+    exprs_down = [
+        "cross_down(a,b)",
+        "CROSSDOWN(a,b)",
+        "crossUnder(a,b)",
+        "keser_asagi(a,b)",
+        "cross_under(a,b)",
+    ]
+    masks_down = [evaluate(df, e) for e in exprs_down]
+    for m in masks_down[1:]:
+        assert m.equals(masks_down[0])
+
+
+def test_constant_level_aliases():
+    df = _df()
+    exprs = [
+        "cross_up(macd_line, 0.0)",
+        "CROSSUP(macd_line, 0.0)",
+    ]
+    masks = [evaluate(df, e) for e in exprs]
+    for m in masks[1:]:
+        assert m.equals(masks[0])
+
+
+def test_na_policy():
+    df = _df()
+    mask_up = evaluate(df, "cross_up(a,b)")
+    assert list(mask_up) == [False, True, False, False, True, False]
+    mask_down = evaluate(df, "cross_down(a,b)")
+    assert list(mask_down) == [False, False, False, True, False, False]
+
+
+def test_cross_over_alias():
+    df = _df()
+    m1 = evaluate(df, "cross_up(a,b)")
+    m2 = evaluate(df, "cross_over(a,b)")
+    assert m1.equals(m2)

--- a/tools/migrate_cross_aliases.py
+++ b/tools/migrate_cross_aliases.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Normalize crossover function names in CSV/DSL files.
+
+Usage:
+    python tools/migrate_cross_aliases.py input.csv output.csv
+
+Replaces legacy crossover function names like ``CROSSUP`` or ``crossOver``
+with the canonical ``cross_up`` / ``cross_down`` equivalents.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ALIASES = [
+    (r"\b(CROSSUP|crossUp|CROSS_UP|crossOver|cross_over|keser_yukari|kesisim_yukari)\s*\(", "cross_up("),
+    (r"\b(CROSSDOWN|crossDown|CROSS_DOWN|crossUnder|cross_under|keser_asagi|kesisim_asagi)\s*\(", "cross_down("),
+]
+
+
+def _normalize(text: str) -> str:
+    for pat, repl in _ALIASES:
+        text = re.sub(pat, repl, text, flags=re.I)
+    # handle Turkish macro forms ``X_keser_Y_yukari`` etc.
+    text = re.sub(
+        r"([A-Za-z0-9_]+)_keser_([A-Za-z0-9_]+)_yukari",
+        r"cross_up(\1,\2)",
+        text,
+        flags=re.I,
+    )
+    text = re.sub(
+        r"([A-Za-z0-9_]+)_keser_([A-Za-z0-9_]+)_asagi",
+        r"cross_down(\1,\2)",
+        text,
+        flags=re.I,
+    )
+    return text
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("usage: python tools/migrate_cross_aliases.py input.csv output.csv")
+        raise SystemExit(1)
+    src, dst = sys.argv[1], sys.argv[2]
+    data = Path(src).read_text()
+    Path(dst).write_text(_normalize(data))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- normalize cross-over/down function names to canonical `cross_up`/`cross_down`
- add runtime aliases in engine, eval env and query parser
- provide migration script and docs for new naming

## Testing
- `pytest -q`
- `python - <<'PY'
from backtest.filters.engine import evaluate
import pandas as pd
s = pd.Series([0,1,2,1,2,3])
df = pd.DataFrame({"a": s, "b": s.shift(1).fillna(0), "macd_line": [0.1,-0.2,0.3, -0.1, 0.2, 0.5]})
exprs = [
  "cross_up(a,b)", "CROSSUP(a,b)", "crossOver(a,b)", "keser_yukari(a,b)",
  "cross_down(a,b)", "CROSSDOWN(a,b)", "crossUnder(a,b)", "keser_asagi(a,b)",
  "cross_up(macd_line, 0.0)", "CROSSUP(macd_line, 0.0)",
]
for e in exprs:
    m = evaluate(df, e)
    print(e, int(m.sum()))
PY`
- `rg "crossOver|crossUnder|CROSSUP|CROSSDOWN|keser_yukari|keser_asagi" -n backtest tools docs | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68ab29408bbc8325b0d6611d7483b4ba