### PR TITLE
Refactor confusion metrics and align lint configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203
+per-file-ignores =
+    tools/build_html_report.py:E501

--- a/backtest/eval/metrics.py
+++ b/backtest/eval/metrics.py
@@ -63,10 +63,10 @@ def confusion_from_signals(
     y_true = y_true[valid]
     y_pred = y_pred[valid]
 
-    tp = int(((y_pred == True) & (y_true == True)).sum())
-    fp = int(((y_pred == True) & (y_true == False)).sum())
-    tn = int(((y_pred == False) & (y_true == False)).sum())
-    fn = int(((y_pred == False) & (y_true == True)).sum())
+    tp = int((y_pred & y_true).sum())
+    fp = int((y_pred & ~y_true).sum())
+    tn = int((~y_pred & ~y_true).sum())
+    fn = int((~y_pred & y_true).sum())
 
     detail = pd.DataFrame({"y_true": y_true, "y_pred": y_pred})
     return Confusion(tp, fp, tn, fn), detail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,7 @@ target-version = ["py310", "py311"]
 [tool.isort]
 profile = "black"
 line_length = 100
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = ["E203"]

--- a/tests/data/test_parquet_roundtrip.py
+++ b/tests/data/test_parquet_roundtrip.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pandas as pd
 
 from backtest.cli import convert_to_parquet

--- a/tests/integration/test_fetch_latest_stub.py
+++ b/tests/integration/test_fetch_latest_stub.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from backtest.downloader.core import DataDownloader
 from backtest.downloader.providers.stub import StubProvider
 

--- a/tests/property/test_metrics_props.py
+++ b/tests/property/test_metrics_props.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 
 from backtest.eval.metrics import rolling_future_return

--- a/tests/quality/test_filters_schema.py
+++ b/tests/quality/test_filters_schema.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 
 from io_filters import load_filters_csv, read_filters_csv

--- a/tests/test_normalize_df.py
+++ b/tests/test_normalize_df.py
@@ -1,7 +1,6 @@
-import numpy as np
 import pandas as pd
 
-from backtest.normalize import CollisionError, build_column_mapping, normalize_dataframe
+from backtest.normalize import CollisionError, normalize_dataframe
 from backtest.paths import ALIAS_PATH
 
 ALIAS = str(ALIAS_PATH)

--- a/tools/build_html_report.py
+++ b/tools/build_html_report.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import csv
 import json
 from datetime import datetime
 from pathlib import Path
@@ -68,8 +67,6 @@ if p_daily.exists():
 p_trades = Path("artifacts/portfolio/trades.csv")
 if p_trades.exists():
     try:
-        import io
-
         head = "\n".join(p_trades.read_text(encoding="utf-8").splitlines()[:12])
         ctx["portfolio_trades_head"] = head
     except Exception as e:

--- a/tools/make_excel_fixtures.py
+++ b/tools/make_excel_fixtures.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from backtest.paths import EXCEL_DIR
+from backtest.paths import EXCEL_DIR  # noqa: E402
 
 EXCEL_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/tools/perf_harness.py
+++ b/tools/perf_harness.py
@@ -13,8 +13,8 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from backtest.data.loader import load_prices
-from backtest.paths import DATA_DIR
+from backtest.data.loader import load_prices  # noqa: E402
+from backtest.paths import DATA_DIR  # noqa: E402
 
 SCENARIOS = {
     "scan-day": lambda symbols, start, end, backend: load_prices(

--- a/tools/walk_forward_eval.py
+++ b/tools/walk_forward_eval.py
@@ -12,7 +12,7 @@ from backtest.eval.walk_forward import (  # noqa: E402
     generate_folds,
     save_folds,
 )
-from backtest.logging_conf import get_logger, set_fold_id
+from backtest.logging_conf import get_logger, set_fold_id  # noqa: E402
 from backtest.paths import DATA_DIR  # noqa: E402
 
 log = get_logger("wf")


### PR DESCRIPTION
## Summary
- Simplify confusion matrix computation by using boolean ops instead of explicit True/False comparisons
- Configure repository-wide flake8 settings and clean up unused imports

## Testing
- `pre-commit run -a`
- `pytest`
- `make test`
- `./tools/ci_checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab5362a0588325a0dccd9aff9c1e86