### PR TITLE
Refactor tools to use module filters

### DIFF
--- a/tools/ci_checks.sh
+++ b/tools/ci_checks.sh
@@ -6,6 +6,10 @@ echo "== Env =="
 python --version
 pip --version
 
+echo "== Legacy CSV guard =="
+if rg -n 'filters\.csv|load_filters_csv|--filters\b|--filters-off' -S tools -g '!ci_checks.sh'; then
+  echo "CSV/legacy flags detected"; exit 1; fi
+
 echo "== Ensure package importable =="
 python - <<'PY'
 import importlib, sys

--- a/tools/lint_filters.py
+++ b/tools/lint_filters.py
@@ -17,7 +17,7 @@ import yaml
 
 from backtest.filters.engine import ALIAS
 from backtest.paths import EXCEL_DIR
-from io_filters import read_filters_file
+from filters.module_loader import load_filters_from_module
 
 
 def _load_cfg(path: Path) -> dict:
@@ -38,9 +38,7 @@ def main() -> None:
     cfg_path = (
         Path(sys.argv[1]) if len(sys.argv) > 1 else Path("config_scan.yml")
     )
-    filters_path = (
-        Path(sys.argv[2]) if len(sys.argv) > 2 else Path("filters.csv")
-    )
+    filters_module = sys.argv[2] if len(sys.argv) > 2 else None
     # fmt: on
     _load_cfg(cfg_path)
 
@@ -51,7 +49,7 @@ def main() -> None:
     df = pd.read_excel(sample)
     cols = set(df.columns)
 
-    fdf = read_filters_file(filters_path)
+    fdf = load_filters_from_module(filters_module)
     ok = True
     for i, expr in enumerate(fdf.get("PythonQuery", [])):
         tokens = _tokenize(str(expr))

--- a/tools/preflight_run.py
+++ b/tools/preflight_run.py
@@ -7,15 +7,13 @@ import pandas as pd
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from backtest.filters.preflight import validate_filters  # noqa: E402
 from backtest.paths import DATA_DIR  # noqa: E402
-from io_filters import read_filters_file  # noqa: E402
+from filters.module_loader import load_filters_from_module  # noqa: E402
 
-filters_path = Path("filters.csv")
-if not filters_path.exists():
-    filters_path = Path("config/filters.csv")
 alias_mode = os.getenv("PREFLIGHT_ALIAS_MODE", "forbid")
 allow_unknown = os.getenv("PREFLIGHT_ALLOW_UNKNOWN", "0") == "1"
+filters_module = os.getenv("FILTERS_MODULE")
 
-filters_df = read_filters_file(filters_path)
+filters_df = load_filters_from_module(filters_module)
 sample = next(DATA_DIR.rglob("*.xlsx"))
 dataset_df = pd.read_excel(sample, nrows=0)
 

--- a/tools/walk_forward_eval.py
+++ b/tools/walk_forward_eval.py
@@ -45,8 +45,6 @@ with results_path.open("w", encoding="utf-8") as w:
             "scan-range",
             "--config",
             "config_scan.yml",
-            "--" "filters-module",
-            "io_filters",
             "--no-preflight",
             "--start",
             f["train_start"],


### PR DESCRIPTION
## Summary
- load filters via module loader in tooling scripts
- drop CSV and legacy flag references
- add CI guard against CSV/legacy filter usage

## Testing
- `./tools/ci_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ada59897048325b9185a02e2c340c9