### PR TITLE
Add validation for empty filter CSV list

### DIFF
--- a/io_filters.py
+++ b/io_filters.py
@@ -70,6 +70,10 @@ def load_filters_csv(paths: list[Path | str]) -> list[dict]:
     """
 
     all_rows: list[dict] = []
+
+    if not paths:
+        raise ValueError("En az bir filtre CSV yolu gerekli")
+
     for path in paths:
         p = resolve_path(path)
         if not p.exists():


### PR DESCRIPTION
## Summary
- ensure `load_filters_csv` errors when no CSV paths are provided

## Testing
- `pre-commit run -a`
- `pytest`
- `make golden`
- `./tools/ci_checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba5851944832594c01e11271395f1