### PR TITLE
Ensure pytest-benchmark is installed in Colab setup

### DIFF
--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -1,4 +1,5 @@
 numpy==1.26.4
 pandas==2.1.4
 pandas-ta==0.3.14b0
+pytest-benchmark==4.0.0
 .[colab]


### PR DESCRIPTION
## Summary
- add `pytest-benchmark` pin to Colab requirements so benchmark options are recognized

## Testing
- `pip freeze | grep -E "pytest-benchmark|pytest-cov|pytest-xdist"`
- `pytest --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68acd818af948325a1e495d630759066