### PR TITLE
Fix missing Result import in strategy objectives

### DIFF
--- a/backtest/strategy/objectives.py
+++ b/backtest/strategy/objectives.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Dict
 
+from .runner import Result
 
-def objective_primary(result: "Result") -> float:
+
+def objective_primary(result: Result) -> float:
     """Primary objective function.
 
     Currently the Sharpe ratio is used as the primary metric.
@@ -12,7 +14,7 @@ def objective_primary(result: "Result") -> float:
     return float(result.metrics.get("sharpe", 0.0))
 
 
-def objective_penalty(result: "Result", constraints: Dict[str, float]) -> float:
+def objective_penalty(result: Result, constraints: Dict[str, float]) -> float:
     """Penalty for violating constraints.
 
     Each constraint is a soft limit. When a metric exceeds the limit the
@@ -32,7 +34,7 @@ def objective_penalty(result: "Result", constraints: Dict[str, float]) -> float:
     return float(penalty)
 
 
-def score(result: "Result", constraints: Dict[str, float]) -> float:
+def score(result: Result, constraints: Dict[str, float]) -> float:
     """Combined score = primary - penalty."""
 
     return objective_primary(result) - objective_penalty(result, constraints)


### PR DESCRIPTION
## Summary
- import `Result` from `runner` in strategy objectives module
- use imported Result type instead of string annotations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3daebc708325bba17cdf310886f0