### PR TITLE
Logger sözleşmesi — events.jsonl ve rapor dizinleri garanti

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -60,12 +60,8 @@ __all__ = [
     "compile_filters",
 ]
 
-from backtest.logging_conf import ensure_run_id
 from backtest.logging_utils import setup_logger
 from loguru import logger
-
-# runtime configurable logger; configured in ``main``
-run_id = None
 
 # setup_logging çağrısından sonra FileHandler eklemek için placeholder
 fh = None
@@ -480,10 +476,10 @@ def main(argv=None):
         argv = pre + [cmd] + post
     args = parser.parse_args(argv)
 
-    global run_id
-    run_id = ensure_run_id()
-    setup_logger(run_id=run_id, level=args.log_level, json_console=args.json_logs)
-    logger.bind(run_id=run_id, cmd=args.cmd).info("CLI start")
+    log_root = os.getenv("LOG_DIR", "loglar")
+    Path(log_root).mkdir(parents=True, exist_ok=True)
+    setup_logger(log_dir=log_root, level=args.log_level, json_console=args.json_logs)
+    logger.bind(cmd=args.cmd).info("CLI start")
     if args.cmd in {
         "fetch-range",
         "fetch-latest",

--- a/tests/test_cli_events_log.py
+++ b/tests/test_cli_events_log.py
@@ -1,0 +1,14 @@
+from backtest import cli
+
+
+def test_cli_creates_events(tmp_path, monkeypatch):
+    log_root = tmp_path / "logs"
+    art_root = tmp_path / "art"
+    monkeypatch.setenv("LOG_DIR", str(log_root))
+    monkeypatch.setenv("ARTIFACTS_DIR", str(art_root))
+    cli.main(["guardrails", "--out-dir", str(tmp_path / "out")])
+    run_dirs = [p for p in log_root.iterdir() if p.is_dir()]
+    assert run_dirs, "no run directory created"
+    events = run_dirs[0] / "events.jsonl"
+    assert events.exists()
+    assert events.read_text().strip()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -18,7 +18,7 @@ import backtest.indicators as indicators
 def _setup_log(tmp_path):
     log_dir = tmp_path / "log"
     os.environ["LOG_DIR"] = str(log_dir)
-    events_path = setup_logger(run_id="t", log_dir=str(log_dir))
+    events_path = setup_logger(log_dir=str(log_dir))
     return Path(events_path)
 
 


### PR DESCRIPTION
## Summary
- Simplify logger setup to build timestamped run directories and initialize `events.jsonl` automatically.
- Initialize logging immediately after CLI argument parsing and ensure logging directories exist.
- Add regression test confirming CLI creates an `events.jsonl` file with at least one log record.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acacde252483258eddf60096562893