### PR TITLE
docs: switch filters to modules

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -7,7 +7,7 @@
 - **`BIST.xlsx` eksikse ne yaparım?** Örnek dosyayı `data/`ya kopyala; [Yol & Veri Sorunları](TROUBLESHOOT.md#yol-veri-sorunlari).
 - **CLI komutları nereden öğrenirim?** `python -m backtest.cli --help`; sorunlar için [CLI Hataları](TROUBLESHOOT.md#cli-hatalari).
 - **Tarih formatı ne olmalı?** ISO `YYYY-MM-DD`; [CLI Hataları](TROUBLESHOOT.md#cli-hatalari).
-- **`filters.csv` bulunamıyor, neden?** Yanlış yol; [Yol & Veri Sorunları](TROUBLESHOOT.md#yol-veri-sorunlari).
+- **Filtre modülü bulunamıyor, neden?** Modül yolu yanlış; [Yol & Veri Sorunları](TROUBLESHOOT.md#yol-veri-sorunlari).
 - **`ModuleNotFoundError: openpyxl` ne demek?** Excel motoru eksik; [Excel/CSV/Parquet Okuma Hataları](TROUBLESHOOT.md#excel-hatalari).
 - **Büyük Excel dosyaları yavaş mı?** Parquet'e dönüştür; [Excel/CSV/Parquet Okuma Hataları](TROUBLESHOOT.md#excel-hatalari).
 - **Parquet'e nasıl dönüştürürüm?** `convert-to-parquet` komutunu kullan; [Excel/CSV/Parquet Okuma Hataları](TROUBLESHOOT.md#excel-hatalari).

--- a/SCOPE_STAGE1.md
+++ b/SCOPE_STAGE1.md
@@ -19,7 +19,7 @@ Hedef: Basit ama hatasız, tekrarlanabilir ve denetlenebilir çıktı.
 MACD histogram rengi, "en iyi hisse seçimi", canlı tarama, portföy kuralları, optimizasyon, dashboard.
 
 ## 3. Girdiler
-- Fiyat verisi, filters.csv, alias_mapping.csv, config.
+- Fiyat verisi, filtre modülü, alias_mapping.csv, config.
 
 ## 4. Çıktılar
 - Günlük sinyaller: `raporlar/gunluk/YYYY-MM-DD.csv`
@@ -34,7 +34,7 @@ MACD histogram rengi, "en iyi hisse seçimi", canlı tarama, portföy kuralları
 Eval yok, deterministik çalışma, NaN→False, isim standardı zorunlu, dry-run varsayılan.
 
 ## 7. Kabul Kriterleri
-1) filters.csv hatasız
+1) filtre modülü hatasız
 2) Örnek 3 gün sinyalleri tutar
 3) Özet tablolar ±0.0001 sapma
 4) Log/artefakt tam

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -13,7 +13,7 @@
 ### Komut örnekleri
 ```bash
 python -m backtest.cli --help
-python -m backtest.cli dry-run \-\-filters filters.csv
+python -m backtest.cli scan-day --config config/scan.yml --filters-module io_filters --filters-include "*"
 python -m backtest.cli convert-to-parquet --out data_parquet
 ```
 
@@ -102,7 +102,7 @@ python -m backtest.cli convert-to-parquet --out data_parquet
 - **Çözüm Adımları**:
   ```bash
   python -m backtest.cli scan-range --start 2024-01-01 --end 2024-01-05 \
-    --data data/BIST.xlsx \-\-filters filters.csv --out raporlar
+    --data data/BIST.xlsx --filters-module io_filters --filters-include "*" --out raporlar
   ```
 - **Doğrulama**: Komut başarıyla tamamlanır ve `raporlar/` dizini oluşur.
 
@@ -144,7 +144,8 @@ python -m backtest.cli convert-to-parquet --out data_parquet
 - **Muhtemel Neden(ler)**: Log seviyesi düşük veya dizin bilinmiyor.
 - **Çözüm Adımları**:
   ```bash
-  python -m backtest.cli scan-day --data data/BIST.xlsx \-\-filters filters.csv \
+  python -m backtest.cli scan-day --data data/BIST.xlsx \
+    --filters-module io_filters --filters-include "*" \
     --date 2024-01-02 --out raporlar --log-level DEBUG
   ```
   Loglar varsayılan olarak `loglar/` dizinine yazılır.

--- a/docs/cli_spec.md
+++ b/docs/cli_spec.md
@@ -2,24 +2,21 @@
 
 ## Amaç
 - Güvenli varsayılanlar, hataya dayanıklı argüman işleme, açık yardım metinleri.
-- Feature flag'lerle davranışın kontrolü (ör. `dry_run`, `filters_enabled`, `write_outputs`).
+- Feature flag'lerle davranışın kontrolü (ör. `dry_run`, `write_outputs`).
 
 ## Varsayılanlar
 - `dry_run = true`
-- `filters_enabled = true`
 - `write_outputs = true` (yalnız `scan-*` komutlarında)
 - `log_level = INFO`
 
 ## Bayraklar (genel)
 - `--config path.yaml` (opsiyonel)
 - `--log-level {DEBUG,INFO,WARNING,ERROR}`
-- `\-\-filters-off` → `filters_enabled = false`
 - `--dry-run` → doğrulama modunu çalıştır (A4)
 
 ## Komutlar
-- `dry-run \-\-filters filters.csv [--alias alias.csv]`
-- `scan-day --data <path> --date YYYY-MM-DD \-\-filters filters.csv --out dir [--alias alias.csv] [\-\-filters-off] [--no-write]`
-- `scan-range --data <path> --start YYYY-MM-DD --end YYYY-MM-DD \-\-filters filters.csv --out dir [--alias alias.csv] [\-\-filters-off] [--no-write]`
+- `scan-day --data <path> --date YYYY-MM-DD --filters-module io_filters --filters-include "*" --out dir [--alias alias.csv] [--no-write]`
+- `scan-range --data <path> --start YYYY-MM-DD --end YYYY-MM-DD --filters-module io_filters --filters-include "*" --out dir [--alias alias.csv] [--no-write]`
 
 ## Hata Kodları (CLI)
 - CL001: Argüman eksik/uyumsuz
@@ -29,5 +26,4 @@
 ## Kabul Kriterleri
 - Yanlış argümanlarda anlamlı hata mesajı + çıkış kodu 2
 - Varsayılanlar config dosyası ve env ile override edilebilir
-- `filters_off` iken filtreler uygulanmaz (sadece veri/indikatör hazırlığı)
 - `--no-write` ile dosya yazımı yapılmadan sadece konsol özeti basılır

--- a/docs/colab.md
+++ b/docs/colab.md
@@ -18,10 +18,6 @@ print("OK: Kurulum bitti. Eğer NumPy/Pandas yükseldiyse Runtime → Restart ru
 !git clone https://github.com/TugrulKaraaslan/finansal-analiz-sistemi.git || echo "Repo zaten var"
 %cd /content/finansal-analiz-sistemi
 !mkdir -p raporlar loglar config data cache
-from pathlib import Path
-if not Path("filters.csv").exists():
-    Path("filters.csv").write_text("FilterCode,PythonQuery\nEXAMPLE_01, (rsi_14 > 50) & (ema_20 > ema_50)\n", encoding="utf-8")
-    print("⚠️ filters.csv örneği oluşturuldu. Kendi dosyanla değiştir.")
 ```
 
 ### Hücre 3 — Config yaz (mutlak yollar)
@@ -38,7 +34,6 @@ project:
 
 data:
   excel_dir: "/content/finansal-analiz-sistemi/data"
-  filters_csv: "/content/finansal-analiz-sistemi/filters.csv"
   enable_cache: false
   cache_parquet_path: "cache"
 
@@ -53,6 +48,10 @@ data:
     csv_path: ""
     column_date: "date"
     column_close: "close"
+
+filters:
+  module: "io_filters"
+  include: ["*"]
 
 report:
   with_bist_ratio_summary: true

--- a/docs/dsl_spec.md
+++ b/docs/dsl_spec.md
@@ -1,7 +1,7 @@
 # PythonQuery DSL – Aşama 1 (Güvenli AST & Kesişim Semantiği)
 
 ## Amaç
-`filters.csv` içindeki `PythonQuery` ifadelerini **güvenli**, **deterministik** ve **okunur** şekilde değerlendirmek.
+Filtre modülündeki `PythonQuery` ifadelerini **güvenli**, **deterministik** ve **okunur** şekilde değerlendirmek.
 
 ## Temel Kurallar
 - **Güvenlik:** Python `eval` YOK. Sadece `ast.parse(..., mode="eval")` + **whitelist** node yürütme.

--- a/docs/run_batch_design.md
+++ b/docs/run_batch_design.md
@@ -4,9 +4,9 @@
 03.01.2022 – 18.04.2025 aralığındaki **her işlem gününde** filtreleri çalıştırıp, günlük sinyal dosyaları üretmek.
 
 ## Akış
-1) **Girdi**: fiyat DataFrame'i (index=Date, kolonlar=kanonik), `filters.csv`, `alias_mapping.csv` (opsiyonel)
+1) **Girdi**: fiyat DataFrame'i (index=Date, kolonlar=kanonik), filtre modülü (ör. `io_filters`), `alias_mapping.csv` (opsiyonel)
 2) **Normalize**: A3 katmanı ile kolonlar alias→kanonik + snake_case (in-memory)
-3) **Dry-Run**: A4 katmanı ile `filters.csv` fail-fast kontrol (hata varsa dur)
+3) **Dry-Run**: A4 katmanı ile filtre tanımlarının fail-fast kontrolü (hata varsa dur)
 4) **Ön Hesap**: A5 katmanı ile gerekli göstergeleri tek seferde hesapla
 5) **Günlük Döngü**: Her işlem günü için DSL (A2) ile bool mask üret; sinyalleri listele
 6) **Yazım**: `raporlar/gunluk/YYYY-MM-DD.csv`

--- a/docs/validation_plan.md
+++ b/docs/validation_plan.md
@@ -1,10 +1,10 @@
 # Dry‑Run Doğrulama (A4) – Plan
 
 ## Amaç
-`filters.csv` içindeki filtrelerin ve veri kolonlarının geçerliliğini **çalıştırmadan önce** kontrol etmek.
+Filtre modülündeki filtrelerin ve veri kolonlarının geçerliliğini **çalıştırmadan önce** kontrol etmek.
 
 ## Doğrulanan Alanlar
-1. **CSV Şeması**
+1. **Filtre Listesi**
    - `FilterCode` boş değil, tekil olmalı
    - `PythonQuery` boş olmamalı
 2. **DSL İfadeleri**
@@ -20,7 +20,7 @@
 
 ## CLI Kullanımı
 ```bash
-python -m backtest.cli \-\-filters filters.csv --dry-run
+python -m backtest.cli --filters-module io_filters --filters-include "*" --dry-run
 ```
 
 Çıktı: Hata/uyarı raporu. Başarılı ise: `✅ Uyum Tam`


### PR DESCRIPTION
## Summary
- remove CSV-based filter references from docs in favor of module-based usage
- add migration note and module config examples

## Testing
- `pre-commit run --files README.md USAGE.md docs/cli_spec.md docs/colab.md docs/dsl_spec.md docs/run_batch_design.md docs/validation_plan.md SCOPE_STAGE1.md TROUBLESHOOT.md FAQ.md`
- `pytest`
- `git grep -n $'filters\.csv|--filters\b|--filters-off' docs/`


------
https://chatgpt.com/codex/tasks/task_e_68ad9def85d08325a97cf341d17ad6a9