### PR TITLE
Handle optional dependencies for tooling

### DIFF
--- a/tools/build_html_report.py
+++ b/tools/build_html_report.py
@@ -6,7 +6,14 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
-from jinja2 import Template
+
+try:  # Optional dependency
+    from jinja2 import Template
+except ModuleNotFoundError as e:  # pragma: no cover - executed only when missing dep
+    raise ModuleNotFoundError(
+        "build_html_report requires the optional dependency 'jinja2'. "
+        "Install it with `pip install jinja2`."
+    ) from e
 
 OUTDIR = Path("artifacts/report")
 OUTDIR.mkdir(parents=True, exist_ok=True)

--- a/tools/profile_pyinstrument.py
+++ b/tools/profile_pyinstrument.py
@@ -2,7 +2,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-from pyinstrument import Profiler
+try:  # Optional dependency
+    from pyinstrument import Profiler
+except ModuleNotFoundError as e:  # pragma: no cover - executed only when missing dep
+    raise ModuleNotFoundError(
+        "profile_pyinstrument requires the optional dependency 'pyinstrument'. "
+        "Install it with `pip install pyinstrument`."
+    ) from e
 
 
 def main():


### PR DESCRIPTION
## Summary
- Guard optional imports in HTML report builder
- Guard optional imports in pyinstrument profiler script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab4b9246d08325b264e96a5321e43d