### PR TITLE
Fail clearly on legacy filter configs

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -448,7 +448,7 @@ def main(argv=None):
         if arg == bad_off:
             raise RuntimeError("Use --" "filters-include= (empty) to disable filters.")
         if arg.startswith(bad) and not any(arg.startswith(ok) for ok in allowed):
-            raise RuntimeError("CSV filters are removed. Use `filters.module`.")
+            raise RuntimeError("CSV-based filters are removed. Use `filters.module`.")
     if argv and argv[0] in {
         "scan-day",
         "scan-range",
@@ -575,7 +575,7 @@ def main(argv=None):
 
     cfg, flags = _load_and_prepare(args)
     if getattr(getattr(cfg, "data", NS()), "filters_csv", None):
-        raise RuntimeError("CSV filters are removed. Use `filters.module`.")
+        raise RuntimeError("CSV-based filters are removed. Use `filters.module`.")
 
     cfg_dict = _ns_to_dict(cfg)
     log_root = cfg_dict.get("paths", {}).get("logs", os.getenv("LOG_DIR", "loglar"))

--- a/backtest/config/config.py
+++ b/backtest/config/config.py
@@ -112,9 +112,7 @@ def _expand_paths(doc: dict, base: Path) -> dict:
         cpp = doc["data"]["cache_parquet_path"]
         doc["data"]["cache_parquet_path"] = _norm(cpp)
     if doc.get("calendar", {}).get("holidays_csv_path"):
-        doc["calendar"]["holidays_csv_path"] = _norm(
-            doc["calendar"]["holidays_csv_path"]
-        )
+        doc["calendar"]["holidays_csv_path"] = _norm(doc["calendar"]["holidays_csv_path"])
     for key in ("excel_path", "csv_path"):
         if doc.get("benchmark", {}).get(key):
             doc["benchmark"][key] = _norm(doc["benchmark"][key])
@@ -133,12 +131,14 @@ def load_config(path: str | Path) -> NS:
         user = yaml.safe_load(f) or {}
     if not isinstance(user, dict):
         raise TypeError("config mapping olmalı")
-    if user.get("data", {}).get("filters_csv"):
-        raise ValueError("data.filters_csv kaldırıldı; filters.module kullanın")
-    if user.get("filters_csv"):
-        raise ValueError("filters_csv kaldırıldı; filters.module kullanın")
-    if user.get("filters", {}).get("path"):
-        raise ValueError("filters.path kaldırıldı; filters.module kullanın")
+    if (
+        user.get("data", {}).get("filters_csv")
+        or user.get("filters_csv")
+        or user.get("filters", {}).get("path")
+    ):
+        raise ValueError("CSV-based filters are removed. Use `filters.module`.")
+    if "filters" not in user or "module" not in user.get("filters", {}):
+        raise ValueError("filters.module is required (default: io_filters)")
     user = _apply_legacy(user)
     doc = _deep_merge(_DEFAULT, user)
     if doc.get("indicators", {}).get("engine") != "none":

--- a/tests/test_filters_csv_removed.py
+++ b/tests/test_filters_csv_removed.py
@@ -4,37 +4,57 @@ from pathlib import Path
 import pytest
 
 from backtest import cli
+from backtest.config import load_config
 
 
-def test_csv_filters_param_and_field_rejected(tmp_path: Path):
+def _write_cfg(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "cfg.yml"
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+def test_cli_filters_args_rejected():
     bad = "--" + "filters"
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="CSV-based filters are removed. Use `filters.module`."):
         cli.main(["scan-day", bad, "foo.csv"])
 
     bad_off = bad + "-off"
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        RuntimeError,
+        match=r"Use --filters-include= \(empty\) to disable filters.",
+    ):
         cli.main(["scan-day", bad_off])
 
-    cfg = tmp_path / "cfg.yml"
-    cfg.write_text(
-        textwrap.dedent(
-            """
-            project:
-              out_dir: out
-              run_mode: range
-              start_date: '2024-01-01'
-              end_date: '2024-01-01'
-              holding_period: 1
-              transaction_cost: 0
-            data:
-              excel_dir: .
-              filters_csv: foo.csv
-            filters:
-              module: io_filters
-              include: ['*']
-            """
-        ),
-        encoding="utf-8",
+
+def test_filters_csv_fields_rejected(tmp_path: Path):
+    cfg = _write_cfg(
+        tmp_path,
+        """
+        data:
+          filters_csv: foo.csv
+        filters:
+          module: io_filters
+        """,
     )
-    with pytest.raises(ValueError):
-        cli.main(["scan-day", "--config", str(cfg), "--date", "2024-01-01"])
+    with pytest.raises(ValueError, match="CSV-based filters are removed. Use `filters.module`."):
+        load_config(cfg)
+
+    cfg = _write_cfg(tmp_path, "filters_csv: foo.csv")
+    with pytest.raises(ValueError, match="CSV-based filters are removed. Use `filters.module`."):
+        load_config(cfg)
+
+    cfg = _write_cfg(
+        tmp_path,
+        """
+        filters:
+          path: foo.csv
+        """,
+    )
+    with pytest.raises(ValueError, match="CSV-based filters are removed. Use `filters.module`."):
+        load_config(cfg)
+
+
+def test_filters_module_missing(tmp_path: Path):
+    cfg = _write_cfg(tmp_path, "")
+    with pytest.raises(ValueError, match=r"filters.module is required \(default: io_filters\)"):
+        load_config(cfg)


### PR DESCRIPTION
## Summary
- validate config for missing filters.module and removed CSV-based filter fields
- reject deprecated CLI flags for CSV filters with clear messages
- add tests for new configuration and flag failures

## Testing
- `pre-commit run --files backtest/config/config.py backtest/cli.py tests/test_filters_csv_removed.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adabc815c08325bcddae8b6837d22c