### PR TITLE
Emit real symbols and all matches in scan-range CSV reports

### DIFF
--- a/backtest/batch/io.py
+++ b/backtest/batch/io.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import pandas as pd
 
+from backtest.logging_conf import get_logger
+
+logger = get_logger("output_writer")
+
 
 class OutputWriter:
     def __init__(self, out_dir: str | Path):
@@ -16,10 +20,12 @@ class OutputWriter:
         if not rows:
             # Boş gün de dosyalanır (görülebilirlik için)
             df = pd.DataFrame(columns=["date", "symbol", "filter_code"])
-            df.to_csv(p, index=False)
+            df.to_csv(p, index=False, encoding="utf-8")
+            logger.info("wrote=%d path=%s", 0, p)
             return p
         df = pd.DataFrame(rows, columns=["symbol", "filter_code"])
         df.insert(0, "date", pd.to_datetime(day).date())
         df.drop_duplicates(subset=["date", "symbol", "filter_code"], inplace=True)
-        df.to_csv(p, index=False)
+        df.to_csv(p, index=False, encoding="utf-8")
+        logger.info("wrote=%d path=%s", len(df), p)
         return p

--- a/backtest/batch/runner.py
+++ b/backtest/batch/runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
 from time import perf_counter
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import pandas as pd
 
@@ -19,40 +19,36 @@ from backtest.normalize import normalize_dataframe
 log = get_logger("runner")
 
 
+def _parse_symbol_columns(df: pd.DataFrame) -> Dict[str, List[str]]:
+    """Map symbols to their column names.
+
+    Column convention: SYMBOL_field. Falls back to df.attrs['symbol'] for
+    single-symbol data.
+    """
+    sym_map: Dict[str, List[str]] = {}
+    for c in df.columns:
+        if isinstance(c, str) and "_" in c:
+            sym, rest = c.split("_", 1)
+            if sym.isupper():
+                sym_map.setdefault(sym, []).append(c)
+    if sym_map:
+        return sym_map
+    sym = df.attrs.get("symbol")
+    if not sym:
+        raise ValueError("df.attrs['symbol'] missing for single-symbol data")
+    return {sym: list(df.columns)}
+
+
 def _process_chunk(args):
-    df_chunk, filters_df, indicators, day, alias_csv, multi_symbol = args
+    df_chunk, filters_df, indicators, day, alias_csv = args
     df_chunk, _ = normalize_dataframe(df_chunk, alias_csv, policy="prefer_first")  # noqa: E501
     df_chunk = precompute_for_chunk(df_chunk, indicators)
     d = pd.to_datetime(day)
     rows: List[Tuple[str, str]] = []
-    if multi_symbol:
-        symbols = sorted({c[0] for c in df_chunk.columns})
-        for sym in symbols:
-            sub = df_chunk.xs(sym, axis=1, level=0)
-            for i, r in enumerate(filters_df.itertuples(index=False)):
-                code = str(r.FilterCode).strip()
-                expr = str(r.PythonQuery).strip()
-                log_with(
-                    log,
-                    "DEBUG",
-                    "evaluate",
-                    expr=expr,
-                    chunk_idx=i,
-                    symbol=sym,
-                )
-                try:
-                    mask = evaluate(sub, expr)
-                except Exception as e:
-                    log.exception(
-                        "evaluate failed",
-                        extra={"extra_fields": {"expr": expr}},
-                    )
-                    raise ValueError(f"Filter evaluation failed: {expr} → {e}") from e  # noqa: E501
-                val = mask.loc[d]
-                ok = val.any() if isinstance(val, pd.Series) else bool(val)
-                if ok:
-                    rows.append((sym, code))
-    else:
+    sym_cols = _parse_symbol_columns(df_chunk)
+    for sym, cols in sym_cols.items():
+        sub = df_chunk[cols].copy()
+        sub.columns = [c.split("_", 1)[1] if c.startswith(f"{sym}_") else c for c in cols]
         for i, r in enumerate(filters_df.itertuples(index=False)):
             code = str(r.FilterCode).strip()
             expr = str(r.PythonQuery).strip()
@@ -62,9 +58,10 @@ def _process_chunk(args):
                 "evaluate",
                 expr=expr,
                 chunk_idx=i,
+                symbol=sym,
             )
             try:
-                mask = evaluate(df_chunk, expr)
+                mask = evaluate(sub, expr)
             except Exception as e:
                 log.exception(
                     "evaluate failed",
@@ -74,7 +71,7 @@ def _process_chunk(args):
             val = mask.loc[d]
             ok = val.any() if isinstance(val, pd.Series) else bool(val)
             if ok:
-                rows.append(("SYMBOL", code))
+                rows.append((sym, code))
     return rows
 
 
@@ -86,7 +83,6 @@ def run_scan_day(
     alias_csv: str | None = None,
 ) -> List[Tuple[str, str]]:
     """Generate signals for a single day."""
-    multi_symbol = isinstance(df.columns, pd.MultiIndex) and df.columns.nlevels == 2  # noqa: E501
     indicators = collect_required_indicators(filters_df)
     return _process_chunk(
         (
@@ -95,7 +91,6 @@ def run_scan_day(
             indicators,
             day,
             alias_csv,
-            multi_symbol,
         )
     )
 
@@ -120,26 +115,19 @@ def run_scan_range(
     if len(days) == 0:
         raise RuntimeError("BR002: tarih aralığı veriyle kesişmiyor")
 
-    multi_symbol = isinstance(df.columns, pd.MultiIndex) and df.columns.nlevels == 2  # noqa: E501
-    symbols = sorted({c[0] for c in df.columns}) if multi_symbol else ["SYMBOL"]  # noqa: E501
-    chunks = [
-        symbols[i : i + chunk_size]  # noqa: E203
-        for i in range(
-            0,
-            len(symbols),
-            chunk_size,
-        )
-    ]
+    sym_cols = _parse_symbol_columns(df)
+    symbols = sorted(sym_cols.keys())
+    chunks = [symbols[i : i + chunk_size] for i in range(0, len(symbols), chunk_size)]  # noqa: E203
     indicators = collect_required_indicators(filters_df)
 
     for day in days:
         t0 = perf_counter()
         tasks = []
         for chunk_syms in chunks:
-            if multi_symbol:
-                df_chunk = df.loc[:, pd.IndexSlice[chunk_syms, :]].copy()
-            else:
-                df_chunk = df.copy()
+            cols: List[str] = []
+            for sym in chunk_syms:
+                cols.extend(sym_cols[sym])
+            df_chunk = df.loc[:, cols].copy()
             tasks.append(
                 (
                     df_chunk,
@@ -147,7 +135,6 @@ def run_scan_range(
                     indicators,
                     str(day.date()),
                     alias_csv,
-                    multi_symbol,
                 )
             )
         if workers > 1:

--- a/tests/test_batch_runner.py
+++ b/tests/test_batch_runner.py
@@ -11,7 +11,7 @@ idx = pd.date_range("2024-01-01", periods=5, freq="B")
 
 def _df_single():
     np.random.seed(0)
-    return pd.DataFrame(
+    df = pd.DataFrame(
         {
             "open": [9, 10, 11, 10, 12],
             "high": [10, 11, 12, 11, 13],
@@ -21,6 +21,8 @@ def _df_single():
         },
         index=idx,
     )
+    df.attrs["symbol"] = "SYM"
+    return df
 
 
 def _filters_df():
@@ -40,7 +42,7 @@ def test_run_scan_day_outputs_rows():
     filters_df = _filters_df()
     rows = run_scan_day(df, str(idx[2].date()), filters_df)  # 3. gün
     # EMA20 NaN olabilir; ikinci kural çalışmalı
-    assert ("SYMBOL", "F2") in rows
+    assert ("SYM", "F2") in rows
 
 
 def test_run_scan_range_writes_files(tmp_path: Path):

--- a/tests/test_filters_engine_normalization.py
+++ b/tests/test_filters_engine_normalization.py
@@ -45,6 +45,7 @@ def test_screener_batch_consistency():
         },
         index=idx,
     )
+    df_batch.attrs["symbol"] = "SYM"
     filters_df = pd.DataFrame({"FilterCode": ["F1"], "PythonQuery": ["close > open"]})
     rows_batch = run_scan_day(df_batch, str(idx[0].date()), filters_df)
 

--- a/tests/test_output_writer_csv.py
+++ b/tests/test_output_writer_csv.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from backtest.batch.io import OutputWriter
+
+
+def test_output_writer_writes_matches(tmp_path):
+    writer = OutputWriter(tmp_path)
+    day = "2025-03-07"
+    rows = [("AAA", "F1"), ("AAA", "F2"), ("BBB", "F3")]
+    csv_path = writer.write_day(day, rows)
+    df = pd.read_csv(csv_path)
+    expected = pd.DataFrame(
+        [
+            ["2025-03-07", "AAA", "F1"],
+            ["2025-03-07", "AAA", "F2"],
+            ["2025-03-07", "BBB", "F3"],
+        ],
+        columns=["date", "symbol", "filter_code"],
+    )
+    pd.testing.assert_frame_equal(df, expected)


### PR DESCRIPTION
## Summary
- parse symbol-prefixed columns to expand every symbol/filter hit
- write each match with its real symbol and log row counts
- test CSV writer to ensure all matches are persisted

## Testing
- `pytest tests/test_batch_runner.py::test_run_scan_day_outputs_rows tests/test_batch_runner.py::test_run_scan_range_writes_files tests/test_filters_engine_normalization.py::test_screener_batch_consistency tests/test_output_writer_csv.py -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68b065e2e0788325bb16cab9da245868