### PR TITLE
feat: enable filter modules in Colab config

### DIFF
--- a/README_COLAB.md
+++ b/README_COLAB.md
@@ -32,6 +32,14 @@ setup_logger()
 !python tools/verify_env.py
 ```
 
+## Hızlı Doğrulama
+
+```bash
+!python -m backtest.cli config-validate --config config/colab_config.yaml
+
+!python -m backtest.cli dry-run --config config/colab_config.yaml
+```
+
 ## Örnek Tarama
 
 ```python
@@ -39,6 +47,15 @@ setup_logger()
   --start 2025-03-07 --end 2025-03-11
 
 !ls -la raporlar | head
+```
+
+## Kısa Smoke Test (opsiyonel)
+
+```bash
+!python -m backtest.cli scan-day --config config/colab_config.yaml --date 2025-03-07
+
+!ls -la raporlar || true
+!head -n 5 raporlar/2025-03-07.csv || true
 ```
 
 > Excel okuma/yazma için gerekli `openpyxl` ve `XlsxWriter` paketleri bağımlılık setinde yer alır.

--- a/config/colab_config.yaml
+++ b/config/colab_config.yaml
@@ -35,4 +35,7 @@ range:
 
 single:
   date: "2025-03-07"
+filters:
+  module: filters.io_filters
+  include: ["*"]
 preflight: true

--- a/filters/__init__.py
+++ b/filters/__init__.py
@@ -1,0 +1,1 @@
+"""Embedded filter definitions package."""

--- a/filters/io_filters.py
+++ b/filters/io_filters.py
@@ -1,0 +1,21 @@
+"""Example embedded filters used in Colab config.
+
+The CLI loads these definitions via ``filters.module`` configuration.
+"""
+from __future__ import annotations
+
+from typing import List, Dict
+
+FILTERS: List[Dict[str, str]] = [
+    {"FilterCode": "T1", "PythonQuery": "close > open"},
+    {"FilterCode": "T2", "PythonQuery": "sma_5 > sma_10"},
+]
+
+
+def get_filters() -> List[Dict[str, str]]:
+    """Return available filter definitions.
+
+    The structure matches ``filters.csv`` rows with ``FilterCode`` and
+    ``PythonQuery`` keys.
+    """
+    return FILTERS


### PR DESCRIPTION
## Summary
- load filters from Python module via `filters.module` config
- fail fast when filters module missing or empty and log first codes
- document quick validation and smoke test commands for Colab

## Testing
- `python -m backtest.cli config-validate --config config/colab_config.yaml`
- `python -m backtest.cli dry-run --config config/colab_config.yaml`
- `python -m backtest.cli scan-day --config config/colab_config.yaml --date 2025-03-07`
- `ls -la raporlar | head`
- `head -n 5 raporlar/2025-03-07.csv`


------
https://chatgpt.com/codex/tasks/task_e_68acf010d664832593fabbd13094139d