### PR TITLE
Enforce non-empty filter CSVs

### DIFF
--- a/io_filters.py
+++ b/io_filters.py
@@ -35,6 +35,9 @@ def validate_filters_df(df: pd.DataFrame) -> pd.DataFrame:
 
     df = df.dropna(how="all")
 
+    if df.empty:
+        raise ValueError("En az bir filtre tanımı gerekli")
+
     if df["FilterCode"].isna().any() or df["FilterCode"].astype(str).str.strip().eq("").any():
         raise ValueError("FilterCode boş olamaz")
     if df["PythonQuery"].isna().any() or df["PythonQuery"].astype(str).str.strip().eq("").any():

--- a/tests/test_filters_validation.py
+++ b/tests/test_filters_validation.py
@@ -21,6 +21,13 @@ def test_load_filters_empty_file(tmp_path):
         load_filters_csv([p])
 
 
+def test_load_filters_header_only(tmp_path):
+    p = tmp_path / "filters.csv"
+    p.write_text("FilterCode;PythonQuery\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_filters_csv([p])
+
+
 def test_load_filters_empty_query():
     with pytest.raises(ValueError):
         load_filters_csv([DATA_DIR / "filters_empty.csv"])


### PR DESCRIPTION
## Summary
- ensure filter CSVs contain at least one row
- test header-only filter files raise an error

## Testing
- `pre-commit run -a`
- `pytest`
- `make golden`
- `./tools/ci_checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab88e5e9a08325b38b03cf1ab50c92