### PR TITLE
Handle NaN values in normalize_key

### DIFF
--- a/backtest/utils/__init__.py
+++ b/backtest/utils/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import math
 import re
 import unicodedata
-from typing import Optional
 
 
-def normalize_key(s: Optional[str]) -> str:
-    if s is None:
+def normalize_key(s: str | float | None) -> str:
+    if s is None or (isinstance(s, float) and math.isnan(s)):
         return ""
     s = str(s).strip()
     # Map Turkish specific chars to ASCII-ish

--- a/tests/test_utils_normalize_key.py
+++ b/tests/test_utils_normalize_key.py
@@ -12,6 +12,10 @@ def test_normalize_key_basic():
     assert normalize_key("İşlem Hacmi") == "islem_hacmi"
 
 
+def test_normalize_key_nan():
+    assert normalize_key(float("nan")) == ""
+
+
 def test_normalize_columns_uses_common_normalize_key():
     df = pd.DataFrame({"Kapanış": [1], "İşlem Hacmi": [100]})
     normalized, colmap = normalize_columns(df)


### PR DESCRIPTION
## Summary
- ensure `normalize_key` returns an empty string for `NaN` inputs to avoid creating `'nan'` column names
- add regression test for NaN handling in `normalize_key`

## Testing
- `pre-commit run -a`
- `pytest`
- `./tools/ci_checks.sh`
- `make golden`


------
https://chatgpt.com/codex/tasks/task_e_68ab998dde54832599e7af473856cdfb