### PR TITLE
Add missing dependencies and drop legacy CLI flags

### DIFF
--- a/README_COLAB.md
+++ b/README_COLAB.md
@@ -36,8 +36,7 @@ setup_logger()
 
 ```python
 !python -m backtest.cli scan-range --config config/colab_config.yaml \
-  --start 2025-03-07 --end 2025-03-11 \
-  --holding-period 1 --transaction-cost 0.0005
+  --start 2025-03-07 --end 2025-03-11
 
 !ls -la raporlar | head
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ python-dateutil<3
 PyYAML<7
 click<9
 hypothesis<7
+pydantic<3
+jinja2<4

--- a/requirements_colab.txt
+++ b/requirements_colab.txt
@@ -9,3 +9,7 @@ loguru
 tqdm
 click
 pydantic
+pandera
+pyyaml
+polars
+jinja2


### PR DESCRIPTION
## Summary
- include pydantic and jinja2 in core requirements
- add pandera, pyyaml, polars and jinja2 to Colab requirements
- remove deprecated `--holding-period` and `--transaction-cost` usage from README_COLAB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9ff5d0908325a98d8b61887ef8cd