### PR TITLE
chore: tidy requirements and drop legacy cli params

### DIFF
--- a/requirements_colab.txt
+++ b/requirements_colab.txt
@@ -1,3 +1,4 @@
+-c constraints.txt
 numpy<2.0.0
 pandas
 pandas-ta
@@ -10,6 +11,7 @@ tqdm
 click
 pydantic
 pandera
-pyyaml
+PyYAML
 polars
 jinja2
+typing-inspect

--- a/tests/test_cli_empty.py
+++ b/tests/test_cli_empty.py
@@ -77,7 +77,7 @@ def test_scan_range_empty(monkeypatch):
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
-        lambda df, sigs, holding_period, transaction_cost, **kwargs: pd.DataFrame(
+        lambda df, sigs, **kwargs: pd.DataFrame(
             columns=[
                 "FilterCode",
                 "Symbol",
@@ -128,7 +128,7 @@ def test_scan_day_empty(monkeypatch):
     monkeypatch.setattr(
         cli,
         "run_1g_returns",
-        lambda df, sigs, holding_period, transaction_cost, **kwargs: pd.DataFrame(
+        lambda df, sigs, **kwargs: pd.DataFrame(
             columns=[
                 "FilterCode",
                 "Symbol",


### PR DESCRIPTION
## Summary
- add missing dependencies in Colab requirements
- remove legacy holding_period/transaction_cost expectations from CLI tests

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -r requirements_colab.txt`
- `pytest -q tests/test_cli_empty.py tests/test_backtester.py`
- `python -m backtest.cli scan-range --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68abbc15dcbc8325bca5352eb22a0feb