### PR TITLE
Remove unused imports and cleanup tools

### DIFF
--- a/tests/integration/test_cli_eval_metrics.py
+++ b/tests/integration/test_cli_eval_metrics.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 

--- a/tests/strategy/test_registry.py
+++ b/tests/strategy/test_registry.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 import yaml
 
@@ -7,7 +5,15 @@ from backtest.strategy import StrategyRegistry
 
 
 def test_load_from_yaml(tmp_path):
-    cfg = {"strategies": [{"id": "s1", "filters": ["T1"], "params": {"risk": 1}}]}
+    cfg = {
+        "strategies": [
+            {
+                "id": "s1",
+                "filters": ["T1"],
+                "params": {"risk": 1},
+            }
+        ]
+    }
     p = tmp_path / "s.yaml"
     p.write_text(yaml.safe_dump(cfg))
     reg, constraints = StrategyRegistry.load_from_file(p)

--- a/tests/test_batch_runner.py
+++ b/tests/test_batch_runner.py
@@ -1,4 +1,3 @@
-import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -48,7 +47,13 @@ def test_run_scan_range_writes_files(tmp_path: Path):
     df = _df_single()
     filters_df = _filters_df()
     out_dir = tmp_path / "gunluk"
-    run_scan_range(df, str(idx[0].date()), str(idx[-1].date()), filters_df, out_dir=str(out_dir))
+    run_scan_range(
+        df,
+        str(idx[0].date()),
+        str(idx[-1].date()),
+        filters_df,
+        out_dir=str(out_dir),
+    )
     # 5 gün dosyası
     files = list(out_dir.glob("*.csv"))
     assert len(files) == 5

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,6 +1,3 @@
-import sys
-import types
-
 import pytest
 
 from backtest.cli import build_parser

--- a/tests/test_perf_pipeline.py
+++ b/tests/test_perf_pipeline.py
@@ -6,7 +6,7 @@ from backtest.indicators.precompute import (
     collect_required_indicators,
     precompute_for_chunk,
 )
-from backtest.io.panel_cache import build_panel_parquet, load_panel_parquet
+from backtest.io.panel_cache import load_panel_parquet
 
 
 def test_build_and_load_parquet(tmp_path: Path):

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -17,9 +17,11 @@ fake_pa.Column = lambda *a, **k: None
 sys.modules.setdefault("pandera", fake_pa)
 
 from backtest import cli  # noqa: E402
-from backtest.filters.normalize_expr import normalize_expr
 from backtest.io.preflight import preflight  # noqa: E402
-from backtest.preflight import UnknownSeriesError, check_unknown_series
+from backtest.preflight import (  # noqa: E402
+    UnknownSeriesError,
+    check_unknown_series,
+)
 
 
 def _touch(path: Path) -> None:
@@ -84,7 +86,10 @@ data:
         "FilterCode;PythonQuery\nF1;close > 0\n", encoding="utf-8"
     )
     runner = CliRunner()
-    result = runner.invoke(cli.scan_day, ["--config", str(cfg_path), "--date", "2025-03-07"])
+    result = runner.invoke(
+        cli.scan_day,
+        ["--config", str(cfg_path), "--date", "2025-03-07"],
+    )
     assert result.exit_code != 0
     assert "Excel klasörü" in result.output
 
@@ -113,7 +118,13 @@ def test_scan_day_no_preflight(monkeypatch):
 
     monkeypatch.setattr(cli, "preflight", _pf)
     monkeypatch.setattr(cli, "_run_scan", lambda cfg: None)
-    cli.scan_day.callback("cfg.yml", "2025-03-07", None, None, no_preflight=True)
+    cli.scan_day.callback(
+        "cfg.yml",
+        "2025-03-07",
+        None,
+        None,
+        no_preflight=True,
+    )
     assert not called
 
 

--- a/tests/test_trace_artifacts.py
+++ b/tests/test_trace_artifacts.py
@@ -1,11 +1,7 @@
 import json
-import os
 from pathlib import Path
 
-import numpy as np
-import pandas as pd
-
-from backtest.trace import ArtifactWriter, RunContext, list_output_files, sha256_file
+from backtest.trace import ArtifactWriter, RunContext, list_output_files
 
 
 def test_run_context_and_artifacts(tmp_path: Path):
@@ -23,9 +19,15 @@ def test_checksum_determinism(tmp_path: Path):
     out = tmp_path / "gunluk"
     out.mkdir(parents=True, exist_ok=True)
     f1 = out / "2024-01-01.csv"
-    f1.write_text("date,symbol,filter_code\n2024-01-01,AAA,F1\n", encoding="utf-8")
+    f1.write_text(
+        "date,symbol,filter_code\n2024-01-01,AAA,F1\n",
+        encoding="utf-8",
+    )
     f2 = out / "2024-01-02.csv"
-    f2.write_text("date,symbol,filter_code\n2024-01-02,BBB,F2\n", encoding="utf-8")
+    f2.write_text(
+        "date,symbol,filter_code\n2024-01-02,BBB,F2\n",
+        encoding="utf-8",
+    )
 
     files = list_output_files(out)
     writer = ArtifactWriter(tmp_path / "artifacts_run")

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -1,7 +1,4 @@
-from pathlib import Path
-
 import pytest
-import yaml
 
 from backtest.config.schema import ColabConfig, CostsConfig, PortfolioConfig
 

--- a/tools/benchmark_scan.py
+++ b/tools/benchmark_scan.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -33,7 +32,10 @@ def main():
         "stdout_tail": res.stdout[-500:],
         "stderr_tail": res.stderr[-500:],
     }
-    Path("artifacts/bench/scan_bench.json").write_text(json.dumps(out, indent=2), encoding="utf-8")
+    Path("artifacts/bench/scan_bench.json").write_text(
+        json.dumps(out, indent=2),
+        encoding="utf-8",
+    )
     print(json.dumps(out, indent=2))
     sys.exit(res.returncode)
 

--- a/tools/fix_filters.py
+++ b/tools/fix_filters.py
@@ -9,12 +9,12 @@ from pathlib import Path
 import pandas as pd
 
 RE_PSAR = re.compile(r"\bpsarl_0\.02_0\.2\b", flags=re.IGNORECASE)
-RE_WILLR = re.compile(r"(?<![A-Za-z0-9_])_(100|80|70|50)\b", flags=re.IGNORECASE)
+RE_WILLR = re.compile(r"(?<![A-Za-z0-9_])_(100|80|70|50)\b", flags=re.IGNORECASE)  # noqa: E501
 RE_EQ = re.compile(r"\s=\s=")
 RE_CCI = re.compile(r"\bcci_(\d+)_0\b", flags=re.IGNORECASE)
 RE_AROONU = re.compile(r"\baroonu_(\d+)\b", flags=re.IGNORECASE)
 RE_AROOND = re.compile(r"\baroond_(\d+)\b", flags=re.IGNORECASE)
-RE_CLASSICP = re.compile(r"\s*&\s*[^&]*classicpivots_1h_p[^&]*", flags=re.IGNORECASE)
+RE_CLASSICP = re.compile(r"\s*&\s*[^&]*classicpivots_1h_p[^&]*", flags=re.IGNORECASE)  # noqa: E501
 
 
 def fix_expr(expr: str) -> str:
@@ -26,7 +26,7 @@ def fix_expr(expr: str) -> str:
     s = RE_CCI.sub(lambda m: f"cci_{m.group(1)}", s)
     s = RE_AROONU.sub(lambda m: f"aroon_up_{m.group(1)}", s)
     s = RE_AROOND.sub(lambda m: f"aroon_down_{m.group(1)}", s)
-    s = re.sub(r"change_1h_percent", "change_1d_percent", s, flags=re.IGNORECASE)
+    s = re.sub(r"change_1h_percent", "change_1d_percent", s, flags=re.IGNORECASE)  # noqa: E501
     s = RE_CLASSICP.sub("", s)
     s = re.sub(r"\s+", " ", s)
     return s.strip()
@@ -48,6 +48,4 @@ def main(argv=None) -> int:
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(main())

--- a/tools/lint_filters.py
+++ b/tools/lint_filters.py
@@ -41,7 +41,7 @@ def main() -> None:
         Path(sys.argv[2]) if len(sys.argv) > 2 else Path("filters.csv")
     )
     # fmt: on
-    cfg = _load_cfg(cfg_path)
+    _load_cfg(cfg_path)
 
     excel_dir = EXCEL_DIR
     print(f"Using excel_dir={excel_dir}")

--- a/tools/update_golden_checksums.py
+++ b/tools/update_golden_checksums.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import sys
-import time
 from pathlib import Path
 
 import yaml


### PR DESCRIPTION
## Summary
- remove stray and duplicate imports across tests and tooling
- streamline linting utilities by dropping unused variables
- format long regex and script lines for clarity

## Testing
- `pre-commit run --files tests/unit/test_config_schema.py tests/test_cli_flags.py tools/fix_filters.py tests/test_perf_pipeline.py tools/lint_filters.py tools/benchmark_scan.py tools/update_golden_checksums.py tests/strategy/test_registry.py tests/test_trace_artifacts.py tests/test_batch_runner.py tests/integration/test_cli_eval_metrics.py tests/test_preflight.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab4f53f538832592befb52fb89c5b8