### PR TITLE
Pin numpy/pandas versions for Colab setup

### DIFF
--- a/notebooks/colab_setup.py
+++ b/notebooks/colab_setup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 LOG_PATH = ROOT / "loglar" / "colab_install.log"
+REQ_FILE = ROOT / "requirements-colab.txt"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -14,10 +15,6 @@ def run(cmd: list[str], log_file) -> None:
     subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
 
 
-req_file = ROOT / "requirements-colab.txt"
-if not req_file.exists():
-    req_file = ROOT / "requirements.txt"
-
 with LOG_PATH.open("w") as log_file:
     run([sys.executable, "-m", "pip", "install", "-U", "pip"], log_file)
-    run([sys.executable, "-m", "pip", "install", "-r", str(req_file)], log_file)
+    run([sys.executable, "-m", "pip", "install", "-r", str(REQ_FILE)], log_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "finansal-analiz-sistemi"
 version = "0.0.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "pandas==2.2.2",
+    "pandas==2.1.4",
     "pandas-ta==0.3.14b0",
-    "numpy==2.0.2",
+    "numpy==1.26.4",
     "click",
     "loguru",
     "pandera>=0.26.0",

--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -1,1 +1,4 @@
+numpy==1.26.4
+pandas==2.1.4
+pandas-ta==0.3.14b0
 .[colab]


### PR DESCRIPTION
## Summary
- pin numpy, pandas and pandas-ta in `requirements-colab.txt`
- align project dependencies with new pins and streamline Colab setup script

## Testing
- `python tools/verify_env.py`
- `python - <<'PY'
import numpy, pandas, pandas_ta
print(numpy.__version__, pandas.__version__, pandas_ta.__version__)
PY`
- `pre-commit run --files requirements-colab.txt notebooks/colab_setup.py pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acd09d482083258ca161a2c85218d4