### PR TITLE
docs: update README with logging options and add triage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ python -m backtest.cli --help
 Tek veri kaynağı depo kökündeki `data/` dizinidir.
 
 
+## CLI Örnekleri
+
+```bash
+# Tek gün taraması
+python -m backtest.cli --log-level INFO --json-logs scan-day \
+  --data data/BIST.parquet --filters filters.csv \
+  --date 2024-01-02 --reports-dir raporlar/gunluk
+
+# Tarih aralığı taraması
+python -m backtest.cli --log-level INFO --json-logs scan-range \
+  --data data/BIST.parquet --filters filters.csv \
+  --start 2024-01-02 --end 2024-01-05 --reports-dir raporlar/aralik
+```
+
+
 ## Hızlı Başlangıç (Colab)
 
 ```python
@@ -56,6 +71,7 @@ make config-validate
 - `LOG_FORMAT` = json|plain (default: json)
 - `LOG_DIR` = loglar (default)
 - `BACKTEST_RUN_ID` = aynı koşudaki tüm logları korele etmek için custom run id
+- CLI global bayrakları: `--log-level` ve `--json-logs`
 
 ```bash
 LOG_LEVEL=DEBUG BACKTEST_RUN_ID=A12-DEV1 \
@@ -309,7 +325,7 @@ python tools/canonicalize_filters.py filters.csv filters_canonical.csv
 
 ## Rapor ve Log Dizini
 
-Komutlar çalıştığında çıktı dosyaları `raporlar/` klasörüne, loglar ise her çalıştırma için ayrı bir alt klasör oluşturularak `loglar/` içine yazılır.
+ Komutlar çalıştığında çıktı dosyaları `raporlar/` klasörüne, loglar ise her çalıştırma için ayrı bir alt klasör oluşturularak `loglar/` içine yazılır; her `run_*/` klasöründe `summary.txt` ve makine okunabilir `events.jsonl` bulunur.
 
 ```
 raporlar/
@@ -317,7 +333,7 @@ raporlar/
 loglar/
     run_20250101-120000/
         summary.txt
-        stages.jsonl
+        events.jsonl
 ```
 
 Colab veya uzak bir ortamda sonuçları indirmenin kolay yolu:

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -1,0 +1,50 @@
+# Triage Rehberi
+
+## TRIAGE CHECKLIST
+
+### DATA
+- `DATA` olayındaki `rows`, `symbols`, `date_min`, `date_max` alanlarını kontrol et.
+- `DATA_EMPTY` olayları veri setinin neden boş olduğunu (`reason`) söyler.
+
+### FILTERS
+- `FILTERS` olayındaki `n_filters` toplamına bak.
+- `invalid`, `missing` veya `unsafe` sayıları sıfır olmalı.
+
+### SCREENER
+- Her gün için `FILTER_RESULT` olaylarında `hits` değerlerini izle.
+
+### BACKTEST
+- `TRADE` olaylarında gün bazında işlemleri say.
+- `NO_TRADES_DAY` olayları işlem olmayan günleri listeler.
+
+### REPORT
+- `WRITE_DAY` ve `WRITE_RANGE` olayları yazılan satır sayılarını bildirir.
+
+### ZERO_RESULT_RANGE
+- Hiç sonuç çıkmadığında `ZERO_RESULT_RANGE` olayındaki `first_zero_day` alanı "ilk nerede sıfırlandı?" sorusuna yanıt verir.
+
+## events.jsonl nasıl okunur?
+`events.jsonl` dosyası satır başına JSON içerir; sorgulamak için `jq` veya Python kullanılabilir.
+
+### jq
+```bash
+# DATA özetini getir
+jq 'select(.event == "DATA") | {rows, symbols, date_min, date_max}' loglar/run_*/events.jsonl
+
+# İlk sinyal gelen günü bul
+jq 'select(.event == "FILTER_RESULT" and .hits > 0) | .date' loglar/run_*/events.jsonl | head -n 1
+```
+
+### Python
+```python
+import json
+from pathlib import Path
+
+run = next(Path('loglar').glob('run_*/events.jsonl'))
+with run.open() as f:
+    events = (json.loads(line) for line in f)
+    for ev in events:
+        if ev['event'] == 'ZERO_RESULT_RANGE':
+            print('first zero day:', ev['first_zero_day'])
+            break
+```


### PR DESCRIPTION
## Summary
- show `scan-day` and `scan-range` CLI examples with `--log-level` and `--json-logs`
- document log output locations including `events.jsonl` and `summary.txt`
- add triage checklist with `jq`/Python snippets for inspecting `events.jsonl`

## Testing
- `pre-commit run --files README.md docs/triage.md`
- `pytest tests/test_cli_empty.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68ac41f58f5883259184b06e2db46129