### PR TITLE
Fix CLI import path for direct execution

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -11,6 +11,9 @@ from types import SimpleNamespace as NS
 
 import pandas as pd
 
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from backtest.backtester import run_1g_returns
 from backtest.batch import run_scan_day, run_scan_range
 from backtest.calendars import add_next_close


### PR DESCRIPTION
## Summary
- ensure `backtest/cli.py` adjusts `sys.path` when run as a script so project modules resolve correctly

## Testing
- `pytest --maxfail=1`
- `python backtest/cli.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68ab3c84fdbc8325a5a5df1464ab3a9e