### PR TITLE
Fix preflight missing call for single-date runs

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -93,6 +93,13 @@ def preflight(cfg):  # tests monkeypatch ediyor
 
     if getattr(cfg.project, "single_date", None):
         dates = [pd.to_datetime(cfg.project.single_date).date()]
+        return _pf(
+            cfg.data.excel_dir,
+            dates,
+            cfg.data.filename_pattern,
+            date_format=getattr(cfg.data, "date_format", "%Y-%m-%d"),
+            case_sensitive=getattr(cfg.data, "case_sensitive", True),
+        )
     elif getattr(cfg.project, "start_date", None) and getattr(cfg.project, "end_date", None):
         s = pd.to_datetime(cfg.project.start_date).date()
         e = pd.to_datetime(cfg.project.end_date).date()


### PR DESCRIPTION
## Summary
- ensure `cli.preflight` runs `_pf` when only `single_date` is provided

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pyflakes $(git ls-files '*.py')`
- `pytest -q` *(fails: KeyboardInterrupt)*
- `pytest tests/test_preflight.py::test_preflight_all_found -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bc0fb3c83259e7f6d83ef251c84