### PR TITLE
Refactor filter pipeline to use DataFrames

### DIFF
--- a/backtest/strategy/cli.py
+++ b/backtest/strategy/cli.py
@@ -11,12 +11,20 @@ import yaml
 from backtest.cv.timeseries import PurgedKFold, WalkForward, cross_validate
 
 from . import StrategyRegistry, StrategySpec, run_strategy
+from io_filters import read_filters_file
 
 
 def compare_strategies_cli(args) -> None:
     """CLI entry for comparing multiple strategies."""
 
-    reg, _constraints = StrategyRegistry.load_from_file(args.space)
+    root = Path(__file__).resolve().parents[2]
+    filters_path = root / "filters.csv"
+    filters_df = (
+        read_filters_file(filters_path)
+        if filters_path.exists()
+        else pd.DataFrame(columns=["FilterCode", "PythonQuery"])
+    )
+    reg, _constraints = StrategyRegistry.load_from_file(args.space, filters_df)
     dates = pd.date_range(args.start, args.end, freq="B")
     np.random.seed(0)
     data = pd.DataFrame({"returns": np.random.normal(0, 0.01, len(dates))}, index=dates)

--- a/backtest/validation/core.py
+++ b/backtest/validation/core.py
@@ -5,7 +5,6 @@ import pandas as pd
 from backtest.dsl import DSLError, parse_expression
 from backtest.naming import (
     CANONICAL_SET,
-    load_alias_map,
     normalize_indicator_token,
 )
 
@@ -14,17 +13,17 @@ from .report import ValidationReport
 
 
 def validate_filters(
-    csv_path: str,
-    alias_csv: str | None = None,
+    filters_df: pd.DataFrame,
+    alias_map: dict[str, str] | None = None,
 ) -> ValidationReport:
-    df = pd.read_csv(csv_path, sep=";", dtype=str, encoding="utf-8")
+    df = filters_df
     report = ValidationReport()
 
     if list(df.columns) != ["FilterCode", "PythonQuery"]:
         raise ValidationError("filters.csv hatalı başlık", code="VC999")
 
     seen_codes = set()
-    alias_map = load_alias_map(alias_csv).mapping if alias_csv else {}
+    alias_map = alias_map or {}
 
     for i, row in df.iterrows():
         code = str(row.get("FilterCode", "")).strip()

--- a/tests/integration/test_cli_preflight_flag.py
+++ b/tests/integration/test_cli_preflight_flag.py
@@ -8,7 +8,7 @@ def test_cli_preflight_flag(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "read_excels_long", lambda src: df)
     called = {}
 
-    def fake_validate(_filters, excel_dir):
+    def fake_validate(_filters_df, _dataset_df):
         called["preflight"] = True
 
     monkeypatch.setattr(cli, "preflight_validate_filters", fake_validate, raising=False)

--- a/tests/strategy/test_registry.py
+++ b/tests/strategy/test_registry.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 import yaml
 
 from backtest.strategy import StrategyRegistry
@@ -16,7 +17,8 @@ def test_load_from_yaml(tmp_path):
     }
     p = tmp_path / "s.yaml"
     p.write_text(yaml.safe_dump(cfg))
-    reg, constraints = StrategyRegistry.load_from_file(p)
+    filters_df = pd.DataFrame({"FilterCode": ["T1"], "PythonQuery": ["close>0"]})
+    reg, constraints = StrategyRegistry.load_from_file(p, filters_df)
     assert reg.get("s1").filters == ["T1"]
     assert constraints == {}
 
@@ -25,5 +27,6 @@ def test_unknown_filter(tmp_path):
     cfg = {"strategies": [{"id": "bad", "filters": ["BAD"]}]}
     p = tmp_path / "bad.yaml"
     p.write_text(yaml.safe_dump(cfg))
+    filters_df = pd.DataFrame({"FilterCode": ["T1"], "PythonQuery": ["close>0"]})
     with pytest.raises(ValueError):
-        StrategyRegistry.load_from_file(p)
+        StrategyRegistry.load_from_file(p, filters_df)

--- a/tests/test_validation_filters.py
+++ b/tests/test_validation_filters.py
@@ -1,4 +1,6 @@
-import tempfile
+from io import StringIO
+
+import pandas as pd
 
 from backtest.validation import validate_filters
 
@@ -10,14 +12,8 @@ F1;close > 10
 
 
 def test_validation_detects_errors():
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".csv",
-        delete=False,
-    ) as f:
-        f.write(CSV_CONTENT)
-        fname = f.name
-    rep = validate_filters(fname)
+    df = pd.read_csv(StringIO(CSV_CONTENT), sep=";")
+    rep = validate_filters(df)
     codes = [e["code"] for e in rep.errors]
     assert "VC002" in codes  # boş query
     assert "VC001" in codes  # FilterCode tekrarı

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,14 +1,10 @@
-from pathlib import Path
-
 import pandas as pd
 
 from backtest.filters.preflight import validate_filters
+from io_filters import read_filters_file
 
 
 def test_preflight_ok(tmp_path):
     df = pd.DataFrame({"close": [1], "volume": [2]})
-    excel_dir = tmp_path / "excels"
-    excel_dir.mkdir()
-    df.to_excel(excel_dir / "sample.xlsx", index=False)
-    filters = Path("tests/data/filters_valid.csv")
-    validate_filters(filters, excel_dir)
+    filters_df = read_filters_file("tests/data/filters_valid.csv")
+    validate_filters(filters_df, df)

--- a/tests/unit/test_preflight_alias_allowed.py
+++ b/tests/unit/test_preflight_alias_allowed.py
@@ -1,16 +1,15 @@
 import pandas as pd
 
 from backtest.filters.preflight import validate_filters
+from io_filters import read_filters_file
 
 
 def test_alias_allowed(tmp_path):
-    excel_dir = tmp_path / "excels"
-    excel_dir.mkdir()
     df = pd.DataFrame({"close": [1]})
-    df.to_excel(excel_dir / "sample.xlsx", index=False)
     f = tmp_path / "filters.csv"
     f.write_text(
         "FilterCode;PythonQuery\nX1;SMA50 > BBU_20_2.0\n",
         encoding="utf-8",
     )
-    validate_filters(f, excel_dir, alias_mode="allow", allow_unknown=True)
+    filters_df = read_filters_file(f)
+    validate_filters(filters_df, df, alias_mode="allow", allow_unknown=True)

--- a/tests/unit/test_preflight_alias_enforce.py
+++ b/tests/unit/test_preflight_alias_enforce.py
@@ -4,26 +4,25 @@ import pandas as pd
 import pytest
 
 from backtest.filters.preflight import validate_filters
+from io_filters import read_filters_file
 
 
-def _setup(tmp_path: Path) -> tuple[Path, Path]:
+def _setup(tmp_path: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
     df = pd.DataFrame({"close": [1]})
-    excel_dir = tmp_path / "excels"
-    excel_dir.mkdir()
-    df.to_excel(excel_dir / "sample.xlsx", index=False)
     filters_path = tmp_path / "filters.csv"
     content = "FilterCode;PythonQuery\nF1;SMA50 > 0\n"
     filters_path.write_text(content, encoding="utf-8")
-    return filters_path, excel_dir
+    filters_df = read_filters_file(filters_path)
+    return filters_df, df
 
 
 def test_alias_forbid(tmp_path: Path) -> None:
-    filters_path, excel_dir = _setup(tmp_path)
+    filters_df, df = _setup(tmp_path)
     with pytest.raises(SystemExit):
-        validate_filters(filters_path, excel_dir, alias_mode="forbid")
+        validate_filters(filters_df, df, alias_mode="forbid")
 
 
 def test_alias_warn(tmp_path: Path) -> None:
-    filters_path, excel_dir = _setup(tmp_path)
+    filters_df, df = _setup(tmp_path)
     with pytest.warns(UserWarning):
-        validate_filters(filters_path, excel_dir, alias_mode="warn")
+        validate_filters(filters_df, df, alias_mode="warn")

--- a/tools/lint_filters.py
+++ b/tools/lint_filters.py
@@ -17,6 +17,7 @@ import yaml
 
 from backtest.filters.engine import ALIAS
 from backtest.paths import EXCEL_DIR
+from io_filters import read_filters_file
 
 
 def _load_cfg(path: Path) -> dict:
@@ -50,12 +51,7 @@ def main() -> None:
     df = pd.read_excel(sample)
     cols = set(df.columns)
 
-    fdf = pd.read_csv(
-        filters_path,
-        sep=";",
-        usecols=["FilterCode", "PythonQuery"],
-        dtype=str,
-    )
+    fdf = read_filters_file(filters_path)
     ok = True
     for i, expr in enumerate(fdf.get("PythonQuery", [])):
         tokens = _tokenize(str(expr))

--- a/tools/preflight_run.py
+++ b/tools/preflight_run.py
@@ -2,19 +2,26 @@ import os
 import sys
 from pathlib import Path
 
+import pandas as pd
+
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from backtest.filters.preflight import validate_filters  # noqa: E402
 from backtest.paths import DATA_DIR  # noqa: E402
+from io_filters import read_filters_file  # noqa: E402
 
-filters = Path("filters.csv")
-if not filters.exists():
-    filters = Path("config/filters.csv")
+filters_path = Path("filters.csv")
+if not filters_path.exists():
+    filters_path = Path("config/filters.csv")
 alias_mode = os.getenv("PREFLIGHT_ALIAS_MODE", "forbid")
 allow_unknown = os.getenv("PREFLIGHT_ALLOW_UNKNOWN", "0") == "1"
 
+filters_df = read_filters_file(filters_path)
+sample = next(DATA_DIR.rglob("*.xlsx"))
+dataset_df = pd.read_excel(sample, nrows=0)
+
 validate_filters(
-    filters,
-    DATA_DIR,
+    filters_df,
+    dataset_df,
     alias_mode=alias_mode,
     allow_unknown=allow_unknown,
 )


### PR DESCRIPTION
## Summary
- refactor preflight validation to operate on in-memory DataFrames instead of CSV paths
- update strategy registry and CLI to source canonical filters from DataFrames
- adjust tools and validation helpers to use DataFrame APIs

## Testing
- `pre-commit run --files backtest/filters/preflight.py backtest/strategy/cli.py backtest/strategy/registry.py backtest/validation/core.py tests/integration/test_cli_preflight_flag.py tests/preflight/test_alias_and_unknown.py tests/strategy/test_registry.py tests/test_validation_filters.py tests/unit/test_preflight.py tests/unit/test_preflight_alias_allowed.py tests/unit/test_preflight_alias_enforce.py tools/lint_filters.py tools/preflight_run.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad963181248325ac98077eca288462