### PR TITLE
Examples & docs—explicit module config snippet

### DIFF
--- a/docs/cli_spec.md
+++ b/docs/cli_spec.md
@@ -21,6 +21,16 @@
 Örnek:
 `python -m backtest.cli scan-day --config config/scan.yml --filters-module io_filters --filters-include "*"`
 
+## Filters configuration
+
+```yaml
+filters:
+  module: "io_filters"
+  include: ["*"]
+```
+
+Tam örnek için `examples/example_filters_module.yml` dosyasına bakın.
+
 ## Hata Kodları (CLI)
 - CL001: Argüman eksik/uyumsuz
 - CL002: Dosya yolu yok/erişilemedi

--- a/examples/example_filters_module.yml
+++ b/examples/example_filters_module.yml
@@ -1,0 +1,5 @@
+---
+filters:
+  module: "io_filters"
+  include: ["*"]
+# diğer alanlar proje örneklerine göre sade bırakılabilir


### PR DESCRIPTION
## Summary
- add minimal filters module configuration example
- document filter module YAML snippet in CLI spec

## Testing
- `pytest -q`
- `PYTHONPATH=. python tools/lint_filters.py` *(fails: cannot import name 'ALIAS')*

------
https://chatgpt.com/codex/tasks/task_e_68ae3c79121c8325be53e805273e3542