### PR TITLE
Data loader uyarı standardı — "no valid sheets"

### DIFF
--- a/backtest/data_loader.py
+++ b/backtest/data_loader.py
@@ -466,7 +466,7 @@ def read_excels_long(
 
     records = [r for r in records if not r.empty]
     if not records:
-        warnings.warn("Hiçbir sheet/çalışma sayfasından veri toplanamadı.")
+        warnings.warn("No valid sheets found", UserWarning)
         empty_df = pd.DataFrame(
             columns=["date", "open", "high", "low", "close", "volume", "symbol"]
         )

--- a/tests/test_data_loader_empty_records.py
+++ b/tests/test_data_loader_empty_records.py
@@ -16,7 +16,8 @@ def test_read_excels_long_no_valid_sheets(tmp_path):
         # sheet missing required 'date' column
         pd.DataFrame({"close": [1]}).to_excel(writer, sheet_name="NoDate", index=False)
 
-    df = read_excels_long(tmp_path)
+    with pytest.warns(UserWarning, match="No valid sheets found"):
+        df = read_excels_long(tmp_path)
     expected = ["date", "open", "high", "low", "close", "volume", "symbol"]
     assert df.empty
     assert list(df.columns) == expected


### PR DESCRIPTION
## Summary
- standardize empty Excel load behavior with explicit `UserWarning`
- test warning when no valid Excel sheets are found

## Testing
- `pytest tests/test_data_loader_empty_records.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca86cf1f483259a8242d893898fb2