### PR TITLE
fix: correct pytest benchmark config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,10 @@
 [pytest]
-addopts = -q
+addopts =
+    -q
+    --benchmark-storage=artifacts/bench
+    --benchmark-group-by=func
+    --benchmark-min-rounds=3
+    --benchmark-columns=min,max,mean,stddev,rounds,iterations
 markers =
     perf: micro/macro benchmark testleri
 # pytest-benchmark ayarları
-benchmark_storage = artifacts/bench
-benchmark_group_by = func
-benchmark_min_rounds = 3
-benchmark_columns = min, max, mean, stddev, rounds, iterations


### PR DESCRIPTION
## Summary
- fix pytest-benchmark configuration by moving options to addopts

## Testing
- `pre-commit run -a`
- `pytest -q`
- `./tools/ci_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ab7abcb8a4832586a32d0004a2930c