### PR TITLE
Add hypothesis dependency for property tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -12,3 +12,4 @@ tqdm==4.67.1
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
 click==8.2.1
+hypothesis==6.138.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=8
-hypothesis>=6.98
+hypothesis>=6.98,<7
 openpyxl>=3.1
 pyyaml>=6
 pre-commit>=3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tqdm<5
 python-dateutil<3
 PyYAML<7
 click<9
+hypothesis<7


### PR DESCRIPTION
## Summary
- Add hypothesis as a dependency and pin version
- Limit dev requirement to hypothesis<7

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3a19fbb88325a32dc4763c5726b2