### PR TITLE
Standardize legacy benchmark config deprecations

### DIFF
--- a/backtest/config/config.py
+++ b/backtest/config/config.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import copy
 import logging
-import warnings
 from pathlib import Path
 from types import SimpleNamespace as NS
 from typing import Any
+
+from backtest.deprecations import emit_deprecation
 
 try:
     import yaml
@@ -82,16 +83,10 @@ def _to_ns(x: Any, *, _key: str | None = None) -> Any:
 def _apply_legacy(doc: dict) -> dict:
     bmk = doc.get("benchmark", {})
     if "xu100_source" in bmk and "source" not in bmk:
-        warnings.warn(
-            "benchmark.xu100_source deprecated; use benchmark.source",
-            DeprecationWarning,
-        )
+        emit_deprecation("benchmark.xu100_source", "benchmark.source")
         bmk["source"] = bmk["xu100_source"]
     if "xu100_csv_path" in bmk and "csv_path" not in bmk:
-        warnings.warn(
-            "benchmark.xu100_csv_path deprecated; use benchmark.csv_path",
-            DeprecationWarning,
-        )
+        emit_deprecation("benchmark.xu100_csv_path", "benchmark.csv_path")
         bmk["csv_path"] = bmk["xu100_csv_path"]
     doc["benchmark"] = bmk
     return doc

--- a/backtest/deprecations.py
+++ b/backtest/deprecations.py
@@ -1,0 +1,10 @@
+import warnings
+
+
+def emit_deprecation(old_key: str, new_key: str, *, stacklevel: int = 2) -> None:
+    """Emit standard deprecation warnings for legacy configuration keys."""
+    warnings.warn(
+        f"Legacy key '{old_key}' is deprecated; use '{new_key}' instead.",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/tests/test_benchmark_legacy_config.py
+++ b/tests/test_benchmark_legacy_config.py
@@ -1,6 +1,48 @@
-import warnings
+import pytest
 
 from backtest.config import load_config
+
+
+CFG_BASE = """
+project:
+  out_dir: out
+data:
+  excel_dir: data
+  filters_csv: filters.csv
+benchmark:
+  {key}: {value}
+"""
+
+
+@pytest.mark.parametrize(
+    "key,value,expected_attr",
+    [
+        ("xu100_source", "csv", "source"),
+        ("xu100_csv_path", "bist.csv", "csv_path"),
+    ],
+)
+def test_legacy_key_individual(tmp_path, key, value, expected_attr):
+    cfg_text = CFG_BASE.format(key=key, value=value)
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(cfg_text, encoding="utf-8")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "filters.csv").write_text(
+        "FilterCode;PythonQuery\nF1;close>0\n", encoding="utf-8"
+    )
+    if key == "xu100_csv_path":
+        (tmp_path / "bist.csv").write_text(
+            "date,close\n2024-01-01,1\n", encoding="utf-8"
+        )
+    with pytest.warns(DeprecationWarning) as record:
+        cfg = load_config(cfg_file)
+    assert getattr(cfg.benchmark, expected_attr) == (
+        str(tmp_path / value) if key == "xu100_csv_path" else value
+    )
+    assert len(record) == 1
+    assert (
+        str(record[0].message)
+        == f"Legacy key 'benchmark.{key}' is deprecated; use 'benchmark.{expected_attr}' instead."
+    )
 
 
 def test_legacy_keys(tmp_path):
@@ -13,17 +55,27 @@ data:
 benchmark:
   xu100_source: csv
   xu100_csv_path: bist.csv
-    """
+"""
     cfg_file = tmp_path / "cfg.yaml"
     cfg_file.write_text(cfg_text, encoding="utf-8")
     (tmp_path / "data").mkdir()
-    (tmp_path / "filters.csv").write_text("FilterCode;PythonQuery\nF1;close>0\n", encoding="utf-8")
-    (tmp_path / "bist.csv").write_text(
-        "date,close\n2024-01-01,1\n",
-        encoding="utf-8",
+    (tmp_path / "filters.csv").write_text(
+        "FilterCode;PythonQuery\nF1;close>0\n", encoding="utf-8"
     )
-    with warnings.catch_warnings(record=True) as w:
+    (tmp_path / "bist.csv").write_text(
+        "date,close\n2024-01-01,1\n", encoding="utf-8"
+    )
+    with pytest.warns(DeprecationWarning) as record:
         cfg = load_config(cfg_file)
     assert cfg.benchmark.source == "csv"
     assert cfg.benchmark.csv_path.endswith("bist.csv")
-    assert any("deprecated" in str(wi.message).lower() for wi in w)
+    messages = {str(w.message) for w in record}
+    assert (
+        "Legacy key 'benchmark.xu100_source' is deprecated; use 'benchmark.source' instead."
+        in messages
+    )
+    assert (
+        "Legacy key 'benchmark.xu100_csv_path' is deprecated; use 'benchmark.csv_path' instead."
+        in messages
+    )
+    assert len(record) == 2


### PR DESCRIPTION
## Summary
- add helper to emit consistent DeprecationWarning messages
- warn and map `benchmark.xu100_source` and `benchmark.xu100_csv_path` to new keys
- cover legacy benchmark config keys with tests verifying warnings

## Testing
- `pre-commit run --files backtest/deprecations.py backtest/config/config.py tests/test_benchmark_legacy_config.py` *(fails: CalledProcessError: command: ('/usr/bin/python3', '-mvirtualenv', '/root/.cache/pre-commit/repofswzsaxc/py_env-python3.11', '-p', 'python3.11'))*
- `pytest tests/test_benchmark_legacy_config.py -q -vv`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polars')*


------
https://chatgpt.com/codex/tasks/task_e_68ac9c17681483259c361a8c9788aba3