### PR TITLE
Fix import usage and clean up modules

### DIFF
--- a/backtest/batch/scheduler.py
+++ b/backtest/batch/scheduler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Iterable
-
 import pandas as pd
 
 

--- a/backtest/config/schema.py
+++ b/backtest/config/schema.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 # --- Ortak yardımcılar ---
 

--- a/backtest/downloader/providers/base.py
+++ b/backtest/downloader/providers/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import date
-from typing import Iterable
 
 import pandas as pd
 

--- a/backtest/downloader/schema.py
+++ b/backtest/downloader/schema.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Optional
 
 import pandas as pd
 

--- a/backtest/dsl/evaluator.py
+++ b/backtest/dsl/evaluator.py
@@ -4,7 +4,6 @@ import ast
 import operator as op
 from typing import Any, Mapping
 
-import numpy as np
 import pandas as pd
 
 from .errors import DSLBadArgs, DSLUnknownName

--- a/backtest/eval/metrics.py
+++ b/backtest/eval/metrics.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from pathlib import Path
 
 import numpy as np
 import pandas as pd

--- a/backtest/eval/report.py
+++ b/backtest/eval/report.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from .metrics import SignalMetricConfig, equity_metrics, signal_metrics_for_filter
+from .metrics import SignalMetricConfig, signal_metrics_for_filter
 
 ART = Path("artifacts/metrics")
 

--- a/backtest/eval_env.py
+++ b/backtest/eval_env.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pandas as pd
 
 from .cross import cross_down as _cross_down
-from .cross import cross_over, cross_under
+from .cross import cross_over
 from .cross import cross_up as _cross_up
 
 

--- a/backtest/indicators/precompute.py
+++ b/backtest/indicators/precompute.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
 
 import pandas as pd
 

--- a/backtest/naming/__init__.py
+++ b/backtest/naming/__init__.py
@@ -5,7 +5,7 @@ import pandas as pd
 from .alias_loader import AliasMap, load_alias_map
 from .aliases import normalize_token
 from .canonical import CANONICAL_BASE, CANONICAL_SET
-from .legacy import *  # noqa: F401,F403
+from .legacy import normalize_name, validate_columns_schema
 from .normalize import (
     normalize_dataframe_columns,
     normalize_indicator_token,
@@ -70,4 +70,6 @@ __all__ = [
     "normalize_token",
     "normalize_dataframe_columns",
     "canonicalize_columns",
+    "normalize_name",
+    "validate_columns_schema",
 ]

--- a/backtest/naming/normalize.py
+++ b/backtest/naming/normalize.py
@@ -4,7 +4,6 @@ import re
 from typing import Dict, Iterable
 
 from .aliases import normalize_token
-from .canonical import CANONICAL_SET
 
 _SNAKE_RE1 = re.compile(r"[^0-9A-Za-z]+")
 _SNAKE_RE2 = re.compile(r"_{2,}")

--- a/backtest/normalize/report.py
+++ b/backtest/normalize/report.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict
 
 
 @dataclass

--- a/backtest/precompute/core.py
+++ b/backtest/precompute/core.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Set
+from typing import Set
 
 import pandas as pd
 import pandas_ta as ta

--- a/backtest/strategy/cli.py
+++ b/backtest/strategy/cli.py
@@ -11,7 +11,6 @@ import yaml
 from backtest.cv.timeseries import PurgedKFold, WalkForward, cross_validate
 
 from . import StrategyRegistry, StrategySpec, run_strategy
-from .objectives import score
 
 
 def compare_strategies_cli(args) -> None:

--- a/backtest/validation/report.py
+++ b/backtest/validation/report.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import List
 
 
 @dataclass

--- a/tests/perf/test_perf_harness.py
+++ b/tests/perf/test_perf_harness.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -16,7 +15,6 @@ pytestmark = pytest.mark.skip(reason="relies on optional deps causing segfaults 
 
 
 def test_perf_harness_creates_files(tmp_path, monkeypatch):
-    outdir = tmp_path / "artifacts"
     monkeypatch.chdir(tmp_path)
     args = [
         "--scenario",


### PR DESCRIPTION
## Summary
- remove unused imports throughout the codebase
- replace wildcard import in naming package with explicit imports
- tidy tests by dropping unused imports

## Testing
- `pyflakes backtest tests/perf/test_perf_harness.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4903c3988325802c9ee5bfcca456