### PR TITLE
Add module-based filter loader

### DIFF
--- a/filters/module_loader.py
+++ b/filters/module_loader.py
@@ -1,0 +1,63 @@
+"""Load filters from a Python module.
+
+This utility provides a single entry point for obtaining filter definitions
+from a Python module. The target module must expose either a ``FILTERS``
+variable or a ``get_filters`` function that returns a list of dictionaries
+with ``FilterCode`` and ``PythonQuery`` keys.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+import importlib
+from typing import Iterable
+
+import pandas as pd
+
+DEFAULT_FILTERS_MODULE = "io_filters"
+
+
+def _extract_filters(mod) -> list[dict]:
+    if hasattr(mod, "FILTERS"):
+        return getattr(mod, "FILTERS")
+    if hasattr(mod, "get_filters"):
+        return mod.get_filters()
+    raise ValueError("filters module missing FILTERS/get_filters")
+
+
+def _filter_codes(df: pd.DataFrame, include: Iterable[str]) -> pd.DataFrame:
+    patterns = list(include)
+    mask = [any(fnmatch(code, p) for p in patterns) for code in df["FilterCode"]]
+    return df[mask].reset_index(drop=True)
+
+
+def load_filters_from_module(
+    module_path: str | None,
+    include: list[str] | None = None,
+) -> pd.DataFrame:
+    """Load filter definitions from a Python module.
+
+    Parameters
+    ----------
+    module_path:
+        Import path of the module containing filter definitions. If ``None``
+        the :data:`DEFAULT_FILTERS_MODULE` value is used.
+    include:
+        Optional list of fnmatch patterns to select a subset of filters.
+        Defaults to ``["*"]`` which selects all filters.
+    """
+
+    module_name = module_path or DEFAULT_FILTERS_MODULE
+    mod = importlib.import_module(module_name)
+    filters_list = _extract_filters(mod)
+    df = pd.DataFrame(filters_list)
+
+    required = ["FilterCode", "PythonQuery"]
+    if any(col not in df.columns for col in required):
+        raise ValueError(f"filters must contain columns {required!r}")
+
+    patterns = include or ["*"]
+    return _filter_codes(df, patterns)
+
+
+__all__ = ["DEFAULT_FILTERS_MODULE", "load_filters_from_module"]

--- a/tests/test_filters_module_loader.py
+++ b/tests/test_filters_module_loader.py
@@ -1,0 +1,45 @@
+import sys
+import types
+
+import pandas as pd
+import pytest
+
+from filters.module_loader import DEFAULT_FILTERS_MODULE, load_filters_from_module
+
+
+def _make_module(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.FILTERS = [
+        {"FilterCode": "F1", "PythonQuery": "close>0"},
+        {"FilterCode": "F2", "PythonQuery": "volume>0"},
+    ]
+    return mod
+
+
+def test_load_filters_from_module(monkeypatch):
+    mod = _make_module("dummy_mod")
+    monkeypatch.setitem(sys.modules, "dummy_mod", mod)
+    df = load_filters_from_module("dummy_mod")
+    assert list(df.columns) == ["FilterCode", "PythonQuery"]
+    assert df.shape[0] == 2
+
+
+def test_load_filters_include_pattern(monkeypatch):
+    mod = _make_module("dummy_mod2")
+    monkeypatch.setitem(sys.modules, "dummy_mod2", mod)
+    df = load_filters_from_module("dummy_mod2", include=["F1"])
+    assert df["FilterCode"].tolist() == ["F1"]
+
+
+def test_load_filters_default_module(monkeypatch):
+    mod = _make_module(DEFAULT_FILTERS_MODULE)
+    monkeypatch.setitem(sys.modules, DEFAULT_FILTERS_MODULE, mod)
+    df = load_filters_from_module(None)
+    assert df["FilterCode"].tolist() == ["F1", "F2"]
+
+
+def test_load_filters_missing(monkeypatch):
+    bad_mod = types.ModuleType("bad_mod")
+    monkeypatch.setitem(sys.modules, "bad_mod", bad_mod)
+    with pytest.raises(ValueError):
+        load_filters_from_module("bad_mod")


### PR DESCRIPTION
## Summary
- add `load_filters_from_module` helper to import filters from a Python module
- allow optional fnmatch-based include pattern filtering
- test module loader behavior and default module handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad62728dfc8325a97f22906deb7ad2